### PR TITLE
RUM-16553: Attach TTFD to Profiling

### DIFF
--- a/DatadogProfiling/Sources/AppLaunchProfiler.swift
+++ b/DatadogProfiling/Sources/AppLaunchProfiler.swift
@@ -108,7 +108,10 @@ extension AppLaunchProfiler: FeatureMessageReceiver {
             self.write(profile: profile, rumVitals: Array(self.currentRUMVitals.values))
             return false
         } else if case let .payload(message as OperationMessage) = message {
-            if message.operation.stepType == .start {
+            // Capture vitals like TTFD that are not operation steps.
+            if message.operation.stepType == nil {
+                currentRUMVitals[message.operation.key] = message.operation
+            } else if message.operation.stepType == .start {
                 currentRUMVitals[message.operation.key] = message.operation
             } else if var startVital = currentRUMVitals[message.operation.key] {
                 // Add duration to vital to help Profiling backend label correctly the samples of this vital

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -298,11 +298,13 @@ private extension DatadogProfiler {
             }
             attributes = message.attributes
 
-            switch message.operation.stepType {
-            case .start:
+            // Capture vitals like TTFD that are not operation steps.
+            if message.operation.stepType == nil {
+                currentRUMVitals[message.operation.key] = message.operation
+            } else if message.operation.stepType == .start {
                 currentRUMVitals[message.operation.key] = message.operation
                 updateProfilerState(canProfile: shouldKeepProfilerRunning())
-            case .end:
+            } else if message.operation.stepType == .end {
                 if var startVital = currentRUMVitals[message.operation.key] {
                     // Add duration to vital to help Profiling backend label correctly the samples of this vital
                     let duration = message.operation.date.timeIntervalSince(startVital.date)
@@ -316,7 +318,6 @@ private extension DatadogProfiler {
                         fireTimer(after: fireInterval)
                     }
                 }
-            default: break
             }
         }
     }

--- a/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
+++ b/DatadogProfiling/Tests/AppLaunchProfilerTests.swift
@@ -403,6 +403,45 @@ final class AppLaunchProfilerTests: XCTestCase {
         let vitalIDs = try eventIDs(ofType: "vital", from: metadata)
         XCTAssertEqual(vitalIDs.count, 2)
         XCTAssertTrue(vitalIDs.contains("start-id"))
+
+        let event = try XCTUnwrap(core.events.first as? ProfileEvent)
+        let attributeVitalIDs = try XCTUnwrap(event.additionalAttributes?[RUMCoreContext.IDs.vitalID] as? [String])
+        XCTAssertTrue(attributeVitalIDs.contains("start-id"))
+    }
+
+    func testApplicationLaunchWithTTFDVital_includesTTIDAndTTFDInProfile() throws {
+        // Given
+        let core = PassthroughCoreMock()
+        let profiler = appLaunchProfiler(core: core, isContinuousProfiling: false)
+        let ttidVital = Vital.mockWith(
+            id: "ttid-id",
+            name: "time_to_initial_display",
+            operationKey: nil,
+            stepType: nil,
+            duration: 1_000_000_000
+        )
+        let ttfdVital = Vital.mockWith(
+            id: "ttfd-id",
+            name: "time_to_full_display",
+            operationKey: nil,
+            stepType: nil,
+            duration: 2_000_000_000
+        )
+
+        XCTAssertEqual(dd_profiler_start(), 1)
+
+        // When
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: ttfdVital)), from: core)
+        _ = profiler.receive(message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: ttidVital)), from: core)
+
+        // Then
+        let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
+        let vitalIDs = try eventIDs(ofType: "vital", from: metadata)
+        XCTAssertEqual(Set(vitalIDs), Set(["ttid-id", "ttfd-id"]))
+
+        let event = try XCTUnwrap(core.events.first as? ProfileEvent)
+        let attributeVitalIDs = try XCTUnwrap(event.additionalAttributes?[RUMCoreContext.IDs.vitalID] as? [String])
+        XCTAssertEqual(Set(attributeVitalIDs), Set(["ttid-id", "ttfd-id"]))
     }
 
     func testApplicationLaunchWithOrphanedEndVital_excludesOrphanedFromProfile() throws {

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -75,6 +75,29 @@ final class DatadogProfilerTests: XCTestCase {
         XCTAssertFalse(result, "Continuous profiler and AppLaunch profiler consume app launch vitals")
     }
 
+    func testReceiveTTFDMessage_afterApplicationLaunchVital() {
+        // Given
+        let profiler = continuousProfiler()
+        let launchVital: Vital = .mockWith(stepType: nil)
+
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: launchVital)),
+            from: core
+        )
+
+        // When
+        let result = profiler.receive(
+            message: .payload(OperationMessage(
+                attributes: mockRandomAttributes(),
+                operation: .mockWith(stepType: nil, duration: 2_000_000_000)
+            )),
+            from: core
+        )
+
+        // Then
+        XCTAssertTrue(result, "Operation messages should be consumed by continuous profiler after app launch")
+    }
+
     func testReceiveLongTask() {
         // Given
         let profiler = continuousProfiler()
@@ -243,6 +266,44 @@ extension DatadogProfilerTests {
         let rumEvents = try typedRUMEvents(from: metadata)
         let vitalIDs = eventIDs(ofType: "vital", in: rumEvents)
         XCTAssertTrue(vitalIDs.contains(startOperation.id))
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testApplicationDidEnterBackground_includesTTFDVitalFromOperationMessageInProfile() throws {
+        // Given
+        let dateProvider = DateProviderMock()
+        let profiler = continuousProfiler(dateProvider: dateProvider)
+        let ttfdVital = Vital.mockWith(
+            id: "ttfd-id",
+            name: "time_to_full_display",
+            operationKey: nil,
+            stepType: nil,
+            date: dateProvider.now,
+            duration: 2_000_000_000
+        )
+
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: ttfdVital)), from: core)
+
+        // When
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .background, date: dateProvider.now)]
+        ))
+        waitForProfileWrite {
+            _ = profiler.receive(message: .context(core.context), from: core)
+        }
+
+        // Then
+        let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
+        let rumEvents = try typedRUMEvents(from: metadata)
+        let vitalIDs = eventIDs(ofType: "vital", in: rumEvents)
+        XCTAssertEqual(vitalIDs, ["ttfd-id"])
+
+        let event = try XCTUnwrap(core.events.first as? ProfileEvent)
+        let attributeVitalIDs = try XCTUnwrap(event.additionalAttributes?[RUMCoreContext.IDs.vitalID] as? [String])
+        XCTAssertEqual(attributeVitalIDs, ["ttfd-id"])
         withExtendedLifetime(profiler) {}
     }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
@@ -63,8 +63,22 @@ private extension RUMAppLaunchManager {
 
         self.timeToInitialDisplay = ttid
         let ttidVitalId = dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat
+        var ttfdVitalId: String?
 
         let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
+
+        if let timeToFullDisplay, let timeToInitialDisplay {
+            let ttfdVital = Vital(
+                id: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                name: RUMVitalAppLaunchEvent.Vital.AppLaunchMetric.ttfd.name,
+                date: context.launchInfo.processLaunchDate,
+                serverTimeOffset: context.serverTimeOffset,
+                duration: max(timeToInitialDisplay, timeToFullDisplay).dd.toInt64Nanoseconds
+            )
+            ttfdVitalId = ttfdVital.id
+
+            sendTTFDMessageToProfiler(vital: ttfdVital)
+        }
 
         sendTTIDMessageToProfiler(
             vital: .init(
@@ -73,8 +87,7 @@ private extension RUMAppLaunchManager {
                 date: context.launchInfo.processLaunchDate,
                 serverTimeOffset: context.serverTimeOffset,
                 duration: ttid.dd.toInt64Nanoseconds
-            ),
-            activeView: activeView
+            )
         )
 
         dependencies.appStateManager.previousAppStateInfo { [weak self] previousAppStateInfo in
@@ -105,14 +118,15 @@ private extension RUMAppLaunchManager {
                 if let timeToFullDisplay {
                     let ttfd = max(ttid, timeToFullDisplay)
                     self.writeVitalEvent(
-                        vitalId: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                        vitalId: ttfdVitalId ?? dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
                         duration: Double(ttfd.dd.toInt64Nanoseconds),
                         appLaunchMetric: .ttfd,
                         startupType: startupType,
                         attributes: attributes,
                         context: context,
                         writer: writer,
-                        activeView: activeView
+                        activeView: activeView,
+                        profiling: profiling
                     )
 
                     telemetryController.trackTTFD(duration: timeToFullDisplay.dd.toInt64Nanoseconds)
@@ -224,10 +238,8 @@ private extension RUMAppLaunchManager {
         telemetryController.track(ttidEvent: vitalEvent, context: context)
     }
 
-    func sendTTIDMessageToProfiler(vital: Vital, activeView: RUMViewScope?) {
-        var contextAttributes: [String: Encodable] = parent.rumContextAttributes
-        contextAttributes[RUMCoreContext.IDs.vitalID] = vital.id
-
+    func sendTTIDMessageToProfiler(vital: Vital) {
+        let contextAttributes: [String: Encodable] = parent.rumContextAttributes
         dependencies.featureScope.send(message: .payload(TTIDMessage(attributes: contextAttributes, ttid: vital)))
     }
 }
@@ -245,16 +257,27 @@ private extension RUMAppLaunchManager {
             let attributes = command.globalAttributes
                 .merging(command.attributes) { $1 }
             let ttfd = max(timeToInitialDisplay, timeToFullDisplay)
+            let ttfdVital = Vital(
+                id: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                name: RUMVitalAppLaunchEvent.Vital.AppLaunchMetric.ttfd.name,
+                date: context.launchInfo.processLaunchDate,
+                serverTimeOffset: context.serverTimeOffset,
+                duration: ttfd.dd.toInt64Nanoseconds
+            )
+            let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
+
+            sendTTFDMessageToProfiler(vital: ttfdVital)
 
             self.writeVitalEvent(
-                vitalId: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                vitalId: ttfdVital.id,
                 duration: Double(ttfd.dd.toInt64Nanoseconds),
                 appLaunchMetric: .ttfd,
                 startupType: startupType,
                 attributes: attributes,
                 context: context,
                 writer: writer,
-                activeView: activeView
+                activeView: activeView,
+                profiling: profiling
             )
         }
     }
@@ -273,6 +296,11 @@ private extension RUMAppLaunchManager {
         }
 
         return true
+    }
+
+    func sendTTFDMessageToProfiler(vital: Vital) {
+        let contextAttributes: [String: Encodable] = parent.rumContextAttributes
+        dependencies.featureScope.send(message: .payload(OperationMessage(attributes: contextAttributes, operation: vital)))
     }
 }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
@@ -21,7 +21,11 @@ internal class RUMAppLaunchManager {
     private let telemetryController: AppLaunchMetricController
 
     private var timeToInitialDisplay: Double?
-    private var timeToFullDisplay: Double?
+    private var timeToFullDisplay: (
+        duration: TimeInterval,
+        vitalId: String,
+        attributes: [AttributeKey: AttributeValue]
+    )?
     private var startupType: RUMVitalAppLaunchEvent.Vital.StartupType?
 
     private lazy var startupTypeHandler = StartupTypeHandler(telemetryController: telemetryController)
@@ -63,20 +67,18 @@ private extension RUMAppLaunchManager {
 
         self.timeToInitialDisplay = ttid
         let ttidVitalId = dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat
-        var ttfdVitalId: String?
-
         let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
 
-        if let timeToFullDisplay, let timeToInitialDisplay {
+        if let timeToFullDisplay {
             let ttfdVital = Vital(
-                id: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                id: timeToFullDisplay.vitalId,
                 name: RUMVitalAppLaunchEvent.Vital.AppLaunchMetric.ttfd.name,
                 date: context.launchInfo.processLaunchDate,
                 serverTimeOffset: context.serverTimeOffset,
-                duration: max(timeToInitialDisplay, timeToFullDisplay).dd.toInt64Nanoseconds
+                duration: max(ttid, timeToFullDisplay.duration).dd.toInt64Nanoseconds
             )
-            ttfdVitalId = ttfdVital.id
 
+            // TTID closes app-launch profiling, so only a TTFD reported earlier is sent here.
             sendTTFDMessageToProfiler(vital: ttfdVital)
         }
 
@@ -116,20 +118,20 @@ private extension RUMAppLaunchManager {
 
                 // The TTFD is always written after the TTID. If it exists already, means it was not written before.
                 if let timeToFullDisplay {
-                    let ttfd = max(ttid, timeToFullDisplay)
+                    let ttfd = max(ttid, timeToFullDisplay.duration)
                     self.writeVitalEvent(
-                        vitalId: ttfdVitalId ?? dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                        vitalId: timeToFullDisplay.vitalId,
                         duration: Double(ttfd.dd.toInt64Nanoseconds),
                         appLaunchMetric: .ttfd,
                         startupType: startupType,
-                        attributes: attributes,
+                        attributes: timeToFullDisplay.attributes,
                         context: context,
                         writer: writer,
                         activeView: activeView,
                         profiling: profiling
                     )
 
-                    telemetryController.trackTTFD(duration: timeToFullDisplay.dd.toInt64Nanoseconds)
+                    telemetryController.trackTTFD(duration: ttfd.dd.toInt64Nanoseconds)
                 }
 
                 telemetryController.sendMetric()
@@ -251,34 +253,38 @@ private extension RUMAppLaunchManager {
         guard shouldProcess(command: command, context: context),
               let ttfd = time(from: command, context: context) else { return }
 
-        self.timeToFullDisplay = ttfd
+        let timeToFullDisplay = (
+            duration: timeToInitialDisplay.map { max($0, ttfd) } ?? ttfd,
+            vitalId: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+            attributes: command.globalAttributes.merging(command.attributes) { $1 }
+        )
+        self.timeToFullDisplay = timeToFullDisplay
 
-        if let timeToFullDisplay, let timeToInitialDisplay, let startupType {
-            let attributes = command.globalAttributes
-                .merging(command.attributes) { $1 }
-            let ttfd = max(timeToInitialDisplay, timeToFullDisplay)
+        if timeToInitialDisplay != nil {
             let ttfdVital = Vital(
-                id: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
+                id: timeToFullDisplay.vitalId,
                 name: RUMVitalAppLaunchEvent.Vital.AppLaunchMetric.ttfd.name,
                 date: context.launchInfo.processLaunchDate,
                 serverTimeOffset: context.serverTimeOffset,
-                duration: ttfd.dd.toInt64Nanoseconds
+                duration: timeToFullDisplay.duration.dd.toInt64Nanoseconds
             )
-            let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
-
             sendTTFDMessageToProfiler(vital: ttfdVital)
 
-            self.writeVitalEvent(
-                vitalId: ttfdVital.id,
-                duration: Double(ttfd.dd.toInt64Nanoseconds),
-                appLaunchMetric: .ttfd,
-                startupType: startupType,
-                attributes: attributes,
-                context: context,
-                writer: writer,
-                activeView: activeView,
-                profiling: profiling
-            )
+            if let startupType {
+                let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
+
+                self.writeVitalEvent(
+                    vitalId: ttfdVital.id,
+                    duration: Double(timeToFullDisplay.duration.dd.toInt64Nanoseconds),
+                    appLaunchMetric: .ttfd,
+                    startupType: startupType,
+                    attributes: timeToFullDisplay.attributes,
+                    context: context,
+                    writer: writer,
+                    activeView: activeView,
+                    profiling: profiling
+                )
+            }
         }
     }
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
@@ -421,6 +421,70 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertNotNil(ttidMessage.attributes[RUMCoreContext.IDs.sessionID])
     }
 
+    func testTTFDCommand_whenReceivedAfterTTIDBeforeStartupType_reusesTTFDVitalIDAndAttributes() throws {
+        // Given
+        let featureScope = FeatureScopeMock()
+        let appStateManager = AppStateManagerMock()
+        appStateManager.shouldDeferPreviousAppStateInfoCallback = true
+        mockDependencies = .mockWith(featureScope: featureScope, appStateManager: appStateManager)
+        manager = RUMAppLaunchManager(
+            parent: mockParent,
+            dependencies: mockDependencies,
+            telemetryController: .init()
+        )
+
+        let ttid = 1.0
+        let ttfd = 2.0
+        let ttidCommand: RUMTimeToInitialDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(ttid),
+            globalAttributes: ["command": "ttid"]
+        )
+        let ttfdCommand: RUMTimeToFullDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(ttfd),
+            globalAttributes: [
+                "command": "ttfd",
+                "overridden": "global"
+            ],
+            attributes: [
+                "overridden": "local",
+                "ttfd": "attribute"
+            ]
+        )
+
+        // When
+        manager.process(ttidCommand, context: mockContext, writer: mockWriter)
+        manager.process(ttfdCommand, context: mockContext, writer: mockWriter)
+
+        // Then
+        let messages = featureScope.messagesSent()
+        XCTAssertEqual(messages.count, 2)
+
+        let ttidMessage = try XCTUnwrap(messages.first?.asPayload as? TTIDMessage)
+        let ttfdMessage = try XCTUnwrap(messages.last?.asPayload as? OperationMessage)
+        XCTAssertEqual(ttidMessage.ttid.name, "time_to_initial_display")
+        XCTAssertEqual(ttfdMessage.operation.name, "time_to_full_display")
+        XCTAssertNil(ttfdMessage.operation.stepType)
+        XCTAssertEqual(ttfdMessage.operation.duration, ttfd.dd.toInt64Nanoseconds)
+        XCTAssertNotNil(ttfdMessage.attributes[RUMCoreContext.IDs.applicationID])
+        XCTAssertNotNil(ttfdMessage.attributes[RUMCoreContext.IDs.sessionID])
+
+        XCTAssertEqual(mockWriter.events(ofType: RUMVitalAppLaunchEvent.self).count, 0)
+
+        appStateManager.completePreviousAppStateInfo()
+
+        let vitalEvents = mockWriter.events(ofType: RUMVitalAppLaunchEvent.self)
+        XCTAssertEqual(vitalEvents.count, 2)
+        XCTAssertEqual(vitalEvents.map(\.vital.appLaunchMetric), [.ttid, .ttfd])
+
+        let ttfdEvent = try XCTUnwrap(vitalEvents.last)
+        XCTAssertEqual(ttfdEvent.vital.id, ttfdMessage.operation.id)
+        XCTAssertEqual(ttfdEvent.context?.contextInfo as? [String: String], [
+            "command": "ttfd",
+            "overridden": "local",
+            "ttfd": "attribute"
+        ])
+    }
+
     func testTTFDCommand_createsAppLaunchVitalEventsForPreWarmingLaunches() throws {
         // Given
         let processLaunchDate = Date()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
@@ -331,6 +331,96 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertNotNil(event.version)
     }
 
+    func testTTFDCommand_createsAppLaunchVitalEventWithProfilingAndSendsOperationMessage() throws {
+        // Given
+        let featureScope = FeatureScopeMock()
+        mockDependencies = .mockWith(featureScope: featureScope, appStateManager: appStateManager)
+        mockContext.set(additionalContext: ProfilingContext(
+            status: .error(reason: .memoryAllocationFailed),
+            quotaReason: .quotaExceeded
+        ))
+        manager = RUMAppLaunchManager(
+            parent: mockParent,
+            dependencies: mockDependencies,
+            telemetryController: .init()
+        )
+
+        let ttfd = 2.0
+        let ttidCommand: RUMTimeToInitialDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(0.1)
+        )
+        let ttfdCommand: RUMTimeToFullDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(ttfd)
+        )
+
+        // When
+        manager.process(ttidCommand, context: mockContext, writer: mockWriter)
+        manager.process(ttfdCommand, context: mockContext, writer: mockWriter)
+
+        // Then
+        let event = try XCTUnwrap(mockWriter.events(ofType: RUMVitalAppLaunchEvent.self).last)
+        XCTAssertEqual(event.vital.appLaunchMetric, .ttfd)
+        XCTAssertEqual(event.dd.profiling?.status, .error)
+        XCTAssertEqual(event.dd.profiling?.errorReason, .unexpectedException)
+        XCTAssertEqual(event.dd.profiling?.quotaReason, .quotaExceeded)
+
+        let message = try XCTUnwrap(
+            featureScope.messagesSent().compactMap { $0.asPayload as? OperationMessage }.first
+        )
+        XCTAssertEqual(message.operation.id, event.vital.id)
+        XCTAssertEqual(message.operation.name, "time_to_full_display")
+        XCTAssertNil(message.operation.stepType)
+        XCTAssertEqual(message.operation.duration, ttfd.dd.toInt64Nanoseconds)
+        XCTAssertNotNil(message.attributes[RUMCoreContext.IDs.applicationID])
+        XCTAssertNotNil(message.attributes[RUMCoreContext.IDs.sessionID])
+    }
+
+    func testTTFDCommand_whenReceivedBeforeTTID_sendsOperationMessageBeforeTTIDMessage() throws {
+        // Given
+        let featureScope = FeatureScopeMock()
+        mockDependencies = .mockWith(featureScope: featureScope, appStateManager: appStateManager)
+        manager = RUMAppLaunchManager(
+            parent: mockParent,
+            dependencies: mockDependencies,
+            telemetryController: .init()
+        )
+
+        let ttid = 1.0
+        let ttfd = 2.0
+        let ttfdCommand: RUMTimeToFullDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(ttfd)
+        )
+        let ttidCommand: RUMTimeToInitialDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(ttid)
+        )
+
+        // When
+        manager.process(ttfdCommand, context: mockContext, writer: mockWriter)
+        manager.process(ttidCommand, context: mockContext, writer: mockWriter)
+
+        // Then
+        let vitalEvents = mockWriter.events(ofType: RUMVitalAppLaunchEvent.self)
+        XCTAssertEqual(vitalEvents.count, 2)
+        XCTAssertEqual(vitalEvents.map(\.vital.appLaunchMetric), [.ttid, .ttfd])
+
+        let ttfdEvent = try XCTUnwrap(vitalEvents.last)
+
+        let messages = featureScope.messagesSent()
+        XCTAssertEqual(messages.count, 2)
+
+        let ttfdMessage = try XCTUnwrap(messages.first?.asPayload as? OperationMessage)
+        let ttidMessage = try XCTUnwrap(messages.last?.asPayload as? TTIDMessage)
+        XCTAssertEqual(ttfdMessage.operation.id, ttfdEvent.vital.id)
+        XCTAssertEqual(ttfdMessage.operation.name, "time_to_full_display")
+        XCTAssertNil(ttfdMessage.operation.stepType)
+        XCTAssertEqual(ttfdMessage.operation.duration, ttfd.dd.toInt64Nanoseconds)
+        XCTAssertNotNil(ttfdMessage.attributes[RUMCoreContext.IDs.applicationID])
+        XCTAssertNotNil(ttfdMessage.attributes[RUMCoreContext.IDs.sessionID])
+        XCTAssertEqual(ttidMessage.ttid.name, "time_to_initial_display")
+        XCTAssertNotNil(ttidMessage.attributes[RUMCoreContext.IDs.applicationID])
+        XCTAssertNotNil(ttidMessage.attributes[RUMCoreContext.IDs.sessionID])
+    }
+
     func testTTFDCommand_createsAppLaunchVitalEventsForPreWarmingLaunches() throws {
         // Given
         let processLaunchDate = Date()

--- a/TestUtilities/Sources/Mocks/DatadogRUM/AppStateManagerMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/AppStateManagerMock.swift
@@ -12,14 +12,27 @@ import DatadogInternal
 public final class AppStateManagerMock: AppStateManaging {
     public var previousAppStateInfo: AppStateInfo?
     public var currentAppStateInfo: AppStateInfo = .mockAny()
+    public var shouldDeferPreviousAppStateInfoCallback: Bool = false
+
+    private var previousAppStateInfoCompletion: ((AppStateInfo?) -> Void)?
 
     public func deleteAppState() {}
     public func updateAppState(state: AppState) {}
     public func previousAppStateInfo(completion: @escaping (DatadogRUM.AppStateInfo?) -> Void) {
-        completion(previousAppStateInfo)
+        if shouldDeferPreviousAppStateInfoCallback {
+            previousAppStateInfoCompletion = completion
+        } else {
+            completion(previousAppStateInfo)
+        }
     }
     public func currentAppStateInfo(completion: @escaping (AppStateInfo) -> Void) {
         completion(currentAppStateInfo)
     }
     public func storeCurrentAppState() {}
+
+    public func completePreviousAppStateInfo() {
+        let completion = previousAppStateInfoCompletion
+        previousAppStateInfoCompletion = nil
+        completion?(previousAppStateInfo)
+    }
 }


### PR DESCRIPTION
### What and why?

This PR adds support for the TTFD vital in Profiling, enabling profiles to be associated with TTFD in the same way they are with TTID and other RUM vitals.

Previously, TTFD was emitted only as a RUM app-launch vital and was not propagated through the profiling vital pipeline. With this change, profiles can now be correlated with TTFD events.

### How?

RUM now forwards TTFD to Profiling as a complete `OperationMessage`, reusing the same vital ID as the corresponding TTFD event. The app-launch and Datadog profilers already treat messages without a `stepType` as complete vitals and TTFD fits into this category. This allows TTFD to flow through the existing vital pipeline without introducing special case handling.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
