### PR TITLE
[PANA-7720] Fix text detection in transparent images

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+DominantColor.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+DominantColor.swift
@@ -16,64 +16,50 @@ extension UIImage {
             return color
         }
 
-        let color = dominantColors(count: 1, context: .sessionReplay).first?.color
+        let color = dominantColor(context: .sessionReplay)
         objc_setAssociatedObject(self, &dominantColorKey, color, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
         return color
     }
 
-    private func dominantColors(
-        count: Int,
+    private func dominantColor(
         context: CIContext
-    ) -> [(color: UIColor, weight: CGFloat)] {
-        guard count > 0 else {
-            return []
-        }
-
+    ) -> UIColor? {
         guard
             let inputImage = CIImage(image: self),
             let filter = CIFilter(name: "CIKMeans")
         else {
-            return []
+            return nil
         }
 
         filter.setValue(inputImage, forKey: kCIInputImageKey)
         filter.setValue(CIVector(cgRect: inputImage.extent), forKey: "inputExtent")
-        filter.setValue(count, forKey: "inputCount")
+        filter.setValue(1, forKey: "inputCount")
 
         guard let outputImage = filter.outputImage else {
-            return []
+            return nil
         }
 
-        var pixels = [UInt8](repeating: 0, count: count * 4)
+        var pixels = [UInt8](repeating: 0, count: 4)
 
         context.render(
-            outputImage,
+            outputImage.settingAlphaOne(in: outputImage.extent),
             toBitmap: &pixels,
-            rowBytes: count * 4,
-            bounds: CGRect(x: 0, y: 0, width: count, height: 1),
+            rowBytes: 4,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
             format: .RGBA8,
             colorSpace: CGColorSpace(name: CGColorSpace.sRGB)
         )
 
-        var dominantColors: [(color: UIColor, weight: CGFloat)] = []
-
-        for index in stride(from: 0, to: pixels.count, by: 4) {
-            dominantColors.append(
-                (
-                    color: UIColor(
-                        red: CGFloat(pixels[index]) / 255,
-                        green: CGFloat(pixels[index + 1]) / 255,
-                        blue: CGFloat(pixels[index + 2]) / 255,
-                        alpha: 1
-                    ),
-                    weight: CGFloat(pixels[index + 3]) / 255
-                )
+        if pixels[0] == pixels[1], pixels[1] == pixels[2] {
+            return UIColor(white: CGFloat(pixels[0]) / 255, alpha: 1)
+        } else {
+            return UIColor(
+                red: CGFloat(pixels[0]) / 255,
+                green: CGFloat(pixels[1]) / 255,
+                blue: CGFloat(pixels[2]) / 255,
+                alpha: 1
             )
-        }
-
-        return dominantColors.sorted { lhs, rhs in
-            lhs.weight > rhs.weight
         }
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+FeatureDetection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+FeatureDetection.swift
@@ -97,7 +97,7 @@ extension UIColor {
 
         self.getRed(&r, green: &g, blue: &b, alpha: nil)
 
-        // W3C Luminance Formula
+        // Approximate perceived brightness to choose a contrasting background
         return (0.299 * r) + (0.587 * g) + (0.114 * b)
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+FeatureDetection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+FeatureDetection.swift
@@ -10,10 +10,24 @@ import Vision
 
 extension UIImage {
     func textRectangles() throws -> [CGRect] {
+        let targetImage = if imageRendererFormat.opaque {
+            self
+        } else {
+            // Composite transparent images over a contrasting background so Vision can detect text
+            UIGraphicsImageRenderer(size: size, format: imageRendererFormat).image { context in
+                let foregroundColor = dominantColor ?? .black
+                let backgroundColor = foregroundColor.luminance < 0.5 ? UIColor.white : .black
+
+                backgroundColor.setFill()
+                UIRectFill(CGRect(origin: .zero, size: size))
+                draw(at: .zero)
+            }
+        }
+
         let request = VNDetectTextRectanglesRequest()
         request.reportCharacterBoxes = false
 
-        try performFeatureDetection(with: request)
+        try targetImage.performFeatureDetection(with: request)
 
         guard let results = request.results else {
             return []
@@ -72,6 +86,19 @@ extension CGImagePropertyOrientation {
         default:
             self = .up
         }
+    }
+}
+
+extension UIColor {
+    fileprivate var luminance: CGFloat {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+
+        self.getRed(&r, green: &g, blue: &b, alpha: nil)
+
+        // W3C Luminance Formula
+        return (0.299 * r) + (0.587 * g) + (0.114 * b)
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Utilities/UIImage+SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/Utilities/UIImage+SessionReplayTests.swift
@@ -6,6 +6,7 @@
 
 #if os(iOS)
 import Foundation
+import UIKit
 import XCTest
 
 @testable import DatadogSessionReplay
@@ -23,6 +24,17 @@ class UIImageSessionReplayTests: XCTestCase {
         let imageData = try XCTUnwrap(image.pngData())
         let scaledData = try XCTUnwrap(image.dd.pngData(maxSize: CGSize(width: 25, height: 25)))
         XCTAssertLessThan(scaledData.count, imageData.count)
+    }
+
+    func testDominantColor_ReturnsOpaqueColorForLowWeightPaletteColor() throws {
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 100, height: 100)).image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }
+
+        let color = try XCTUnwrap(image.dominantColor)
+
+        XCTAssertEqual(color, .white)
     }
 }
 


### PR DESCRIPTION
### What and why?

This PR fixes text redaction for layer snapshot images with transparent backgrounds.

Vision can miss dark text when it is rendered over transparency. In that case, text detection can fail and the text may not be redacted in the layer tree recording pipeline.

### How?

For non-opaque images, the redaction path now composites the image over a solid background before running Vision text detection.

The background color is chosen to contrast with the image dominant color, so dark text is placed over a light background and light text is placed over a dark background.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
