### PR TITLE
[RUM-7478] Encode non-encodable attribute values as their string description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FEATURE] Add support for UK1 Datadog Site. See [#3087][]
 - [IMPROVEMENT] Non-encodable attribute values are now encoded as their string description instead of being silently dropped. See [#TODO][]
+- [IMPROVEMENT] Non-encodable attribute values are now encoded as their string description instead of being silently dropped. See [#3003][]
 - [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
 - [FIX] Fix watchOS uploads blocked by NWPathMonitor always reporting no reachability. See [#2975][]
 
@@ -1203,6 +1204,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3019]: https://github.com/DataDog/dd-sdk-ios/pull/3019
 [#3051]: https://github.com/DataDog/dd-sdk-ios/pull/3051
 [#3087]: https://github.com/DataDog/dd-sdk-ios/pull/3087
+[#3003]: https://github.com/DataDog/dd-sdk-ios/pull/3003
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 - [FEATURE] Add support for UK1 Datadog Site. See [#3087][]
+- [IMPROVEMENT] Non-encodable attribute values are now encoded as their string description instead of being silently dropped. See [#TODO][]
+- [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
+- [FIX] Fix watchOS uploads blocked by NWPathMonitor always reporting no reachability. See [#2975][]
 
 # 3.14.0 / 15-07-2026
 

--- a/DatadogInternal/Sources/Codable/AnyEncodable.swift
+++ b/DatadogInternal/Sources/Codable/AnyEncodable.swift
@@ -121,11 +121,12 @@ extension _AnyEncodable {
         case let encodable as Encodable:
             try encodable.encode(to: encoder)
         default:
-            let context = EncodingError.Context(
-                codingPath: container.codingPath,
-                debugDescription: "AnyEncodable value cannot be encoded: \(type(of: value))"
-            )
-            throw EncodingError.invalidValue(value, context)
+            // As a last resort, encode the value's string description.
+            // This handles cross-platform types (e.g. Kotlin data classes bridged via KMP)
+            // whose `.description` produces a human-readable representation.
+            let stringValue = String(describing: value)
+            DD.logger.debug("AnyEncodable: value of type '\(type(of: value))' is not encodable. It will be encoded as its string description: '\(stringValue)'.")
+            try container.encode(stringValue)
         }
     }
 

--- a/DatadogInternal/Tests/AttributeEncodingTests.swift
+++ b/DatadogInternal/Tests/AttributeEncodingTests.swift
@@ -8,6 +8,12 @@ import XCTest
 import TestUtilities
 @testable import DatadogInternal
 
+private struct ThrowingEncodable: Encodable {
+    func encode(to encoder: Encoder) throws {
+        throw EncodingError.invalidValue(self, .init(codingPath: encoder.codingPath, debugDescription: "intentional failure"))
+    }
+}
+
 class AttributeEncodingTests: XCTestCase {
     private let encoder = JSONEncoder()
 
@@ -78,7 +84,7 @@ class AttributeEncodingTests: XCTestCase {
         XCTAssertEqual(jsonObject["validAttr"] as? String, "valid")
         XCTAssertEqual(jsonObject["nonEncodableAttr"] as? String, "NonEncodableObject()")
 
-        // And a debug log is emitted (not an error — the attribute is not dropped)
+        // And a debug log is emitted
         let debugLog = try XCTUnwrap(dd.logger.debugLog)
         XCTAssertTrue(debugLog.message.contains("It will be encoded as its string description: 'NonEncodableObject()'"))
         XCTAssertNil(dd.logger.errorLog)
@@ -88,13 +94,6 @@ class AttributeEncodingTests: XCTestCase {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
-
-        // An Encodable that always throws — exercises the encodeAttribute error path
-        struct ThrowingEncodable: Encodable {
-            func encode(to encoder: Encoder) throws {
-                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
-            }
-        }
 
         struct TestEvent: Encodable {
             enum CodingKeys: String, CodingKey { case customAttr }
@@ -117,12 +116,6 @@ class AttributeEncodingTests: XCTestCase {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        struct ThrowingEncodable: Encodable {
-            func encode(to encoder: Encoder) throws {
-                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
-            }
-        }
-
         struct UserInfoStruct: Encodable {
             enum CodingKeys: String, CodingKey { case customField = "usr.customField" }
             func encode(to encoder: Encoder) throws {
@@ -143,12 +136,6 @@ class AttributeEncodingTests: XCTestCase {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
-
-        struct ThrowingEncodable: Encodable {
-            func encode(to encoder: Encoder) throws {
-                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
-            }
-        }
 
         struct AccountInfoStruct: Encodable {
             enum CodingKeys: String, CodingKey { case accountField = "account.accountField" }
@@ -171,12 +158,6 @@ class AttributeEncodingTests: XCTestCase {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        struct ThrowingEncodable: Encodable {
-            func encode(to encoder: Encoder) throws {
-                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
-            }
-        }
-
         struct InternalStruct: Encodable {
             enum CodingKeys: String, CodingKey { case internalField }
             func encode(to encoder: Encoder) throws {
@@ -197,12 +178,6 @@ class AttributeEncodingTests: XCTestCase {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
-
-        struct ThrowingEncodable: Encodable {
-            func encode(to encoder: Encoder) throws {
-                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
-            }
-        }
 
         struct TestEvent: Encodable {
             enum CodingKeys: String, CodingKey { case attr }

--- a/DatadogInternal/Tests/AttributeEncodingTests.swift
+++ b/DatadogInternal/Tests/AttributeEncodingTests.swift
@@ -46,25 +46,27 @@ class AttributeEncodingTests: XCTestCase {
         XCTAssertEqual(jsonObject["intAttr"] as? Int, 42)
     }
 
-    func testEncodeAttributeWithInvalidValueSkipsAttributeAndLogsError() throws {
+    func testEncodeAttributeWithNonEncodableValueFallsBackToStringDescription() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        class NonEncodableObject {}
+        class NonEncodableObject: NSObject {
+            override var description: String { "NonEncodableObject()" }
+        }
 
         struct TestEvent: Encodable {
             let nonEncodableValue: Any
 
             enum CodingKeys: String, CodingKey {
                 case validAttr
-                case invalidAttr
+                case nonEncodableAttr
             }
 
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 container.encodeAttribute(AnyEncodable("valid"), forKey: .validAttr, attributeName: CodingKeys.validAttr.rawValue)
-                container.encodeAttribute(AnyEncodable(nonEncodableValue), forKey: .invalidAttr, attributeName: CodingKeys.invalidAttr.rawValue)
+                container.encodeAttribute(AnyEncodable(nonEncodableValue), forKey: .nonEncodableAttr, attributeName: CodingKeys.nonEncodableAttr.rawValue)
             }
         }
 
@@ -72,15 +74,14 @@ class AttributeEncodingTests: XCTestCase {
         let encodedData = try encoder.encode(TestEvent(nonEncodableValue: NonEncodableObject()))
         let jsonObject = try JSONSerialization.jsonObject(with: encodedData) as! [String: Any]
 
-        // Then - valid attribute is present, invalid is skipped
+        // Then - both attributes are present; non-encodable is encoded as its string description
         XCTAssertEqual(jsonObject["validAttr"] as? String, "valid")
-        XCTAssertNil(jsonObject["invalidAttr"])
+        XCTAssertEqual(jsonObject["nonEncodableAttr"] as? String, "NonEncodableObject()")
 
-        // And error is logged
-        let errorLog = try XCTUnwrap(dd.logger.errorLog)
-        XCTAssertTrue(
-            errorLog.message.contains("Failed to encode attribute 'invalidAttr'")
-        )
+        // And a debug log is emitted (not an error — the attribute is not dropped)
+        let debugLog = try XCTUnwrap(dd.logger.debugLog)
+        XCTAssertTrue(debugLog.message.contains("It will be encoded as its string description: 'NonEncodableObject()'"))
+        XCTAssertNil(dd.logger.errorLog)
     }
 
     func testEncodeAttributeWithCustomContextUsesNoPrefix() throws {
@@ -88,21 +89,18 @@ class AttributeEncodingTests: XCTestCase {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        class NonEncodableObject {}
+        // An Encodable that always throws — exercises the encodeAttribute error path
+        struct ThrowingEncodable: Encodable {
+            func encode(to encoder: Encoder) throws {
+                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
+            }
+        }
 
         struct TestEvent: Encodable {
-            enum CodingKeys: String, CodingKey {
-                case customAttr
-            }
-
+            enum CodingKeys: String, CodingKey { case customAttr }
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
-                container.encodeAttribute(
-                    AnyEncodable(NonEncodableObject()),
-                    forKey: .customAttr,
-                    attributeName: CodingKeys.customAttr.rawValue,
-                    context: .custom
-                )
+                container.encodeAttribute(ThrowingEncodable(), forKey: .customAttr, attributeName: CodingKeys.customAttr.rawValue, context: .custom)
             }
         }
 
@@ -119,35 +117,26 @@ class AttributeEncodingTests: XCTestCase {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        struct UserInfoStruct: Encodable {
-            enum CodingKeys: String, CodingKey {
-                case customField = "usr.customField"
-            }
-
-            let value: Any
-
+        struct ThrowingEncodable: Encodable {
             func encode(to encoder: Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                container.encodeAttribute(
-                    AnyEncodable(value),
-                    forKey: .customField,
-                    attributeName: "customField",  // Customer-facing name without prefix
-                    context: .userInfo
-                )
+                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
             }
         }
 
-        class NonEncodableObject {}
-        let testStruct = UserInfoStruct(value: NonEncodableObject())
+        struct UserInfoStruct: Encodable {
+            enum CodingKeys: String, CodingKey { case customField = "usr.customField" }
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                container.encodeAttribute(ThrowingEncodable(), forKey: .customField, attributeName: "customField", context: .userInfo)
+            }
+        }
 
         // When
-        _ = try encoder.encode(testStruct)
+        _ = try encoder.encode(UserInfoStruct())
 
         // Then
         let errorLog = try XCTUnwrap(dd.logger.errorLog)
-        XCTAssertTrue(
-            errorLog.message.contains("Failed to encode user info attribute 'customField'")
-        )
+        XCTAssertTrue(errorLog.message.contains("Failed to encode user info attribute 'customField'"))
     }
 
     func testEncodeAttributeWithAccountInfoContextUsesCorrectPrefix() throws {
@@ -155,35 +144,26 @@ class AttributeEncodingTests: XCTestCase {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        struct AccountInfoStruct: Encodable {
-            enum CodingKeys: String, CodingKey {
-                case accountField = "account.accountField"
-            }
-
-            let value: Any
-
+        struct ThrowingEncodable: Encodable {
             func encode(to encoder: Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                container.encodeAttribute(
-                    AnyEncodable(value),
-                    forKey: .accountField,
-                    attributeName: "accountField",  // Customer-facing name without prefix
-                    context: .accountInfo
-                )
+                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
             }
         }
 
-        class NonEncodableObject {}
-        let testStruct = AccountInfoStruct(value: NonEncodableObject())
+        struct AccountInfoStruct: Encodable {
+            enum CodingKeys: String, CodingKey { case accountField = "account.accountField" }
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                container.encodeAttribute(ThrowingEncodable(), forKey: .accountField, attributeName: "accountField", context: .accountInfo)
+            }
+        }
 
         // When
-        _ = try encoder.encode(testStruct)
+        _ = try encoder.encode(AccountInfoStruct())
 
         // Then
         let errorLog = try XCTUnwrap(dd.logger.errorLog)
-        XCTAssertTrue(
-            errorLog.message.contains("Failed to encode account attribute 'accountField'")
-        )
+        XCTAssertTrue(errorLog.message.contains("Failed to encode account attribute 'accountField'"))
     }
 
     func testEncodeAttributeWithInternalContextUsesCorrectPrefix() throws {
@@ -191,35 +171,26 @@ class AttributeEncodingTests: XCTestCase {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        struct InternalStruct: Encodable {
-            enum CodingKeys: String, CodingKey {
-                case internalField
-            }
-
-            let value: Any
-
+        struct ThrowingEncodable: Encodable {
             func encode(to encoder: Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
-                container.encodeAttribute(
-                    AnyEncodable(value),
-                    forKey: .internalField,
-                    attributeName: CodingKeys.internalField.rawValue,
-                    context: .internal
-                )
+                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
             }
         }
 
-        class NonEncodableObject {}
-        let testStruct = InternalStruct(value: NonEncodableObject())
+        struct InternalStruct: Encodable {
+            enum CodingKeys: String, CodingKey { case internalField }
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                container.encodeAttribute(ThrowingEncodable(), forKey: .internalField, attributeName: CodingKeys.internalField.rawValue, context: .internal)
+            }
+        }
 
         // When
-        _ = try encoder.encode(testStruct)
+        _ = try encoder.encode(InternalStruct())
 
         // Then
         let errorLog = try XCTUnwrap(dd.logger.errorLog)
-        XCTAssertTrue(
-            errorLog.message.contains("Failed to encode internal attribute 'internalField'")
-        )
+        XCTAssertTrue(errorLog.message.contains("Failed to encode internal attribute 'internalField'"))
     }
 
     func testEncodeAttributeErrorMessageIncludesDroppedNotice() throws {
@@ -227,16 +198,17 @@ class AttributeEncodingTests: XCTestCase {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        class NonEncodableObject {}
+        struct ThrowingEncodable: Encodable {
+            func encode(to encoder: Encoder) throws {
+                throw EncodingError.invalidValue(self, .init(codingPath: [], debugDescription: "intentional failure"))
+            }
+        }
 
         struct TestEvent: Encodable {
-            enum CodingKeys: String, CodingKey {
-                case attr
-            }
-
+            enum CodingKeys: String, CodingKey { case attr }
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
-                container.encodeAttribute(AnyEncodable(NonEncodableObject()), forKey: .attr, attributeName: CodingKeys.attr.rawValue)
+                container.encodeAttribute(ThrowingEncodable(), forKey: .attr, attributeName: CodingKeys.attr.rawValue)
             }
         }
 
@@ -245,8 +217,6 @@ class AttributeEncodingTests: XCTestCase {
 
         // Then
         let errorLog = try XCTUnwrap(dd.logger.errorLog)
-        XCTAssertTrue(
-            errorLog.message.contains("This attribute will be dropped from the event")
-        )
+        XCTAssertTrue(errorLog.message.contains("This attribute will be dropped from the event"))
     }
 }

--- a/DatadogInternal/Tests/Codable/AnyEncodableTests.swift
+++ b/DatadogInternal/Tests/Codable/AnyEncodableTests.swift
@@ -156,6 +156,19 @@ class AnyEncodableTests: XCTestCase {
         XCTAssert(encodedJSONObject["double"] is Double)
     }
 
+    func testNonEncodableValueFallsBackToStringDescription() throws {
+        // Non-encodable type — simulates a Kotlin data class bridged via KMP
+        class NonEncodable: NSObject {
+            override var description: String { "NonEncodable(foo=bar)" }
+        }
+
+        let dictionary: [String: Any] = ["object-value": NonEncodable()]
+        let json = try JSONEncoder().encode(AnyEncodable(dictionary))
+        let result = try JSONSerialization.jsonObject(with: json) as! [String: String]
+
+        XCTAssertEqual(result["object-value"], "NonEncodable(foo=bar)")
+    }
+
     func testStringInterpolationEncoding() throws {
         let dictionary: [String: Any] = [
             "boolean": "\(true)",

--- a/DatadogLogs/Sources/Log/LogEventSanitizer.swift
+++ b/DatadogLogs/Sources/Log/LogEventSanitizer.swift
@@ -22,7 +22,7 @@ internal struct LogEventSanitizer {
         /// Tags with name starting with different character will be dropped.
         static let allowedTagNameFirstCharacterASCIIRange: [UInt8] = Array(97...122)
         /// Maximum length of the tag.
-        /// Tags exceeting this length will be trunkated.
+        /// Tags exceeding this length will be truncated.
         static let maxTagLength: Int = 200
         /// Tag keys reserved for Datadog.
         /// If any of those is used by user, the tag will be ignored.

--- a/DatadogLogs/Tests/RemoteLoggerTests.swift
+++ b/DatadogLogs/Tests/RemoteLoggerTests.swift
@@ -653,10 +653,14 @@ class RemoteLoggerTests: XCTestCase {
     /// - **Swift APIs with manual wrapping**: Swift API requires `Encodable`, but customers can explicitly wrap non-encodable
     ///   types using `AnyEncodable(value)` to bypass compile-time checks.
 
-    func testWhenMultipleAttributesFailToEncode_itSkipsAllMalformedAttributes() throws {
+    func testWhenMultipleAttributesAreNonEncodable_itEncodesThemAsStringsAndSendsEvent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
+
+        class DescribableObject: NSObject {
+            override var description: String { "DescribableObject()" }
+        }
 
         let logger = RemoteLogger(
             featureScope: featureScope,
@@ -674,36 +678,39 @@ class RemoteLoggerTests: XCTestCase {
         logger.addAttribute(forKey: "valid", value: "test")
         logger.addAttribute(forKey: "onComplete", value: AnyEncodable(closure1))
         logger.addAttribute(forKey: "callback", value: AnyEncodable(closure2))
-        logger.addAttribute(forKey: "custom_object", value: AnyEncodable(NSObject()))
+        logger.addAttribute(forKey: "custom_object", value: AnyEncodable(DescribableObject()))
         logger.info("Test message")
 
-        // Then - encode to trigger error handling
+        // Then
         let logs = featureScope.eventsWritten(ofType: LogEvent.self)
         XCTAssertEqual(logs.count, 1)
 
         let log = try XCTUnwrap(logs.first)
-
-        // Encode to JSON
         let jsonData = try JSONEncoder().encode(log)
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
 
-        // Event sent with only valid attribute
+        // Valid attribute present, non-encodable ones encoded as strings
         XCTAssertEqual(jsonObject["valid"] as? String, "test")
-        XCTAssertNil(jsonObject["onComplete"])
-        XCTAssertNil(jsonObject["callback"])
-        XCTAssertNil(jsonObject["custom_object"])
+        XCTAssertEqual(jsonObject["onComplete"] as? String, "(Function)")
+        XCTAssertEqual(jsonObject["callback"] as? String, "(Function)")
+        XCTAssertEqual(jsonObject["custom_object"] as? String, "DescribableObject()")
 
-        // And all errors logged
+        // And debug logs emitted (no errors)
         XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
+            dd.logger.debugLogs.filter { $0.message.contains("It will be encoded as its string description") }.count,
             3
         )
+        XCTAssertTrue(dd.logger.errorLogs.isEmpty)
     }
 
-    func testWhenOnlyMalformedAttributesAdded_itSendsEventWithoutCustomAttributes() throws {
+    func testWhenAllAttributesAreNonEncodable_itEncodesThemAsStringsAndSendsEvent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
+
+        class DescribableObject: NSObject {
+            override var description: String { "DescribableObject()" }
+        }
 
         let logger = RemoteLogger(
             featureScope: featureScope,
@@ -716,30 +723,28 @@ class RemoteLoggerTests: XCTestCase {
         )
 
         // When
-        logger.addAttribute(forKey: "invalid1", value: AnyEncodable(NSObject()))
-        logger.addAttribute(forKey: "invalid2", value: AnyEncodable(NSObject()))
+        logger.addAttribute(forKey: "attr1", value: AnyEncodable(DescribableObject()))
+        logger.addAttribute(forKey: "attr2", value: AnyEncodable(DescribableObject()))
         logger.info("Test message")
 
-        // Then - encode to trigger error handling
+        // Then
         let logs = featureScope.eventsWritten(ofType: LogEvent.self)
         XCTAssertEqual(logs.count, 1)
 
         let log = try XCTUnwrap(logs.first)
         XCTAssertEqual(log.message, "Test message")
 
-        // Encode to JSON
         let jsonData = try JSONEncoder().encode(log)
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
 
-        // Event still sent, just without custom attributes (all were malformed)
         XCTAssertEqual(jsonObject["message"] as? String, "Test message")
-        XCTAssertNil(jsonObject["invalid1"])
-        XCTAssertNil(jsonObject["invalid2"])
+        XCTAssertEqual(jsonObject["attr1"] as? String, "DescribableObject()")
+        XCTAssertEqual(jsonObject["attr2"] as? String, "DescribableObject()")
 
-        // And errors logged
         XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
+            dd.logger.debugLogs.filter { $0.message.contains("It will be encoded as its string description") }.count,
             2
         )
+        XCTAssertTrue(dd.logger.errorLogs.isEmpty)
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
@@ -19,7 +19,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
     private let featureScope = FeatureScopeMock()
     private var monitor: Monitor! // swiftlint:disable:this implicitly_unwrapped_optional
 
-    // A non-encodable NSObject subclass with a fixed, predictable description
+    // Sample non-Encodable object used in fallback assertions.
     private class DescribableObject: NSObject {
         override var description: String { "DescribableObject()" }
     }

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
@@ -9,7 +9,7 @@ import DatadogInternal
 @testable import DatadogRUM
 @testable import TestUtilities
 
-/// Tests that verify attribute encoding error handling in RUM events.
+/// Tests that verify attribute encoding behavior for non-encodable types in RUM events.
 /// These tests use `AnyEncodable` to wrap non-`Encodable` types, simulating real production scenarios:
 /// - **ObjC APIs** (primary production path): Customers use ObjC APIs like `addAttribute(forKey:value:)` which accepts `Any`.
 ///   SDK automatically wraps values in `AnyEncodable`, losing type safety. Telemetry shows this is the dominant error path.
@@ -18,6 +18,11 @@ import DatadogInternal
 class Monitor_AttributeEncodingTests: XCTestCase {
     private let featureScope = FeatureScopeMock()
     private var monitor: Monitor! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    // A non-encodable NSObject subclass with a fixed, predictable description
+    private class DescribableObject: NSObject {
+        override var description: String { "DescribableObject()" }
+    }
 
     override func setUp() {
         monitor = Monitor(
@@ -32,63 +37,56 @@ class Monitor_AttributeEncodingTests: XCTestCase {
 
     // MARK: - Custom attributes (context.*)
 
-    func testWhenCustomAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+    func testWhenCustomAttributeIsNonEncodable_itIsEncodedAsStringAndEventIsSent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
         // When
         monitor.addAttribute(forKey: "valid", value: "test")
-        monitor.addAttribute(forKey: "invalid", value: AnyEncodable(NSObject()))
+        monitor.addAttribute(forKey: "non-encodable", value: AnyEncodable(DescribableObject()))
         monitor.notifySDKInit()
 
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
         let context = json["context"] as? [String: Any]
 
-        XCTAssertEqual(context?["valid"] as? String, "test", "Valid attribute should be present in the event")
-        XCTAssertNil(context?["invalid"], "Non-encodable attribute should be dropped")
-
-        XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute 'invalid'") }.count,
-            1,
-            "One error should be logged for the dropped attribute"
-        )
+        XCTAssertEqual(context?["valid"] as? String, "test")
+        XCTAssertEqual(context?["non-encodable"] as? String, "DescribableObject()", "Non-encodable attribute should be encoded as its string description")
+        XCTAssertTrue(dd.logger.debugLogs.contains { $0.message.contains("It will be encoded as its string description: 'DescribableObject()'") })
     }
 
-    func testWhenOnlyMalformedCustomAttributesAdded_itSendsEventWithoutCustomAttributes() throws {
+    func testWhenAllCustomAttributesAreNonEncodable_itSendsEventWithAttributesAsStrings() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
         // When
-        monitor.addAttribute(forKey: "invalid1", value: AnyEncodable(NSObject()))
+        monitor.addAttribute(forKey: "attr1", value: AnyEncodable(DescribableObject()))
         let closure: (NSArray) -> Void = { _ in }
-        monitor.addAttribute(forKey: "invalid2", value: AnyEncodable(closure))
+        monitor.addAttribute(forKey: "attr2", value: AnyEncodable(closure))
         monitor.notifySDKInit()
 
-        // Then - event is sent even though all custom attributes are malformed
+        // Then - event is sent with both attributes encoded as strings
         let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
         XCTAssertEqual(viewEvents.count, 1)
 
         let viewEvent = try XCTUnwrap(viewEvents.first)
         let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let context = json["context"] as? [String: Any]
 
-        XCTAssertNil((json["context"] as? [String: Any])?["invalid1"])
-        XCTAssertNil((json["context"] as? [String: Any])?["invalid2"])
-
-        XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
-            2
-        )
+        XCTAssertEqual(context?["attr1"] as? String, "DescribableObject()")
+        let attr2 = try XCTUnwrap(context?["attr2"] as? String)
+        XCTAssertTrue(attr2.contains("(Function)"))
+        XCTAssertEqual(dd.logger.debugLogs.filter { $0.message.contains("It will be encoded as its string description") }.count, 2)
     }
 
     // MARK: - User info extra attributes (usr.*)
 
-    func testWhenUserInfoExtraAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+    func testWhenUserInfoExtraAttributeIsNonEncodable_itIsEncodedAsStringAndEventIsSent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -97,7 +95,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
             id: "user-id",
             extraInfo: [
                 "valid_info": "test",
-                "invalid_info": AnyEncodable(NSObject())
+                "non_encodable_info": AnyEncodable(DescribableObject())
             ]
         ))
 
@@ -107,21 +105,17 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
         let usr = json["usr"] as? [String: Any]
 
-        XCTAssertEqual(usr?["valid_info"] as? String, "test", "Valid user info attribute should be present")
-        XCTAssertNil(usr?["invalid_info"], "Non-encodable user info attribute should be dropped")
-
-        XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_info") }.count,
-            1
-        )
+        XCTAssertEqual(usr?["valid_info"] as? String, "test")
+        XCTAssertEqual(usr?["non_encodable_info"] as? String, "DescribableObject()")
+        XCTAssertTrue(dd.logger.debugLogs.contains { $0.message.contains("It will be encoded as its string description: 'DescribableObject()'") })
     }
 
     // MARK: - Account info extra attributes (account.*)
 
-    func testWhenAccountInfoExtraAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+    func testWhenAccountInfoExtraAttributeIsNonEncodable_itIsEncodedAsStringAndEventIsSent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -130,7 +124,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
             id: "acc-id",
             extraInfo: [
                 "valid_plan": "enterprise",
-                "invalid_plan": AnyEncodable(NSObject())
+                "non_encodable_plan": AnyEncodable(DescribableObject())
             ]
         ))
 
@@ -140,21 +134,17 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
         let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
         let account = json["account"] as? [String: Any]
 
-        XCTAssertEqual(account?["valid_plan"] as? String, "enterprise", "Valid account info attribute should be present")
-        XCTAssertNil(account?["invalid_plan"], "Non-encodable account info attribute should be dropped")
-
-        XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_plan") }.count,
-            1
-        )
+        XCTAssertEqual(account?["valid_plan"] as? String, "enterprise")
+        XCTAssertEqual(account?["non_encodable_plan"] as? String, "DescribableObject()")
+        XCTAssertTrue(dd.logger.debugLogs.contains { $0.message.contains("It will be encoded as its string description: 'DescribableObject()'") })
     }
 
     // MARK: - Feature flag values (feature_flags.*)
 
-    func testWhenFeatureFlagValueFailsToEncode_itIsDroppedAndEventIsSent() throws {
+    func testWhenFeatureFlagValueIsNonEncodable_itIsEncodedAsStringAndEventIsSent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -163,21 +153,17 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         monitor.notifySDKInit()
         monitor.startView(key: "TestView")
         monitor.addFeatureFlagEvaluation(name: "valid_flag", value: "enabled")
-        monitor.addFeatureFlagEvaluation(name: "invalid_flag", value: AnyEncodable(NSObject()))
+        monitor.addFeatureFlagEvaluation(name: "non_encodable_flag", value: AnyEncodable(DescribableObject()))
 
         // Then
         let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
         let viewWithFlags = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "TestView" }))
         let jsonData = try JSONEncoder().encode(viewWithFlags)
-        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
         let featureFlags = json["feature_flags"] as? [String: Any]
 
-        XCTAssertEqual(featureFlags?["valid_flag"] as? String, "enabled", "Valid feature flag should be present")
-        XCTAssertNil(featureFlags?["invalid_flag"], "Non-encodable feature flag should be dropped")
-
-        XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_flag") }.count,
-            1
-        )
+        XCTAssertEqual(featureFlags?["valid_flag"] as? String, "enabled")
+        XCTAssertEqual(featureFlags?["non_encodable_flag"] as? String, "DescribableObject()")
+        XCTAssertTrue(dd.logger.debugLogs.contains { $0.message.contains("It will be encoded as its string description: 'DescribableObject()'") })
     }
 }

--- a/DatadogTrace/Tests/DDSpanTests.swift
+++ b/DatadogTrace/Tests/DDSpanTests.swift
@@ -218,10 +218,14 @@ class DDSpanTests: XCTestCase {
     /// - **Swift APIs with manual wrapping**: Swift API requires `Encodable`, but customers can explicitly wrap non-encodable
     ///   types using `AnyEncodable(value)` to bypass compile-time checks.
 
-    func testWhenMultipleSpanTagsFailToEncode_itSkipsAllMalformedTags() throws {
+    func testWhenMultipleSpanTagsAreNonEncodable_itEncodesThemAsStringsAndSendsSpan() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
+
+        class DescribableObject: NSObject {
+            override var description: String { "DescribableObject()" }
+        }
 
         let core = PassthroughCoreMock()
         let tracer: DatadogTracer = .mockWith(core: core)
@@ -233,7 +237,7 @@ class DDSpanTests: XCTestCase {
         span.setTag(key: "valid_tag", value: "test_value")
         span.setTag(key: "onComplete", value: AnyEncodable(closure1) as! OTTagValue)
         span.setTag(key: "callback", value: AnyEncodable(closure2) as! OTTagValue)
-        span.setTag(key: "custom_object", value: AnyEncodable(NSObject()) as! OTTagValue)
+        span.setTag(key: "custom_object", value: AnyEncodable(DescribableObject()) as! OTTagValue)
         span.finish()
 
         // Then
@@ -241,36 +245,45 @@ class DDSpanTests: XCTestCase {
         XCTAssertEqual(events.count, 1)
 
         let spanEvent = try XCTUnwrap(events.first?.spans.first)
-
-        // Encode to JSON to trigger attribute encoding
         let jsonData = try JSONEncoder().encode(spanEvent)
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
 
-        // Span sent with only valid tag
-        XCTAssertEqual(jsonObject["meta.valid_tag"] as? String, "test_value")
-        XCTAssertNil(jsonObject["meta.onComplete"])
-        XCTAssertNil(jsonObject["meta.callback"])
-        XCTAssertNil(jsonObject["meta.custom_object"])
+        // Valid tag present, non-encodable ones encoded as strings
+        // Note: span tags go through an extra JSON-encoding step (value → JSON string),
+        // so a String "DescribableObject()" becomes "\"DescribableObject()\"" in the final JSON.
+        let tag1 = try XCTUnwrap(jsonObject["meta.valid_tag"] as? String)
+        XCTAssertEqual(tag1, "test_value")
+        let tag2 = try XCTUnwrap(jsonObject["meta.onComplete"] as? String)
+        XCTAssertEqual(tag2, "\"(Function)\"")
+        let tag3 = try XCTUnwrap(jsonObject["meta.callback"] as? String)
+        XCTAssertEqual(tag3, "\"(Function)\"")
+        let tag4 = try XCTUnwrap(jsonObject["meta.custom_object"] as? String)
+        XCTAssertTrue(tag4.contains("DescribableObject()"))
 
-        // And all errors logged
+        // And debug logs emitted (no errors)
         XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
+            dd.logger.debugLogs.filter { $0.message.contains("It will be encoded as its string description") }.count,
             3
         )
+        XCTAssertTrue(dd.logger.errorLogs.isEmpty)
     }
 
-    func testWhenOnlyMalformedSpanTagsAdded_itSendsSpanWithoutCustomTags() throws {
+    func testWhenAllSpanTagsAreNonEncodable_itEncodesThemAsStringsAndSendsSpan() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
+
+        class DescribableObject: NSObject {
+            override var description: String { "DescribableObject()" }
+        }
 
         let core = PassthroughCoreMock()
         let tracer: DatadogTracer = .mockWith(core: core)
         let span = tracer.startSpan(operationName: "test operation")
 
         // When
-        span.setTag(key: "invalid_tag1", value: AnyEncodable(NSObject()) as! OTTagValue)
-        span.setTag(key: "invalid_tag2", value: AnyEncodable(NSObject()) as! OTTagValue)
+        span.setTag(key: "tag1", value: AnyEncodable(DescribableObject()) as! OTTagValue)
+        span.setTag(key: "tag2", value: AnyEncodable(DescribableObject()) as! OTTagValue)
         span.finish()
 
         // Then
@@ -280,18 +293,16 @@ class DDSpanTests: XCTestCase {
         let spanEvent = try XCTUnwrap(events.first?.spans.first)
         XCTAssertEqual(spanEvent.operationName, "test operation")
 
-        // Encode to JSON
         let jsonData = try JSONEncoder().encode(spanEvent)
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
 
-        // Span still sent, just without custom tags
-        XCTAssertNil(jsonObject["meta.invalid_tag1"])
-        XCTAssertNil(jsonObject["meta.invalid_tag2"])
+        XCTAssertTrue((jsonObject["meta.tag1"] as? String)?.contains("DescribableObject()") == true)
+        XCTAssertTrue((jsonObject["meta.tag2"] as? String)?.contains("DescribableObject()") == true)
 
-        // And errors logged
         XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
+            dd.logger.debugLogs.filter { $0.message.contains("It will be encoded as its string description") }.count,
             2
         )
+        XCTAssertTrue(dd.logger.errorLogs.isEmpty)
     }
 }


### PR DESCRIPTION
### What and why?

When a non-encodable value is passed as an attribute, the entire event was previously dropped. This fixes the gap for `AnyEncodable` by falling back to `String(describing:)` as a last resort, consistent with Android SDK behavior.

This is particularly relevant for cross-platform SDKs (e.g. Kotlin Multiplatform) where objects bridged from other languages aren't Swift-encodable but have a meaningful `toString()` / `description`.

### How?

In `AnyEncodable`'s `default` encoding case (previously a hard throw), the value's string description is now encoded instead. A debug log is emitted to inform developers when this fallback is triggered.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs