### PR TITLE
[RUM-16599] Add LOGS_FEATURE.md and update platform availability in feature docs

### DIFF
--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -9,6 +9,7 @@ on:
             - 'DatadogSessionReplay/SESSION_REPLAY_FEATURE.md'
             - 'DatadogTrace/TRACE_FEATURE.md'
             - 'DatadogProfiling/PROFILING_FEATURE.md'
+            - 'DatadogLogs/LOGS_FEATURE.md'
 permissions:
     contents: read
 jobs:
@@ -23,10 +24,10 @@ jobs:
                   mkdir -p publish_folder
                   cp CHANGELOG.md publish_folder/dd-ios-sdk-changelog.md
                   echo "Publishing CHANGELOG.md"
-                  
+
                   cp DatadogRUM/RUM_FEATURE.md publish_folder/dd-sdk-ios-rum-feature.md
                   echo "Publishing RUM_FEATURE.md"
-                  
+
                   cp DatadogSessionReplay/SESSION_REPLAY_FEATURE.md publish_folder/dd-sdk-ios-session-replay-feature.md
                   echo "Publishing SESSION_REPLAY_FEATURE.md"
 
@@ -35,6 +36,9 @@ jobs:
 
                   cp DatadogProfiling/PROFILING_FEATURE.md publish_folder/dd-sdk-ios-profiling-feature.md
                   echo "Publishing PROFILING_FEATURE.md"
+
+                  cp DatadogLogs/LOGS_FEATURE.md publish_folder/dd-sdk-ios-logs-feature.md
+                  echo "Publishing LOGS_FEATURE.md"
 
             - name: Publish Markdown to Confluence
               uses: markdown-confluence/publish-action@7767a0a7f438bb1497ee7ffd7d3d685b81dfe700 # v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,8 @@ Feature-specific docs (in each module directory):
 ├── DatadogRUM/RUM_FEATURE.md
 ├── DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
 ├── DatadogTrace/TRACE_FEATURE.md
-└── DatadogProfiling/PROFILING_FEATURE.md
+├── DatadogProfiling/PROFILING_FEATURE.md
+└── DatadogLogs/LOGS_FEATURE.md
 ```
 
 ## Where to Look First
@@ -54,6 +55,7 @@ Feature-specific docs (in each module directory):
 | Work on Session Replay specifically | `DatadogSessionReplay/SESSION_REPLAY_FEATURE.md` |
 | Work on Trace (APM) specifically | `DatadogTrace/TRACE_FEATURE.md` |
 | Work on Profiling specifically | `DatadogProfiling/PROFILING_FEATURE.md` |
+| Work on Logs specifically | `DatadogLogs/LOGS_FEATURE.md` |
 | Update a `*_FEATURE.md` file | `docs/LLM_FEATURE_DOCS_GUIDELINES.md` |
 
 ## Critical Rules (always apply)

--- a/DatadogLogs/LOGS_FEATURE.md
+++ b/DatadogLogs/LOGS_FEATURE.md
@@ -7,6 +7,7 @@ tracked_files:
   - DatadogLogs/Sources/Logger.swift
   - DatadogLogs/Sources/LoggerProtocol.swift
   - DatadogLogs/Sources/Logs+objc.swift
+  - DatadogLogs/Sources/Log/LogEventEncoder.swift
 ---
 
 # Logs Feature
@@ -160,7 +161,7 @@ logger.error(
 - **Service**: `service` (default: SDK service value) — overrides `service` on log events.
 - **Logger name**: `name` — reported as `logger.name` on log events.
 - **Network info**: `networkInfoEnabled` (default: `false`) — attaches reachability, connection type, mobile carrier to every log.
-- **RUM bundling**: `bundleWithRumEnabled` (default: `true`) — attaches `_dd.application.id`, `_dd.session.id`, `_dd.view.id`, `_dd.action.id` when a sampled-in RUM session is active.
+- **RUM bundling**: `bundleWithRumEnabled` (default: `true`) — attaches `application_id`, `session_id`, `view.id`, `user_action.id` when a sampled-in RUM session is active.
 - **Trace bundling**: `bundleWithTraceEnabled` (default: `true`) — attaches `dd.trace_id` and `dd.span_id` when an active trace span is present.
 
 ### Console Output

--- a/DatadogLogs/LOGS_FEATURE.md
+++ b/DatadogLogs/LOGS_FEATURE.md
@@ -1,0 +1,219 @@
+---
+last_updated: 2026-06-19
+sdk_version: 3.12.0
+verified_against_commit: 72544f987
+tracked_files:
+  - DatadogLogs/Sources/Logs.swift
+  - DatadogLogs/Sources/Logger.swift
+  - DatadogLogs/Sources/LoggerProtocol.swift
+  - DatadogLogs/Sources/Logs+objc.swift
+---
+
+# Logs Feature
+
+## Overview
+
+Logs sends structured log events to Datadog. Loggers are created per-component and support log levels, tags, custom attributes, and optional console output. Logs requires initialization via `Datadog.initialize()` before enabling.
+
+**Platform**: iOS, tvOS, watchOS, visionOS
+
+## Quick Start Example
+
+```swift
+import DatadogCore
+import DatadogLogs
+
+// 1. Initialize Core SDK first
+Datadog.initialize(
+    with: Datadog.Configuration(
+        clientToken: "<client_token>",
+        env: "<environment>"
+    ),
+    trackingConsent: .granted
+)
+
+// 2. Enable Logs
+Logs.enable(
+    with: Logs.Configuration(
+        // Modify or drop log events before upload
+        // Return nil to drop an event
+        // Default: nil (no mapping)
+        eventMapper: { logEvent in
+            var modified = logEvent
+            // Scrub sensitive data
+            if modified.message.contains("password") {
+                return nil // drop the event
+            }
+            return modified
+        },
+
+        // Custom intake endpoint for log data
+        // Default: nil (uses Datadog intake)
+        customEndpoint: nil
+    )
+)
+
+// 3. (Optional) Add global attributes to all logs
+Logs.addAttribute(forKey: "app.flavor", value: "release")
+Logs.removeAttribute(forKey: "app.flavor")
+
+// 4. Create a logger
+let logger = Logger.create(
+    with: Logger.Configuration(
+        // Override the service name reported on logs
+        // Default: nil (uses the SDK service value)
+        service: "my-ios-app",
+
+        // Logger name, reported as `logger.name` on log events
+        // Default: nil
+        name: "MyViewController",
+
+        // Attach network connectivity info (reachability, interface, carrier)
+        // Default: false
+        networkInfoEnabled: false,
+
+        // Attach sampled-in RUM session, view and action IDs when available
+        // Default: true
+        bundleWithRumEnabled: true,
+
+        // Attach active span and trace IDs when available
+        // Default: true
+        bundleWithTraceEnabled: true,
+
+        // Sampling rate for remote log upload (0 = none sent, 100 = all sent)
+        // Default: 100.0
+        remoteSampleRate: 100.0,
+
+        // Minimum log level sent to the remote intake
+        // Default: .debug (all levels sent)
+        remoteLogThreshold: .debug,
+
+        // Print logs to console for local debugging
+        // Default: nil (disabled)
+        // Options: .short, .shortWith(prefix: "MyApp")
+        consoleLogFormat: .short
+    )
+)
+
+// 5. Log messages at various levels
+logger.debug("Fetching user profile")
+logger.info("User logged in", attributes: ["user.id": "abc123"])
+logger.notice("Low memory warning received")
+logger.warn("Retry attempt", attributes: ["attempt": 3])
+logger.error("Request failed", error: someError, attributes: ["endpoint": "/v2/users"])
+logger.critical("Unrecoverable state", error: someError)
+
+// 6. Manage per-logger attributes and tags
+logger.addAttribute(forKey: "screen", value: "ProductList")
+logger.removeAttribute(forKey: "screen")
+
+logger.addTag(withKey: "env", value: "staging")
+logger.removeTag(withKey: "env")
+logger.add(tag: "beta")
+logger.remove(tag: "beta")
+
+// 7. (Optional) Set an error fingerprint on the log event
+// Requires an Error to be passed; sets `error.fingerprint` on the event
+logger.error(
+    "Database write failed",
+    error: dbError,
+    attributes: [Logs.Attributes.errorFingerprint: "db-write-failure"]
+)
+```
+
+## Key Files
+
+### Feature Entry Point
+- **`DatadogLogs/Sources/Logs.swift`** — Main entry point. Call `Logs.enable(with:)` to activate.
+  - `addAttribute(forKey:value:)` / `removeAttribute(forKey:)` — global attributes applied to all loggers
+
+### Configuration
+- **`DatadogLogs/Sources/Logger.swift`** — `Logger.create(with:)` factory and `Logger.Configuration`.
+  - Per-logger options: service, name, sampling, log threshold, console format, RUM/Trace bundling, network info
+
+### Public API
+- **`DatadogLogs/Sources/LoggerProtocol.swift`** — `LoggerProtocol` and `LogLevel` enum.
+  - Logging methods: `debug`, `info`, `notice`, `warn`, `error`, `critical`
+  - Attribute management: `addAttribute(forKey:value:)`, `removeAttribute(forKey:)`
+  - Tag management: `addTag(withKey:value:)`, `removeTag(withKey:)`, `add(tag:)`, `remove(tag:)`
+
+### Objective-C Bridge
+- **`DatadogLogs/Sources/Logs+objc.swift`** — Objective-C entry point (`DDLogs`, `DDLoggerConfiguration`, `DDLogger`).
+  - `+[DDLogs enableWith:]` mirrors Swift `Logs.enable(with:)`
+  - `+[DDLogger createWith:]` mirrors Swift `Logger.create(with:)`
+  - ObjC `printLogsToConsole: Bool` maps to Swift `consoleLogFormat: .short`
+
+### Implementation
+- **`DatadogLogs/Sources/Feature/`** — Internal feature implementation. Shows how configuration translates to behavior.
+
+## Configuration Categories
+
+### Sampling
+- **Remote sampling**: `Logger.Configuration.remoteSampleRate` (default: 100%) — controls what fraction of logs are uploaded. Applied per-logger.
+- **Log level filter**: `remoteLogThreshold` (default: `.debug`) — logs below this level are not sent remotely. Console output is unaffected by this threshold.
+
+### Event Modification
+- **`Logs.Configuration.eventMapper`** — `(LogEvent) -> LogEvent?`. Modify or drop log events before upload. Return `nil` to drop. Runs on a background thread; keep it fast.
+- **Error fingerprint**: Set `Logs.Attributes.errorFingerprint` (`"_dd.error.fingerprint"`) as a log attribute to set `error.fingerprint` on the log event. Requires an `Error` to be passed to the log call.
+
+### Logger Enrichment
+- **Service**: `service` (default: SDK service value) — overrides `service` on log events.
+- **Logger name**: `name` — reported as `logger.name` on log events.
+- **Network info**: `networkInfoEnabled` (default: `false`) — attaches reachability, connection type, mobile carrier to every log.
+- **RUM bundling**: `bundleWithRumEnabled` (default: `true`) — attaches `_dd.application.id`, `_dd.session.id`, `_dd.view.id`, `_dd.action.id` when a sampled-in RUM session is active.
+- **Trace bundling**: `bundleWithTraceEnabled` (default: `true`) — attaches `dd.trace_id` and `dd.span_id` when an active trace span is present.
+
+### Console Output
+- `consoleLogFormat: nil` (default) — no console output.
+- `consoleLogFormat: .short` — prints `[level] message` to the console.
+- `consoleLogFormat: .shortWith(prefix: "MyApp")` — prepends a custom prefix.
+
+### Global Attributes
+Applied to all loggers in the same SDK instance:
+```swift
+Logs.addAttribute(forKey: "build.number", value: "42")
+Logs.removeAttribute(forKey: "build.number")
+```
+
+### Per-Logger Tags and Attributes
+```swift
+logger.addTag(withKey: "feature", value: "checkout")  // tag: "feature:checkout"
+logger.add(tag: "experiment_a")                        // bare tag
+logger.addAttribute(forKey: "user.plan", value: "pro") // searchable attribute
+```
+
+## Common Troubleshooting Patterns
+
+### "No logs appearing in Datadog"
+1. Check `Datadog.initialize()` and `Logs.enable()` were called before creating loggers.
+2. Verify `remoteSampleRate` is > 0.
+3. Verify `remoteLogThreshold` — logs below the threshold are silently dropped before upload.
+4. Check if `eventMapper` is returning `nil` for those events.
+
+### "Some log levels not appearing"
+1. `remoteLogThreshold` filters out levels below the configured minimum; only levels ≥ threshold are sent remotely.
+2. Console output via `consoleLogFormat` is not affected by `remoteLogThreshold` — it always prints all levels.
+
+### "Logs not linked to RUM session"
+1. Verify `RUM.enable()` is called and a RUM session is active.
+2. Verify the RUM session is sampled in — sampled-out sessions do not add RUM linkage.
+3. Confirm `bundleWithRumEnabled: true` (default) on the logger.
+
+### "Logs not linked to a trace span"
+1. Verify `Trace.enable()` is called and an active span exists when logging.
+2. Confirm `bundleWithTraceEnabled: true` (default) on the logger.
+
+### "Logger.create() returns a no-op logger"
+Returned when `Datadog.initialize()` was not called or `Logs.enable()` was not called. Check the console for `ProgrammerError` messages via `consolePrint`.
+
+## Feature Interactions
+
+- **RUM**: When `bundleWithRumEnabled` is `true` and the current RUM session is sampled in, logs are enriched with the current RUM view / session / action IDs for correlation in Datadog.
+- **Trace**: When `bundleWithTraceEnabled` is `true` and an active span is present (via `Tracer.shared()` or `OTelTracerProvider`), logs are enriched with `dd.trace_id` and `dd.span_id`. Span logs written via `OTSpan.log(...)` also flow through the Logs feature — if Logs is not enabled, those span logs are dropped.
+
+## Additional Context
+
+- Each call to `Logger.create(with:)` returns an independent logger instance. Multiple loggers can coexist with different configurations (service, name, threshold, etc.).
+- Global attributes set via `Logs.addAttribute(forKey:value:)` are merged with per-logger attributes; per-logger attributes take precedence on key conflicts.
+- Tags are stored as `"key:value"` strings in the backend; bare tags (via `add(tag:)`) are stored as-is.
+- `Logger.Configuration.remoteSampleRate` is applied per log event independently — unlike RUM session sampling which is decided once per session.

--- a/DatadogLogs/LOGS_FEATURE.md
+++ b/DatadogLogs/LOGS_FEATURE.md
@@ -163,7 +163,7 @@ logger.error(
 - **Logger name**: `name` — reported as `logger.name` on log events.
 - **Network info**: `networkInfoEnabled` (default: `false`) — attaches reachability, connection type, mobile carrier to every log.
 - **RUM bundling**: `bundleWithRumEnabled` (default: `true`) — attaches `application_id`, `session_id`, `view.id`, `user_action.id` when a sampled-in RUM session is active.
-- **Trace bundling**: `bundleWithTraceEnabled` (default: `true`) — attaches `dd.trace_id` and `dd.span_id` when an active trace span is present.
+- **Trace bundling**: `bundleWithTraceEnabled` (default: `true`) — attaches `dd.trace_id` and `dd.span_id` when a Datadog span is active (via `span.setActive()` from `Tracer.shared()`). OTel spans activated through `withActiveSpan` do not propagate through this path.
 
 ### Console Output
 - `consoleLogFormat: nil` (default) — no console output.

--- a/DatadogLogs/LOGS_FEATURE.md
+++ b/DatadogLogs/LOGS_FEATURE.md
@@ -8,6 +8,7 @@ tracked_files:
   - DatadogLogs/Sources/LoggerProtocol.swift
   - DatadogLogs/Sources/Logs+objc.swift
   - DatadogLogs/Sources/Log/LogEventEncoder.swift
+  - DatadogLogs/Sources/Scrubbing/LogEventMapper.swift
 ---
 
 # Logs Feature
@@ -66,7 +67,7 @@ let logger = Logger.create(
         service: "my-ios-app",
 
         // Logger name, reported as `logger.name` on log events
-        // Default: nil
+        // Default: nil (falls back to the app bundle identifier in the log payload)
         name: "MyViewController",
 
         // Attach network connectivity info (reachability, interface, carrier)
@@ -108,8 +109,8 @@ logger.critical("Unrecoverable state", error: someError)
 logger.addAttribute(forKey: "screen", value: "ProductList")
 logger.removeAttribute(forKey: "screen")
 
-logger.addTag(withKey: "env", value: "staging")
-logger.removeTag(withKey: "env")
+logger.addTag(withKey: "feature", value: "checkout")
+logger.removeTag(withKey: "feature")
 logger.add(tag: "beta")
 logger.remove(tag: "beta")
 

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -15,6 +15,11 @@ tracked_files:
 
 RUM tracks user interactions, views, resources, errors, and performance metrics in iOS applications. It requires initialization via `Datadog.initialize()` before enabling.
 
+**Platform**: iOS, tvOS, watchOS, visionOS — with platform-specific limitations:
+- **iOS / visionOS**: Full feature set.
+- **tvOS**: UIKit and SwiftUI view tracking, UIKit action tracking (press-based), app hangs, long tasks, vitals, slow frames, memory warnings. No SwiftUI action auto-tracking, no scroll/swipe tracking, no watchdog terminations.
+- **watchOS**: App hangs and long tasks only. No auto-tracking predicates, no vitals, no slow frames, no memory warnings.
+
 ## Quick Start Example
 
 ```swift

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -18,7 +18,7 @@ RUM tracks user interactions, views, resources, errors, and performance metrics 
 **Platform**: iOS, tvOS, watchOS, visionOS — with platform-specific limitations:
 - **iOS / visionOS**: Full feature set.
 - **tvOS**: UIKit and SwiftUI view tracking, UIKit action tracking (press-based), app hangs, long tasks, vitals, slow frames, memory warnings. No SwiftUI action auto-tracking, no scroll/swipe tracking, no watchdog terminations.
-- **watchOS**: App hangs and long tasks only. No auto-tracking predicates, no vitals, no slow frames, no memory warnings.
+- **watchOS**: No automatic view/action tracking predicates (UIKit and SwiftUI), no memory warnings. URLSession tracking, event mappers, manual RUM instrumentation, and session callbacks are available. `vitalsUpdateFrequency` and `trackSlowFrames` config options exist but are non-functional (DisplayLinker unavailable on watchOS).
 
 ## Quick Start Example
 

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -17,7 +17,7 @@ RUM tracks user interactions, views, resources, errors, and performance metrics 
 
 **Platform**: iOS, tvOS, watchOS, visionOS — with platform-specific limitations:
 - **iOS / visionOS**: Full feature set.
-- **tvOS**: UIKit and SwiftUI view tracking, UIKit action tracking (press-based), app hangs, long tasks, vitals, slow frames, memory warnings, watchdog terminations. No SwiftUI action auto-tracking, no scroll/swipe tracking.
+- **tvOS**: UIKit and SwiftUI view tracking, UIKit action tracking (press-based), app hangs, long tasks, vitals, slow frames, memory warnings, watchdog terminations. No `swiftUIActionsPredicate` (tap-gesture path), no scroll/swipe tracking.
 - **watchOS**: No automatic view/action tracking predicates (UIKit and SwiftUI), no memory warnings. URLSession tracking, event mappers, manual RUM instrumentation, session callbacks, and CPU/memory vitals are available. Refresh-rate and slow-frame data are unavailable (no DisplayLink on watchOS).
 
 ## Quick Start Example

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -17,8 +17,8 @@ RUM tracks user interactions, views, resources, errors, and performance metrics 
 
 **Platform**: iOS, tvOS, watchOS, visionOS — with platform-specific limitations:
 - **iOS / visionOS**: Full feature set.
-- **tvOS**: UIKit and SwiftUI view tracking, UIKit action tracking (press-based), app hangs, long tasks, vitals, slow frames, memory warnings. No SwiftUI action auto-tracking, no scroll/swipe tracking, no watchdog terminations.
-- **watchOS**: No automatic view/action tracking predicates (UIKit and SwiftUI), no memory warnings. URLSession tracking, event mappers, manual RUM instrumentation, and session callbacks are available. `vitalsUpdateFrequency` and `trackSlowFrames` config options exist but are non-functional (DisplayLinker unavailable on watchOS).
+- **tvOS**: UIKit and SwiftUI view tracking, UIKit action tracking (press-based), app hangs, long tasks, vitals, slow frames, memory warnings, watchdog terminations. No SwiftUI action auto-tracking, no scroll/swipe tracking.
+- **watchOS**: No automatic view/action tracking predicates (UIKit and SwiftUI), no memory warnings. URLSession tracking, event mappers, manual RUM instrumentation, session callbacks, and CPU/memory vitals are available. Refresh-rate and slow-frame data are unavailable (no DisplayLink on watchOS).
 
 ## Quick Start Example
 

--- a/DatadogTrace/TRACE_FEATURE.md
+++ b/DatadogTrace/TRACE_FEATURE.md
@@ -36,6 +36,8 @@ Trace can also connect to automatic `URLSession` network instrumentation; for th
 
 Trace requires initialization via `Datadog.initialize()` before enabling.
 
+**Platform**: iOS, tvOS, watchOS, visionOS
+
 ## Quick Start Example
 
 ```swift
@@ -200,7 +202,9 @@ requestSpan.finish()
 - **`DatadogTrace/Sources/OpenTelemetry/OTelTracerProvider.swift`** — `OTelTracerProvider` to register with `OpenTelemetry.registerTracerProvider(...)` and use the standard OpenTelemetry `Tracer` / `SpanBuilder` API.
 
 ### Public API — Objective-C Bridge
-- **`DatadogTrace/Sources/Objc/Tracing/Trace+objc.swift`** — Objective-C Trace entry point and configuration bridge (`DDTrace`, `DDTraceConfiguration`, `DDTraceURLSessionTracking`, `DDTracer`). Includes multi-instance variants: `+[DDTrace enableWith:instanceName:]` and `+[DDTracer sharedWithInstanceName:]`.
+- **`DatadogTrace/Sources/Objc/Tracing/Trace+objc.swift`** — Objective-C Trace entry point and configuration bridge (`DDTrace`, `DDTraceConfiguration`, `DDTraceURLSessionTracking`, `DDTracer`).
+  - `+[DDTrace enableWith:instanceName:]` — enables Trace in a named SDK instance (mirrors Swift `Trace.enable(with:in:)`).
+  - `+[DDTracer sharedWithInstanceName:]` — retrieves the tracer from a named SDK instance (mirrors Swift `Tracer.shared(in:)`).
 - **`DatadogTrace/Sources/Objc/OpenTracing/OTTracer+objc.swift`**, **`OTSpan+objc.swift`**, **`OTSpanContext+objc.swift`** — Objective-C OpenTracing protocols and constants.
 - **`DatadogTrace/Sources/Objc/Tracing/DDSpan+objc.swift`**, **`DDSpanContext+objc.swift`** — Objective-C wrappers around Datadog span and span context implementations.
 - **`DatadogTrace/Sources/Objc/Tracing/Propagation/*+objc.swift`** — Objective-C wrappers for Datadog, W3C, B3 header writers and trace context injection.

--- a/docs/LLM_FEATURE_DOCS_GUIDELINES.md
+++ b/docs/LLM_FEATURE_DOCS_GUIDELINES.md
@@ -23,7 +23,7 @@ DatadogRUM/RUM_FEATURE.md
 DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
 DatadogTrace/TRACE_FEATURE.md
 DatadogProfiling/PROFILING_FEATURE.md
-DatadogLogs/LOGS_FEATURE.md            # (future)
+DatadogLogs/LOGS_FEATURE.md
 DatadogWebViewTracking/WEBVIEW_FEATURE.md  # (future)
 ```
 
@@ -53,7 +53,7 @@ Every feature doc contains these core sections, in order. Optional sections are 
 
 ### Overview
 - Brief description of feature purpose
-- Platform availability (iOS, tvOS, watchOS, visionOS)
+- Platform availability — use the format `**Platform**: iOS, tvOS, watchOS, visionOS` (list only platforms declared in the podspec; add a note for platforms where functionality is limited or absent)
 - Key dependencies (e.g. "requires RUM")
 
 ### Quick Start Example


### PR DESCRIPTION
### What and why?

Add `DatadogLogs/LOGS_FEATURE.md` — the LLM-optimized feature doc for the Logs module, following the format established by RUM, Session Replay, and Trace.

Also adds platform availability notes to all existing feature docs (RUM, Trace) that were missing them, updates the `LLM_FEATURE_DOCS_GUIDELINES.md` to prescribe the `**Platform**:` format, and registers `LOGS_FEATURE.md` in `AGENTS.md` and the Confluence publishing workflow.

### How?

- New `DatadogLogs/LOGS_FEATURE.md` covering: Quick Start, Key Files, Configuration Categories (sampling, event modification, enrichment, console output, global/per-logger attributes), Troubleshooting, Feature Interactions, Additional Context.
- `DatadogRUM/RUM_FEATURE.md`: added per-platform breakdown (iOS/visionOS full, tvOS partial, watchOS minimal) verified against source `#if` guards in `RUMConfiguration.swift`.
- `DatadogTrace/TRACE_FEATURE.md`: added `**Platform**: iOS, tvOS, watchOS, visionOS` (no limitations).
- `docs/LLM_FEATURE_DOCS_GUIDELINES.md`: prescribes `**Platform**:` format in Overview.
- `AGENTS.md` + `.github/workflows/changelog-to-confluence.yaml`: registered by the `update-feature-docs` skill.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs