### PR TITLE
Add Swift API design skill

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/swift-api-design/SKILL.md
+++ b/.claude/skills/swift-api-design/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: dd-sdk-ios:swift-api-design
+description: Use when writing, reviewing, or renaming Swift APIs, including declarations, call sites, argument labels, Boolean names, protocols, overloads, documentation comments, and small abstractions.
+---
+
+# Swift API Design
+
+Use Swift's API Design Guidelines for clear call sites. Prefer the smallest API that preserves meaning.
+
+Reference: https://www.swift.org/documentation/api-design-guidelines/
+
+## Review
+
+Before adding or renaming a Swift declaration:
+
+1. Read call sites first; isolated declarations can mislead.
+2. Search nearby terms, helpers, and overloads. Reuse same-concept names.
+3. Draft the one-sentence documentation summary. Redesign if it needs caveats, implementation details, or repeated type names.
+4. Add helpers, types, overloads, or wrappers only for real concepts, meaningful repetition, or bug prevention.
+5. Re-read final use sites as English. Fix anything artificial, vague, redundant, or ambiguous.
+
+## Names
+
+- Include words needed to avoid ambiguity.
+- Omit words that repeat visible type information.
+- Name values by role. Use established terms correctly.
+- Avoid nonstandard abbreviations. Keep acronyms consistent with Swift casing, such as `URL`, `UTF8`, and `userID`.
+- Prefer member APIs when there is a natural receiver.
+- Use `make...` for factories that create new values.
+- Use properties for cheap, side-effect-free state; methods for work, conversion, or effects.
+- Give side-effect-free methods noun-phrase or prepositional names, such as `distance(to:)`; give mutating or side-effecting methods imperative verb names, such as `append(_:)`.
+- Name mutating/nonmutating pairs consistently: `sort()` / `sorted()`, `append(_:)` / `appending(_:)`, `union(_:)` / `formUnion(_:)`.
+- Name Booleans as positive assertions about the receiver, such as `isEmpty`, `hasBorder`, or `contains(_:)`.
+- Name protocols for things as nouns, such as `Collection`; capabilities with `able`, `ible`, or `ing`, such as `Equatable`.
+
+## Argument Labels
+
+Design the whole call, not only the base name.
+
+- Omit the first argument label only when the argument completes the base name or the initializer is a value-preserving conversion.
+- Include the first label when it clarifies role, unit, source, destination, or narrowing conversion.
+- Make the base name and labels form a clear phrase; do not force awkward grammar.
+- Use labels to clarify weakly typed values such as `String`, `Int`, `Any`, `NSObject`, or `AnyObject`.
+- Put prepositions where they make the call read naturally, such as `move(from:to:)` or `insert(_:at:)`.
+
+## Overloads and Defaults
+
+- Overloads must share one semantic operation. Different work needs different names.
+- Avoid overloads that differ only by return type or weakly typed parameters.
+- Defaults should keep common calls clean without hiding important behavior.
+- Boolean arguments need clear labels. Prefer an enum when `true` and `false` are not self-explanatory.
+
+## Reject These
+
+- Helpers that wrap simple expressions, such as `hasA || hasB`, without improving the call site.
+- Names based on implementation details instead of the caller's role.
+- Types created only for future flexibility before a second real use or clear invariant exists.
+- Vague verbs such as `process`, `handle`, or `perform` when the actual operation can be named.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Feature-specific docs (in each module directory):
 - **Do NOT change networking formats or endpoints.**
 - **Do NOT introduce new public API** without RFC review.
 - **Do NOT edit build scripts** unless instructed.
+- **Do NOT name branches with `codex`.** Use repo branch naming conventions instead.
 - **Never mention AI assistant names** (Claude, ChatGPT, Cursor, Copilot, etc.) in commit messages, PR descriptions, code comments, or co-author tags.
 - **Never write or modify a swizzle without reading `docs/SWIZZLING.md` first.** Past incidents have caused production crashes.
 


### PR DESCRIPTION
### What and why?

This PR adds a shared Swift API design skill for reviewing names, argument labels, overloads, booleans, protocols, and small abstractions.

It gives agents a short checklist based on the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).

### How?

The new skill lives in the shared skills folder.
The repo also exposes that folder through `.agents/skills` so Codex can discover the same skills.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
