### PR TITLE
Add user confirmation gates to git-commit and open-pr skills

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -23,6 +23,15 @@ description: Use when committing changes in dd-sdk-ios. Use when writing commit 
 
 Third-party contributions skip the prefix.
 
+## Before Committing
+
+Always show the user what will be committed and get explicit approval before running `git commit`.
+
+1. Run `git diff --staged` and show the output
+2. Propose the commit message following the format below
+3. Ask: "Shall I commit with this message?"
+4. Only run `git commit -S -m "..."` after the user confirms
+
 ## Commit Command
 
 ```bash

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -27,6 +27,14 @@ description: Use when creating a pull request in dd-sdk-ios. Use when writing PR
 
 The repo has a PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Read it and fill in all sections.
 
+**Before pushing**, show the user the commits that will be pushed and ask for confirmation:
+
+```bash
+git log origin/develop..HEAD --oneline
+```
+
+Ask: "Shall I push these commits and open the PR?" Only proceed after the user confirms.
+
 **Before running the command**, show the user the proposed PR title and full body and ask for confirmation. Only run `gh pr create` after the user approves.
 
 ```bash


### PR DESCRIPTION
### What and why?

Adds explicit user-confirmation rules to the agent skills so Claude always pauses and asks before running `git commit` or `git push` in this repo.

### How?

- `git-commit/SKILL.md`: new "Before Committing" section — show staged diff, propose message, wait for approval before running `git commit`
- `open-pr/SKILL.md`: new push confirmation step — show `git log origin/develop..HEAD --oneline`, ask before pushing (placed before the existing PR body confirmation gate)

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs