### PR TITLE
Fixes `testAddLink()`.

### DIFF
--- a/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
+++ b/DatadogCore/Tests/Datadog/Tracing/OTelSpanTests.swift
@@ -86,7 +86,7 @@ final class OTelSpanTests: XCTestCase {
 
     func testAddLink() throws {
         let core = DatadogCoreProxy()
-        defer { XCTAssertNoThrow(try core.flushAndTearDown())}
+        defer { XCTAssertNoThrow(try core.flushAndTearDown()) }
 
         Trace.enable(in: core)
 
@@ -125,8 +125,8 @@ final class OTelSpanTests: XCTestCase {
         XCTAssertEqual(links.count, 1)
         let firstLink = try XCTUnwrap(links.first)
 
-        XCTAssertEqual(firstLink["trace_id"]?.value as? String, try span2Matcher.traceID()?.toString(representation: .hexadecimal))
-        XCTAssertEqual(firstLink["span_id"]?.value as? String, try span2Matcher.spanID()?.toString(representation: .hexadecimal))
+        XCTAssertEqual(firstLink["trace_id"]?.value as? String, try span2Matcher.traceID()?.toString(representation: .hexadecimal32Chars))
+        XCTAssertEqual(firstLink["span_id"]?.value as? String, try span2Matcher.spanID()?.toString(representation: .hexadecimal16Chars))
 
         let attributes = try XCTUnwrap(firstLink["attributes"]?.value as? [String: String])
         XCTAssertEqual(attributes["weight"], "42")


### PR DESCRIPTION
### What and why?

Fixes flaky test (`testAddLink()`).

### How?

When traceID or spanID started with 0, the hex representation was dropping those zeros. Fixed by calling the correct representation.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
