### PR TITLE
[RUM-16387] Generate RC models from iOS-specific staging schema

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -4464,9 +4464,9 @@
 		61133B9E2423979B00786299 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				10E906292FBDB818002D5F45 /* RemoteConfigurationProvider.swift */,
 				D2B3F04C282A85FD00C2B5EE /* DatadogCore.swift */,
 				D214DAA429E072D7004D0AE8 /* MessageBus.swift */,
+				10E906292FBDB818002D5F45 /* RemoteConfigurationProvider.swift */,
 				D2EFA866286DA82700F1FAA6 /* Context */,
 				61133BA62423979B00786299 /* Storage */,
 				6128F56C2BA223A100D35B08 /* DataStore */,

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -135,9 +135,11 @@ internal final class DatadogCore {
 
         self.remoteConfigurationProvider?.start { [weak self] result in
             switch result {
-            case .success(let remoteConfiguration):
+            case let .success(remoteConfiguration):
                 self?.remoteConfiguration = remoteConfiguration
-            case .failure(let error):
+            case let .failure(.etagError(error)):
+                self?.telemetry.error("[RemoteConfig] ETag caching failed", error: error)
+            case let .failure(error):
                 self?.telemetry.error("[RemoteConfig] Sync failed", error: error)
             }
         }

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -7,7 +7,27 @@
 import Foundation
 import DatadogInternal
 
-/// Fetches remote configuration when started and when the app enters foreground.
+/// Fetches and caches remote configuration from the Datadog CDN.
+///
+/// On `start(_:)`, the provider immediately delivers any previously cached configuration
+/// from disk, then fires an async CDN request to refresh it. On UIKit platforms it also
+/// re-syncs whenever the app returns to the foreground, so long-lived sessions always
+/// converge on the latest configuration without requiring a restart.
+///
+/// ## Caching
+/// A successful fetch is persisted as `<id>.json` inside the supplied `directory`.
+/// The accompanying HTTP ETag is stored in `<id>.etag` and sent back as `If-None-Match`
+/// on subsequent requests, turning unchanged responses into lightweight 304s that skip
+/// body transfer and re-parse entirely.
+///
+/// ## Threading
+/// - The synchronous cache read in `start` runs on the caller's thread.
+/// - The network completion and all `completionHandler` calls are dispatched on an
+///   internal URLSession delegate queue (not the main thread).
+///
+/// ## Lifecycle
+/// Call `stop()` (or let the instance deinit) to unsubscribe from foreground
+/// notifications and prevent further `completionHandler` invocations.
 internal final class RemoteConfigurationProvider {
     let id: String
     let site: DatadogSite
@@ -37,13 +57,24 @@ internal final class RemoteConfigurationProvider {
         self.dateProvider = dateProvider
     }
 
+    /// Starts the provider.
+    ///
+    /// - Immediately calls `completionHandler` with the cached configuration if one exists on disk.
+    /// - Fires an async CDN request; calls `completionHandler` again when it completes (success or failure).
+    /// - On UIKit platforms, re-syncs on every `UIApplication.willEnterForegroundNotification`,
+    ///   calling `completionHandler` each time with the refreshed result.
+    ///
+    /// `completionHandler` may be called more than once: once synchronously for the cache,
+    /// and once (or more, on foreground transitions) asynchronously for network results.
+    /// It is always called with an up-to-date result — callers should replace, not accumulate.
+    ///
+    /// - Parameter completionHandler: Called with `.success` when configuration is available
+    ///   (from cache or network), or `.failure` if a read or fetch error occurs.
     func start(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
         // Synchronous read on the caller's thread (main thread during SDK init).
         // Acceptable because the file is small (a single JSON document) and only
         // present after a previous successful fetch — absent on first launch.
-        if let cached = Self.readCache(id: id, from: directory) {
-            completionHandler(cached)
-        }
+        readCache().map(completionHandler)
 
 #if canImport(UIKit)
         foregroundObserver = notificationCenter.addObserver(
@@ -67,6 +98,18 @@ internal final class RemoteConfigurationProvider {
         sync(completionHandler)
     }
 
+    deinit {
+        stop()
+    }
+
+    /// Stops the provider.
+    ///
+    /// Unsubscribes from foreground notifications so that in-flight or future syncs
+    /// no longer invoke the completion handler passed to `start(_:)`. Any network
+    /// request already in flight may still complete, but its result is discarded
+    /// because the `[weak self]` capture in the HTTP callback resolves to `nil`.
+    ///
+    /// Safe to call multiple times and from any thread.
     func stop() {
         _foregroundObserver.mutate { observer in
 #if canImport(UIKit)
@@ -78,45 +121,40 @@ internal final class RemoteConfigurationProvider {
 
     // MARK: - Private
 
-    private static func readCache(
-        id: String,
-        from directory: Directory
-    ) -> Result<RemoteConfiguration, RemoteConfigurationError>? {
-        let fileName = "\(id).json"
-        guard directory.hasFile(named: fileName) else {
+    private func readCache() -> Result<RemoteConfiguration, RemoteConfigurationError>? {
+        let cacheFilename = "\(id).json"
+        guard directory.hasFile(named: cacheFilename) else {
             return nil
         }
 
-        let data: Data
         do {
-            data = try directory.file(named: fileName).read()
-        } catch {
-            return .failure(.diskError)
-        }
-
-        return decode(data)
-    }
-
-    private static func decode(_ data: Data) -> Result<RemoteConfiguration, RemoteConfigurationError> {
-        do {
-            return .success(try JSONDecoder().decode(RemoteConfiguration.self, from: data))
-        } catch {
+            let data = try directory.file(named: cacheFilename).read()
+            let remoteConfiguration = try JSONDecoder().decode(RemoteConfiguration.self, from: data)
+            return .success(remoteConfiguration)
+        } catch let error as DecodingError {
             return .failure(.decodingError(error))
+        } catch {
+            return .failure(.internalError(error))
         }
     }
 
     /// Fires an async CDN fetch and persists the configuration on success.
     private func sync(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
-        // Build request with conditional ETag header if a previous ETag is stored.
-        var request = URLRequest(url: site.remoteConfigurationEndpoint
-            .appendingPathComponent("v1")
-            .appendingPathComponent(id)
-            .appendingPathExtension("json"))
+        let cacheFilename = "\(id).json"
+        let etagFilename = "\(id).etag"
 
-        if directory.hasFile(named: "\(id).json"),
-           let data = try? directory.file(named: "\(id).etag").read(),
-           let etag = String(data: data, encoding: .utf8) {
-            request.setValue(etag, forHTTPHeaderField: "If-None-Match")
+        // Build request with conditional ETag header if a previous ETag is stored.
+        var request = URLRequest(
+            url: site.remoteConfigurationEndpoint
+                .appendingPathComponent("v1")
+                .appendingPathComponent(id)
+                .appendingPathExtension("json")
+        )
+
+        if let data = try? directory.file(named: etagFilename).read() {
+            String(data: data, encoding: .utf8).map {
+                request.setValue($0, forHTTPHeaderField: "If-None-Match")
+            }
         }
 
         httpClient.send(request: request, delegate: nil) { [weak self] result in
@@ -124,63 +162,57 @@ internal final class RemoteConfigurationProvider {
                 return
             }
 
-            switch result {
-            case .failure(let error):
-                completionHandler(.failure(.networkError(error)))
+            do {
+                let (http, data) = try result
+                    .mapError { RemoteConfigurationError.networkError($0) }
+                    .get()
 
-            case .success(let (http, data)):
-                // 1. Not Modified — existing persisted configuration is still valid.
                 if http.statusCode == 304 {
                     self.lastSyncDate = self.dateProvider.now
                     return
                 }
 
-                // 2. Non-2xx HTTP status
                 guard (200..<300).contains(http.statusCode) else {
-                    completionHandler(.failure(.httpError(http.statusCode)))
-                    return
+                    throw RemoteConfigurationError.httpError(http.statusCode)
                 }
 
-                // 3. Empty body
-                guard let data = data, !data.isEmpty else {
-                    completionHandler(.failure(.emptyBody))
-                    return
+                // Persist ETag before decoding — the ETag belongs to the HTTP response,
+                // not to whether we could parse the body. This prevents re-fetching a
+                // known-bad payload on every sync; we recover when the server updates.
+                if let etag = http.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "etag" })?.value as? String {
+                    try? self.write(Data(etag.utf8), to: etagFilename)
+                } else {
+                    try? self.directory.file(named: etagFilename).delete()
                 }
 
-                let remoteConfiguration: RemoteConfiguration
-                switch Self.decode(data) {
-                case .success(let decodedRemoteConfiguration):
-                    remoteConfiguration = decodedRemoteConfiguration
-                case .failure(let error):
-                    completionHandler(.failure(error))
-                    return
+                guard let data, !data.isEmpty else {
+                    throw RemoteConfigurationError.emptyBody
                 }
+
+                let remoteConfiguration = try JSONDecoder().decode(RemoteConfiguration.self, from: data)
 
                 // All checks passed — persist to disk.
                 // File.write uses .atomic (write to temp, then rename), so the update is
                 // all-or-nothing: the existing file is never left in a truncated state.
-                do {
-                    try File(url: self.directory.url.appendingPathComponent("\(self.id).json")).write(data: data)
-                    self.lastSyncDate = self.dateProvider.now
-                    // Store ETag for conditional requests on the next sync.
-                    // If the response has no ETag, delete any stale validator so we
-                    // never send If-None-Match for a different representation.
-                    let etagFileName = "\(self.id).etag"
-                    if let etag = http.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "etag" })?.value as? String {
-                        let etagFile = self.directory.hasFile(named: etagFileName)
-                            ? (try? self.directory.file(named: etagFileName))
-                            : (try? self.directory.createFile(named: etagFileName))
-                        try? etagFile?.write(data: Data(etag.utf8))
-                    } else {
-                        // try? silently handles the case where the file does not exist
-                        try? self.directory.file(named: etagFileName).delete()
-                    }
-                    completionHandler(.success(remoteConfiguration))
-                } catch {
-                    completionHandler(.failure(.diskError))
-                }
+                try self.write(data, to: cacheFilename)
+                self.lastSyncDate = self.dateProvider.now
+
+                completionHandler(.success(remoteConfiguration))
+            } catch let error as RemoteConfigurationError {
+                completionHandler(.failure(error))
+            } catch let error as DecodingError {
+                completionHandler(.failure(.decodingError(error)))
+            } catch {
+                completionHandler(.failure(.internalError(error)))
             }
         }
+    }
+
+    private func write(_ data: Data, to filename: String) throws {
+        let file = directory.hasFile(named: filename)
+            ? try directory.file(named: filename)
+            : try directory.createFile(named: filename)
+        try file.write(data: data)
     }
 }
 
@@ -188,16 +220,16 @@ internal enum RemoteConfigurationError: Error, LocalizedError {
     case networkError(Error)
     case httpError(Int)
     case emptyBody
-    case decodingError(Error)
-    case diskError
+    case decodingError(DecodingError)
+    case internalError(Error)
 
     var errorDescription: String? {
         switch self {
         case .networkError(let error): return "Network error: \(error.localizedDescription)"
         case .httpError(let code): return "Non-2xx response: HTTP \(code)"
         case .emptyBody: return "Empty response body"
-        case .decodingError(let error): return "Remote configuration decoding failed: \(error.localizedDescription)"
-        case .diskError: return "Remote configuration disk read/write failed"
+        case .decodingError(let error): return "Decoding failed: \(error.localizedDescription)"
+        case .internalError(let error): return "Internal error: \(error.localizedDescription)"
         }
     }
 }

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -22,22 +22,23 @@ import DatadogInternal
 ///
 /// ## Threading
 /// - The synchronous cache read in `start` runs on the caller's thread.
-/// - The network completion and all `completionHandler` calls are dispatched on an
+/// - The network completion and all `handler` calls are dispatched on an
 ///   internal URLSession delegate queue (not the main thread).
 ///
 /// ## Lifecycle
 /// Call `stop()` (or let the instance deinit) to unsubscribe from foreground
-/// notifications and prevent further `completionHandler` invocations.
+/// notifications and prevent further `handler` invocations.
 internal final class RemoteConfigurationProvider {
     let id: String
     let site: DatadogSite
     let directory: Directory
     let httpClient: HTTPClient
+
     private let notificationCenter: NotificationCenter
     private let dateProvider: DateProvider
+    private let minimumSyncInterval: TimeInterval = 300
     @ReadWriteLock
     private var lastSyncDate: Date? = nil
-    private let minimumSyncInterval: TimeInterval = 300
     @ReadWriteLock
     private var foregroundObserver: NSObjectProtocol?
 
@@ -59,22 +60,23 @@ internal final class RemoteConfigurationProvider {
 
     /// Starts the provider.
     ///
-    /// - Immediately calls `completionHandler` with the cached configuration if one exists on disk.
-    /// - Fires an async CDN request; calls `completionHandler` again when it completes (success or failure).
-    /// - On UIKit platforms, re-syncs on every `UIApplication.willEnterForegroundNotification`,
-    ///   calling `completionHandler` each time with the refreshed result.
+    /// `handler` is **not** a one-shot completion — it is invoked every time a configuration
+    /// result becomes available:
+    /// - synchronously with the cached configuration, if one exists on disk;
+    /// - asynchronously when the CDN request completes (success or failure);
+    /// - on UIKit platforms, again on each `UIApplication.willEnterForegroundNotification`
+    ///   that triggers a refresh.
     ///
-    /// `completionHandler` may be called more than once: once synchronously for the cache,
-    /// and once (or more, on foreground transitions) asynchronously for network results.
-    /// It is always called with an up-to-date result — callers should replace, not accumulate.
+    /// Each invocation carries the latest result, so callers should replace the previously
+    /// delivered value rather than accumulate.
     ///
-    /// - Parameter completionHandler: Called with `.success` when configuration is available
+    /// - Parameter handler: Called with `.success` when configuration is available
     ///   (from cache or network), or `.failure` if a read or fetch error occurs.
-    func start(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
+    func start(_ handler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
         // Synchronous read on the caller's thread (main thread during SDK init).
         // Acceptable because the file is small (a single JSON document) and only
         // present after a previous successful fetch — absent on first launch.
-        readCache().map(completionHandler)
+        readCache().map(handler)
 
 #if canImport(UIKit)
         foregroundObserver = notificationCenter.addObserver(
@@ -91,11 +93,11 @@ internal final class RemoteConfigurationProvider {
                     return
                 }
             }
-            self.sync(completionHandler)
+            self.sync(handler)
         }
 #endif
 
-        sync(completionHandler)
+        sync(handler)
     }
 
     deinit {
@@ -139,7 +141,7 @@ internal final class RemoteConfigurationProvider {
     }
 
     /// Fires an async CDN fetch and persists the configuration on success.
-    private func sync(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
+    private func sync(_ handler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
         let cacheFilename = "\(id).json"
         let etagFilename = "\(id).etag"
 
@@ -151,9 +153,12 @@ internal final class RemoteConfigurationProvider {
                 .appendingPathExtension("json")
         )
 
-        if let data = try? directory.file(named: etagFilename).read() {
-            String(data: data, encoding: .utf8).map {
-                request.setValue($0, forHTTPHeaderField: "If-None-Match")
+        if let file = try? directory.file(named: etagFilename) {
+            do {
+                try String(data: file.read(), encoding: .utf8)
+                    .map { request.setValue($0, forHTTPHeaderField: "If-None-Match") }
+            } catch {
+                handler(.failure(.etagError(error)))
             }
         }
 
@@ -176,13 +181,18 @@ internal final class RemoteConfigurationProvider {
                     throw RemoteConfigurationError.httpError(http.statusCode)
                 }
 
-                // Persist ETag before decoding — the ETag belongs to the HTTP response,
-                // not to whether we could parse the body. This prevents re-fetching a
-                // known-bad payload on every sync; we recover when the server updates.
-                if let etag = http.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "etag" })?.value as? String {
-                    try? self.write(Data(etag.utf8), to: etagFilename)
-                } else {
-                    try? self.directory.file(named: etagFilename).delete()
+                do {
+                    // Persist ETag before decoding — the ETag belongs to the HTTP response,
+                    // not to whether we could parse the body. This prevents re-fetching a
+                    // known-bad payload on every sync; we recover when the server updates.
+                    if let etag = http.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "etag" })?.value as? String {
+                        try self.write(Data(etag.utf8), to: etagFilename)
+                    } else if let file = try? directory.file(named: etagFilename) {
+                        // Only delete a validator that actually exists; "nothing to delete" is not an error.
+                        try file.delete()
+                    }
+                } catch {
+                    handler(.failure(.etagError(error)))
                 }
 
                 guard let data, !data.isEmpty else {
@@ -197,13 +207,13 @@ internal final class RemoteConfigurationProvider {
                 try self.write(data, to: cacheFilename)
                 self.lastSyncDate = self.dateProvider.now
 
-                completionHandler(.success(remoteConfiguration))
+                handler(.success(remoteConfiguration))
             } catch let error as RemoteConfigurationError {
-                completionHandler(.failure(error))
+                handler(.failure(error))
             } catch let error as DecodingError {
-                completionHandler(.failure(.decodingError(error)))
+                handler(.failure(.decodingError(error)))
             } catch {
-                completionHandler(.failure(.internalError(error)))
+                handler(.failure(.internalError(error)))
             }
         }
     }
@@ -221,6 +231,7 @@ internal enum RemoteConfigurationError: Error, LocalizedError {
     case httpError(Int)
     case emptyBody
     case decodingError(DecodingError)
+    case etagError(Error)
     case internalError(Error)
 
     var errorDescription: String? {
@@ -229,6 +240,7 @@ internal enum RemoteConfigurationError: Error, LocalizedError {
         case .httpError(let code): return "Non-2xx response: HTTP \(code)"
         case .emptyBody: return "Empty response body"
         case .decodingError(let error): return "Decoding failed: \(error.localizedDescription)"
+        case .etagError(let error): return "Etag storage failed: \(error.localizedDescription)"
         case .internalError(let error): return "Internal error: \(error.localizedDescription)"
         }
     }

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -359,8 +359,45 @@ class RemoteConfigurationTests: XCTestCase {
         waitForExpectations(timeout: 2)
 
         let etagFileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.etag")
-        XCTAssertEqual(try? String(data: Data(contentsOf: etagFileURL), encoding: .utf8), "abc123",
-            "ETag must be stored even when the body cannot be decoded — prevents re-fetching a known-bad payload")
+        XCTAssertEqual(try String(data: Data(contentsOf: etagFileURL), encoding: .utf8), "abc123")
+        withExtendedLifetime(rc) {}
+    }
+
+    func testInitSyncStillDeliversConfigurationWhenETagWriteFails() throws {
+        // Given — the ETag path is occupied by a directory, so writing the ETag fails,
+        // while the configuration (.json) write still succeeds.
+        try FileManager.default.createDirectory(
+            at: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
+            withIntermediateDirectories: false
+        )
+        let response = HTTPURLResponse(
+            url: URL(string: "https://sdk-configuration.browser-intake-datadoghq.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["ETag": "abc123"]
+        )!
+        let payload = remoteConfigurationData(applicationID: "fetched-application-id")
+        let rc = makeProvider(httpClient: HTTPClientMock(response: response, data: payload), start: false)
+
+        // Then — ETag caching is best-effort: the failure is reported, but the freshly
+        // fetched configuration is still delivered. The handler may fire more than once,
+        // and an ETag error may be reported more than once (the conditional-request read
+        // and the persist write both fail when the path is a directory).
+        let etagFailure = expectation(description: "ETag failure is reported")
+        etagFailure.assertForOverFulfill = false
+        let configDelivered = expectation(description: "configuration is still delivered")
+        rc.start { result in
+            switch result {
+            case .failure(.etagError): etagFailure.fulfill()
+            case .success: configDelivered.fulfill()
+            case .failure: break
+            }
+        }
+        waitForExpectations(timeout: 2)
+
+        // And — the configuration is persisted to disk despite the ETag failure.
+        let configURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
+        XCTAssertEqual(try? Data(contentsOf: configURL), payload, "Configuration must be persisted even when the ETag write fails")
         withExtendedLifetime(rc) {}
     }
 
@@ -389,13 +426,14 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(provider) {}
     }
 
-    func testInitSyncDoesNotSendIfNoneMatchWhenPersistedConfigurationIsMissing() throws {
-        // Given — ETag file exists but JSON configuration is missing.
+    func testInitSyncSendsIfNoneMatchWhenETagStoredEvenWithoutConfiguration() throws {
+        // Given — an ETag exists but the JSON configuration does not. This happens when a
+        // previous fetch returned a payload we could not decode: we keep its ETag on purpose
+        // so we can skip re-downloading the known-bad payload.
         try Data("abc123".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
             options: .atomic
         )
-        // No .json file means a 304 response would leave the caller with no configuration.
 
         let httpClient = HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8))
         let provider = makeProvider(httpClient: httpClient)
@@ -405,9 +443,12 @@ class RemoteConfigurationTests: XCTestCase {
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
-        XCTAssertNil(
+        // Then — If-None-Match is still sent: a 304 means the known-bad payload is unchanged
+        // (nothing to gain by re-downloading), and a 200 with a new ETag lets us recover.
+        XCTAssertEqual(
             httpClient.requestsSent().first?.value(forHTTPHeaderField: "If-None-Match"),
-            "Must not send If-None-Match when persisted configuration is missing — a 304 would leave us with no data"
+            "abc123",
+            "If-None-Match must be sent whenever an ETag is stored, so a known-bad payload is not re-fetched"
         )
         withExtendedLifetime(provider) {}
     }
@@ -546,19 +587,17 @@ class RemoteConfigurationTests: XCTestCase {
         // Given — init sync fails, lastSyncDate stays nil
         let notificationCenter = NotificationCenter()
         let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
-        let requestLock = NSLock()
-        var requestCount = 0
-        MockURLProtocol.requestHandler = { request in
-            requestLock.lock()
-            requestCount += 1
-            let count = requestCount
-            requestLock.unlock()
-            if count == 1 {
-                throw URLError(.networkConnectionLost)
+        var didFailInitialSync = false
+        let httpClient = HTTPClientMock { _ in
+            // Invoked on the mock's serial queue, so this state needs no lock.
+            // Fail the first (init) sync so lastSyncDate stays nil, then succeed.
+            guard didFailInitialSync else {
+                didFailInitialSync = true
+                return .failure(URLError(.networkConnectionLost))
             }
-            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, foregroundPayload)
+            return .success((.mockResponseWith(statusCode: 200), foregroundPayload))
         }
-        let rc = makeProvider(notificationCenter: notificationCenter)
+        let rc = makeProvider(httpClient: httpClient, notificationCenter: notificationCenter)
 
         // When — foreground fires immediately after a failed init sync
         notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
@@ -574,16 +613,16 @@ class RemoteConfigurationTests: XCTestCase {
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0)
         let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
         let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
-        let requestLock = NSLock()
-        var requestCount = 0
-        MockURLProtocol.requestHandler = { request in
-            requestLock.lock()
-            requestCount += 1
-            let payload = requestCount == 1 ? initialPayload : foregroundPayload
-            requestLock.unlock()
-            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
+        var servedInitial = false
+        let httpClient = HTTPClientMock { _ in
+            // Invoked on the mock's serial queue, so this state needs no lock.
+            guard servedInitial else {
+                servedInitial = true
+                return .success((.mockResponseWith(statusCode: 200), initialPayload))
+            }
+            return .success((.mockResponseWith(statusCode: 200), foregroundPayload))
         }
-        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider)
+        let rc = makeProvider(httpClient: httpClient, notificationCenter: notificationCenter, dateProvider: dateProvider)
         waitForPersistedConfiguration(applicationID: "initial-application-id")
 
         // When — TTL elapses and foreground fires
@@ -600,18 +639,13 @@ class RemoteConfigurationTests: XCTestCase {
         let notificationCenter = NotificationCenter()
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0)
         let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
-        let requestLock = NSLock()
-        var requestCount = 0
-        MockURLProtocol.requestHandler = { request in
-            requestLock.lock()
-            requestCount += 1
-            requestLock.unlock()
-            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, initialPayload)
+        let httpClient = HTTPClientMock { _ in
+            .success((.mockResponseWith(statusCode: 200), initialPayload))
         }
-        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider)
+        let rc = makeProvider(httpClient: httpClient, notificationCenter: notificationCenter, dateProvider: dateProvider)
         waitForPersistedConfiguration(applicationID: "initial-application-id")
 
-        let countAfterInit = requestLock.withLock { requestCount }
+        let countAfterInit = httpClient.requestsSent().count
 
         // When — only 1 minute passes and foreground fires
         dateProvider.advance(bySeconds: 60)
@@ -620,7 +654,7 @@ class RemoteConfigurationTests: XCTestCase {
         // Then — no additional sync fires within TTL
         let noSyncExpectation = expectation(description: "no foreground sync within TTL")
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
-            XCTAssertEqual(requestLock.withLock { requestCount }, countAfterInit, "No sync should fire within TTL")
+            XCTAssertEqual(httpClient.requestsSent().count, countAfterInit, "No sync should fire within TTL")
             noSyncExpectation.fulfill()
         }
         waitForExpectations(timeout: 2)
@@ -636,19 +670,14 @@ class RemoteConfigurationTests: XCTestCase {
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             options: .atomic
         )
-        let requestLock = NSLock()
-        var requestCount = 0
-        MockURLProtocol.requestHandler = { request in
-            requestLock.lock()
-            requestCount += 1
-            requestLock.unlock()
-            return (HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil, headerFields: nil)!, nil)
+        let httpClient = HTTPClientMock { _ in
+            .success((.mockResponseWith(statusCode: 304), nil))
         }
-        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider)
+        let rc = makeProvider(httpClient: httpClient, notificationCenter: notificationCenter, dateProvider: dateProvider)
 
         // Wait for init sync (304)
         let initExpectation = expectation(description: "init sync completes")
-        wait(until: { requestLock.withLock { requestCount } == 1 }, andThenFulfill: initExpectation)
+        wait(until: { httpClient.requestsSent().count == 1 }, andThenFulfill: initExpectation)
         waitForExpectations(timeout: 2)
 
         // When — foreground fires within TTL
@@ -658,7 +687,7 @@ class RemoteConfigurationTests: XCTestCase {
         // Then — no additional request fires
         let noSyncExpectation = expectation(description: "no foreground sync after 304 within TTL")
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
-            XCTAssertEqual(requestLock.withLock { requestCount }, 1, "No sync should fire within TTL after 304")
+            XCTAssertEqual(httpClient.requestsSent().count, 1, "No sync should fire within TTL after 304")
             noSyncExpectation.fulfill()
         }
         waitForExpectations(timeout: 2)

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -9,38 +9,6 @@ import TestUtilities
 import DatadogInternal
 @testable import DatadogCore
 
-// MARK: - MockURLProtocol
-
-private class MockURLProtocol: URLProtocol {
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let handler = MockURLProtocol.requestHandler else {
-            client?.urlProtocolDidFinishLoading(self)
-            return
-        }
-        do {
-            let (response, data) = try handler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            if let data = data { client?.urlProtocol(self, didLoad: data) }
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
-}
-
-private func mockSession() -> URLSession {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
-    return URLSession(configuration: config)
-}
-
 private final class NeverHTTPClient: HTTPClient {
     func send(
         request: URLRequest,
@@ -53,26 +21,21 @@ private final class NeverHTTPClient: HTTPClient {
 
 class RemoteConfigurationTests: XCTestCase {
     private var coreDir: CoreDirectory! // swiftlint:disable:this implicitly_unwrapped_optional
-    private var httpClient: URLSessionClient! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
         super.setUp()
         coreDir = temporaryUniqueCoreDirectory()
         coreDir.create()
-        httpClient = URLSessionClient(session: mockSession())
     }
 
     override func tearDown() {
-        MockURLProtocol.requestHandler = nil
-        httpClient.session.invalidateAndCancel()
-        httpClient = nil
         coreDir.delete()
         super.tearDown()
     }
 
     private func makeProvider(
         id: String = "test-id",
-        httpClient: HTTPClient? = nil,
+        httpClient: HTTPClient = HTTPClientMock(),
         notificationCenter: NotificationCenter = NotificationCenter(),
         dateProvider: DateProvider = SystemDateProvider(),
         start: Bool = true
@@ -81,7 +44,7 @@ class RemoteConfigurationTests: XCTestCase {
             id: id,
             site: .us1,
             directory: coreDir.coreDirectory,
-            httpClient: httpClient ?? self.httpClient,
+            httpClient: httpClient,
             notificationCenter: notificationCenter,
             dateProvider: dateProvider
         )
@@ -185,19 +148,6 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(rc) {}
     }
 
-    func testStartDoesNotCallCompletionWhenNoFileExists() {
-        let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
-        let expectation = expectation(description: "completion is not called when no cache exists")
-        expectation.isInverted = true
-
-        rc.start { _ in
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 0.1)
-
-        withExtendedLifetime(rc) {}
-    }
-
     func testStartReturnsFailureWhenFileCannotBeRead() throws {
         try FileManager.default.createDirectory(
             at: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
@@ -208,7 +158,7 @@ class RemoteConfigurationTests: XCTestCase {
         let expectation = expectation(description: "cache read failure is returned")
 
         rc.start { result in
-            if case .failure(.diskError) = result {
+            if case .failure = result {
                 expectation.fulfill()
             }
         }
@@ -260,10 +210,7 @@ class RemoteConfigurationTests: XCTestCase {
 
     func testInitSyncReturnsSuccessAndPersistsConfiguration() {
         let payload = remoteConfigurationData(applicationID: "fetched-application-id")
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
-        }
-        let rc = makeProvider()
+        let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload))
 
         waitForPersistedConfiguration(applicationID: "fetched-application-id", fileData: payload)
         withExtendedLifetime(rc) {}
@@ -271,10 +218,7 @@ class RemoteConfigurationTests: XCTestCase {
 
     func testInitSyncPersistsConfigurationAcrossInstances() throws {
         let payload = remoteConfigurationData(applicationID: "persisted-application-id")
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
-        }
-        let rc = makeProvider()
+        let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload))
         waitForPersistedConfiguration(applicationID: "persisted-application-id", fileData: payload)
 
         let cachedProvider = makeProvider(httpClient: NeverHTTPClient(), start: false)
@@ -292,14 +236,7 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testInitSyncNetworkErrorReturnsFailureAndLeavesNoPersistedConfiguration() {
-        let error = URLError(.networkConnectionLost)
-        let rc = RemoteConfigurationProvider(
-            id: "test-id",
-            site: .us1,
-            directory: coreDir.coreDirectory,
-            httpClient: HTTPClientMock(error: error),
-            notificationCenter: NotificationCenter()
-        )
+        let rc = makeProvider(httpClient: HTTPClientMock(error: URLError(.networkConnectionLost)), start: false)
 
         let expectation = expectation(description: "sync fails")
         rc.start { result in
@@ -317,13 +254,14 @@ class RemoteConfigurationTests: XCTestCase {
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
-        let requestExpectation = expectation(description: "request completes")
 
-        MockURLProtocol.requestHandler = { request in
-            requestExpectation.fulfill()
-            return (HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!, nil as Data?)
+        let rc = makeProvider(httpClient: HTTPClientMock(responseCode: 500), start: false)
+        let requestExpectation = expectation(description: "request completes")
+        rc.start { result in
+            if case .failure(.httpError) = result {
+                requestExpectation.fulfill()
+            }
         }
-        let rc = makeProvider()
         wait(for: [requestExpectation], timeout: 2)
 
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after non-2xx")
@@ -331,10 +269,7 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testInitSyncEmptyBodyReturnsFailureAndLeavesNoPersistedConfiguration() {
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
-        }
-        let rc = makeProvider(start: false)
+        let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data()), start: false)
 
         let expectation = expectation(description: "sync fails")
         rc.start { result in
@@ -352,14 +287,15 @@ class RemoteConfigurationTests: XCTestCase {
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
-        let requestExpectation = expectation(description: "request completes")
 
         let nonJSON = Data("this is not json".utf8)
-        MockURLProtocol.requestHandler = { request in
-            requestExpectation.fulfill()
-            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, nonJSON)
+        let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: nonJSON), start: false)
+        let requestExpectation = expectation(description: "request completes")
+        rc.start { result in
+            if case .failure(.decodingError) = result {
+                requestExpectation.fulfill()
+            }
         }
-        let rc = makeProvider()
         wait(for: [requestExpectation], timeout: 2)
 
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after decoding error")
@@ -367,21 +303,18 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testInitSyncDiskWriteFailureReturnsFailure() {
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
-        }
         let missingDir = Directory(url: URL(fileURLWithPath: "/no/such/path/"))
         let rc = RemoteConfigurationProvider(
             id: "test-id",
             site: .us1,
             directory: missingDir,
-            httpClient: httpClient,
+            httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8)),
             notificationCenter: NotificationCenter()
         )
 
         let expectation = expectation(description: "sync fails")
         rc.start { result in
-            if case .failure(.diskError) = result {
+            if case .failure = result {
                 expectation.fulfill()
             }
         }
@@ -391,10 +324,13 @@ class RemoteConfigurationTests: XCTestCase {
     // MARK: ETag
 
     func testInitSyncStoresETagAfterSuccessfulFetch() {
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: ["ETag": "abc123"])!, Data("{}".utf8))
-        }
-        let provider = makeProvider()
+        let response = HTTPURLResponse(
+            url: URL(string: "https://sdk-configuration.browser-intake-datadoghq.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["ETag": "abc123"]
+        )!
+        let provider = makeProvider(httpClient: HTTPClientMock(response: response, data: Data("{}".utf8)))
 
         let expectation = expectation(description: "etag is stored")
         let etagFileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.etag")
@@ -408,6 +344,26 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(provider) {}
     }
 
+    func testInitSyncStoresETagEvenWhenBodyCannotBeDecoded() {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://sdk-configuration.browser-intake-datadoghq.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["ETag": "abc123"]
+        )!
+        let rc = makeProvider(httpClient: HTTPClientMock(response: response, data: Data("this is not json".utf8)), start: false)
+        let expectation = expectation(description: "decode fails")
+        rc.start { result in
+            if case .failure(.decodingError) = result { expectation.fulfill() }
+        }
+        waitForExpectations(timeout: 2)
+
+        let etagFileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.etag")
+        XCTAssertEqual(try? String(data: Data(contentsOf: etagFileURL), encoding: .utf8), "abc123",
+            "ETag must be stored even when the body cannot be decoded — prevents re-fetching a known-bad payload")
+        withExtendedLifetime(rc) {}
+    }
+
     func testInitSyncDeletesStaleETagWhenResponseHasNoETag() throws {
         // Given — a stale ETag file from a previous fetch
         try Data("old-etag".utf8).write(
@@ -416,10 +372,7 @@ class RemoteConfigurationTests: XCTestCase {
         )
 
         // When — server returns 200 with new data but no ETag header
-        MockURLProtocol.requestHandler = { request in
-            (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
-        }
-        let provider = makeProvider()
+        let provider = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8)))
 
         // Then — stale ETag file must be deleted so it is never sent as If-None-Match
         let expectation = expectation(description: "stale etag is deleted")
@@ -444,21 +397,16 @@ class RemoteConfigurationTests: XCTestCase {
         )
         // No .json file means a 304 response would leave the caller with no configuration.
 
-        var capturedRequest: URLRequest?
-        MockURLProtocol.requestHandler = { request in
-            capturedRequest = request
-            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
-        }
-
-        let provider = makeProvider()
+        let httpClient = HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8))
+        let provider = makeProvider(httpClient: httpClient)
         let expectation = expectation(description: "request is sent")
         wait(until: {
-            capturedRequest != nil
+            !httpClient.requestsSent().isEmpty
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
         XCTAssertNil(
-            capturedRequest?.value(forHTTPHeaderField: "If-None-Match"),
+            httpClient.requestsSent().first?.value(forHTTPHeaderField: "If-None-Match"),
             "Must not send If-None-Match when persisted configuration is missing — a 304 would leave us with no data"
         )
         withExtendedLifetime(provider) {}
@@ -477,20 +425,15 @@ class RemoteConfigurationTests: XCTestCase {
             options: .atomic
         )
 
-        var capturedRequest: URLRequest?
-        MockURLProtocol.requestHandler = { request in
-            capturedRequest = request
-            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data("{}".utf8))
-        }
-
-        let provider = makeProvider()
+        let httpClient = HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8))
+        let provider = makeProvider(httpClient: httpClient)
         let expectation = expectation(description: "request is sent")
         wait(until: {
-            capturedRequest != nil
+            !httpClient.requestsSent().isEmpty
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
-        XCTAssertEqual(capturedRequest?.value(forHTTPHeaderField: "If-None-Match"), "abc123")
+        XCTAssertEqual(httpClient.requestsSent().first?.value(forHTTPHeaderField: "If-None-Match"), "abc123")
         withExtendedLifetime(provider) {}
     }
 
@@ -500,20 +443,21 @@ class RemoteConfigurationTests: XCTestCase {
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
 
-        let requestExpectation = expectation(description: "CDN request is sent")
-        MockURLProtocol.requestHandler = { request in
-            requestExpectation.fulfill()
-            return (HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil, headerFields: nil)!, nil as Data?)
-        }
+        let httpClient = HTTPClientMock(response: .mockResponseWith(statusCode: 304))
 
         // completion is called once synchronously from cache; NOT again after CDN 304
         let cacheExpectation = expectation(description: "cached config returned once from start")
-        let rc = makeProvider(start: false)
+        let rc = makeProvider(httpClient: httpClient, start: false)
         rc.start { result in
             if case .success(let config) = result, config.rum?.applicationId == "existing-application-id" {
                 cacheExpectation.fulfill()
             }
         }
+
+        let requestExpectation = expectation(description: "CDN request is sent")
+        wait(until: {
+            !httpClient.requestsSent().isEmpty
+        }, andThenFulfill: requestExpectation)
 
         wait(for: [requestExpectation, cacheExpectation], timeout: 2)
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "File must be unchanged after 304")
@@ -545,14 +489,14 @@ class RemoteConfigurationTests: XCTestCase {
         let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
         let requestLock = NSLock()
         var requestCount = 0
-        MockURLProtocol.requestHandler = { request in
+        let httpClient = HTTPClientMock { _ in
             requestLock.lock()
+            defer { requestLock.unlock() }
             requestCount += 1
             let payload = requestCount == 1 ? initialPayload : foregroundPayload
-            requestLock.unlock()
-            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
+            return .success((.mockResponseWith(statusCode: 200), payload))
         }
-        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider)
+        let rc = makeProvider(httpClient: httpClient, notificationCenter: notificationCenter, dateProvider: dateProvider)
         waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
 
         // Advance past TTL so the foreground sync is not suppressed
@@ -570,28 +514,21 @@ class RemoteConfigurationTests: XCTestCase {
         let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
         let requestLock = NSLock()
         var requestCount = 0
-        MockURLProtocol.requestHandler = { request in
+        let httpClient = HTTPClientMock { _ in
             requestLock.lock()
+            defer { requestLock.unlock() }
             requestCount += 1
             let payload = requestCount == 1 ? initialPayload : foregroundPayload
-            requestLock.unlock()
-            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
+            return .success((.mockResponseWith(statusCode: 200), payload))
         }
 
-        let completionLock = NSLock()
-        var completionCount = 0
         let completionExpectation = expectation(description: "completion is called for each sync")
         completionExpectation.expectedFulfillmentCount = 2
-        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider, start: false)
+        let rc = makeProvider(httpClient: httpClient, notificationCenter: notificationCenter, dateProvider: dateProvider, start: false)
         rc.start { result in
             guard case .success = result else {
                 return
             }
-
-            completionLock.lock()
-            completionCount += 1
-            completionLock.unlock()
-
             completionExpectation.fulfill()
         }
         waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
@@ -602,7 +539,6 @@ class RemoteConfigurationTests: XCTestCase {
         waitForPersistedConfiguration(applicationID: "foreground-application-id", fileData: foregroundPayload)
 
         wait(for: [completionExpectation], timeout: 2)
-        XCTAssertEqual(completionLock.withLock { completionCount }, 2)
         withExtendedLifetime(rc) {}
     }
 
@@ -735,16 +671,10 @@ class RemoteConfigurationTests: XCTestCase {
         let payload1 = remoteConfigurationData(applicationID: "application-id-one")
         let payload2 = remoteConfigurationData(applicationID: "application-id-two")
 
-        MockURLProtocol.requestHandler = { _ in
-            (HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload1)
-        }
-        let rc1 = makeProvider(id: "id-one")
+        let rc1 = makeProvider(id: "id-one", httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload1))
         waitForPersistedConfiguration(applicationID: "application-id-one", fileData: payload1, fileName: "id-one.json")
 
-        MockURLProtocol.requestHandler = { _ in
-            (HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload2)
-        }
-        let rc2 = makeProvider(id: "id-two")
+        let rc2 = makeProvider(id: "id-two", httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload2))
         waitForPersistedConfiguration(applicationID: "application-id-two", fileData: payload2, fileName: "id-two.json")
 
         let cachedProvider1 = makeProvider(id: "id-one", httpClient: NeverHTTPClient(), start: false)

--- a/DatadogInternal/Sources/Models/RC/RCDataModels.swift
+++ b/DatadogInternal/Sources/Models/RC/RCDataModels.swift
@@ -8,1070 +8,286 @@
 
 // swiftlint:disable all
 
-/// RUM Browser & Mobile SDKs Remote Configuration properties
+/// iOS RUM SDK Remote Configuration
 public struct RemoteConfiguration: Codable {
-    /// RUM feature Remote Configuration properties
+    public let platform: String = "ios"
+
+    public let profiling: Profiling?
+
     public let rum: RUM?
 
+    public let sessionReplay: SessionReplay?
+
+    public let trace: Trace?
+
     public enum CodingKeys: String, CodingKey {
+        case platform = "platform"
+        case profiling = "profiling"
         case rum = "rum"
+        case sessionReplay = "sessionReplay"
+        case trace = "trace"
     }
 
-    /// RUM Browser & Mobile SDKs Remote Configuration properties
+    /// iOS RUM SDK Remote Configuration
     ///
     /// - Parameters:
-    ///   - rum: RUM feature Remote Configuration properties
+    ///   - profiling:
+    ///   - rum:
+    ///   - sessionReplay:
+    ///   - trace:
     public init(
-        rum: RUM? = nil
+        profiling: Profiling? = nil,
+        rum: RUM? = nil,
+        sessionReplay: SessionReplay? = nil,
+        trace: Trace? = nil
     ) {
+        self.profiling = profiling
         self.rum = rum
+        self.sessionReplay = sessionReplay
+        self.trace = trace
     }
 
-    /// RUM feature Remote Configuration properties
-    public struct RUM: Codable {
-        /// URLs where tracing is allowed
-        public let allowedTracingUrls: [AllowedTracingUrls]?
+    public struct Profiling: Codable {
+        public let applicationLaunchSampleRate: Double?
 
-        /// Origins where tracking is allowed
-        public let allowedTrackingOrigins: [AllowedTrackingOrigins]?
-
-        /// UUID of the application
-        public let applicationId: String
-
-        /// Function to define global context
-        public let context: [Context]?
-
-        /// Session replay default privacy level
-        public let defaultPrivacyLevel: String?
-
-        /// Privacy control for action name
-        public let enablePrivacyForActionName: Bool?
-
-        /// The environment for this application
-        public let env: String?
-
-        /// The service name for this application
-        public let service: String?
-
-        /// The percentage of sessions with RUM & Session Replay pricing tracked
-        public let sessionReplaySampleRate: Double?
-
-        /// The percentage of sessions tracked
-        public let sessionSampleRate: Double?
-
-        /// The percentage of traces sampled
-        public let traceSampleRate: Double?
-
-        /// Whether to track sessions across subdomains
-        public let trackSessionAcrossSubdomains: Bool?
-
-        /// Function to define user information
-        public let user: [User]?
-
-        /// The version for this application
-        public let version: Version?
+        public let continuousSampleRate: Double?
 
         public enum CodingKeys: String, CodingKey {
-            case allowedTracingUrls = "allowedTracingUrls"
-            case allowedTrackingOrigins = "allowedTrackingOrigins"
-            case applicationId = "applicationId"
-            case context = "context"
-            case defaultPrivacyLevel = "defaultPrivacyLevel"
-            case enablePrivacyForActionName = "enablePrivacyForActionName"
-            case env = "env"
-            case service = "service"
-            case sessionReplaySampleRate = "sessionReplaySampleRate"
-            case sessionSampleRate = "sessionSampleRate"
-            case traceSampleRate = "traceSampleRate"
-            case trackSessionAcrossSubdomains = "trackSessionAcrossSubdomains"
-            case user = "user"
-            case version = "version"
+            case applicationLaunchSampleRate = "applicationLaunchSampleRate"
+            case continuousSampleRate = "continuousSampleRate"
         }
 
-        /// RUM feature Remote Configuration properties
         ///
         /// - Parameters:
-        ///   - allowedTracingUrls: URLs where tracing is allowed
-        ///   - allowedTrackingOrigins: Origins where tracking is allowed
-        ///   - applicationId: UUID of the application
-        ///   - context: Function to define global context
-        ///   - defaultPrivacyLevel: Session replay default privacy level
-        ///   - enablePrivacyForActionName: Privacy control for action name
-        ///   - env: The environment for this application
-        ///   - service: The service name for this application
-        ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
-        ///   - sessionSampleRate: The percentage of sessions tracked
-        ///   - traceSampleRate: The percentage of traces sampled
-        ///   - trackSessionAcrossSubdomains: Whether to track sessions across subdomains
-        ///   - user: Function to define user information
-        ///   - version: The version for this application
+        ///   - applicationLaunchSampleRate:
+        ///   - continuousSampleRate:
         public init(
-            allowedTracingUrls: [AllowedTracingUrls]? = nil,
-            allowedTrackingOrigins: [AllowedTrackingOrigins]? = nil,
-            applicationId: String,
-            context: [Context]? = nil,
-            defaultPrivacyLevel: String? = nil,
-            enablePrivacyForActionName: Bool? = nil,
-            env: String? = nil,
-            service: String? = nil,
-            sessionReplaySampleRate: Double? = nil,
-            sessionSampleRate: Double? = nil,
-            traceSampleRate: Double? = nil,
-            trackSessionAcrossSubdomains: Bool? = nil,
-            user: [User]? = nil,
-            version: Version? = nil
+            applicationLaunchSampleRate: Double? = nil,
+            continuousSampleRate: Double? = nil
         ) {
-            self.allowedTracingUrls = allowedTracingUrls
-            self.allowedTrackingOrigins = allowedTrackingOrigins
+            self.applicationLaunchSampleRate = applicationLaunchSampleRate
+            self.continuousSampleRate = continuousSampleRate
+        }
+    }
+
+    public struct RUM: Codable {
+        /// Minimum main-thread freeze duration to report as an app hang. Omit to disable.
+        public let appHangThresholdMs: Double?
+
+        /// UUID of the RUM application
+        public let applicationId: String
+
+        public let env: String?
+
+        /// Minimum main-thread task duration to report as a long task
+        public let longTaskThresholdMs: Double?
+
+        public let service: String?
+
+        public let telemetrySampleRate: Double?
+
+        public let trackAnonymousUser: Bool?
+
+        public let trackBackgroundEvents: Bool?
+
+        public let trackFrustrations: Bool?
+
+        public let trackMemoryWarnings: Bool?
+
+        public let trackResources: Bool?
+
+        public let trackSlowFrames: Bool?
+
+        public let trackUserInteractions: Bool?
+
+        public let trackWatchdogTerminations: Bool?
+
+        public let vitalsUpdateFrequency: VitalsUpdateFrequency?
+
+        public enum CodingKeys: String, CodingKey {
+            case appHangThresholdMs = "appHangThresholdMs"
+            case applicationId = "applicationId"
+            case env = "env"
+            case longTaskThresholdMs = "longTaskThresholdMs"
+            case service = "service"
+            case telemetrySampleRate = "telemetrySampleRate"
+            case trackAnonymousUser = "trackAnonymousUser"
+            case trackBackgroundEvents = "trackBackgroundEvents"
+            case trackFrustrations = "trackFrustrations"
+            case trackMemoryWarnings = "trackMemoryWarnings"
+            case trackResources = "trackResources"
+            case trackSlowFrames = "trackSlowFrames"
+            case trackUserInteractions = "trackUserInteractions"
+            case trackWatchdogTerminations = "trackWatchdogTerminations"
+            case vitalsUpdateFrequency = "vitalsUpdateFrequency"
+        }
+
+        ///
+        /// - Parameters:
+        ///   - appHangThresholdMs: Minimum main-thread freeze duration to report as an app hang. Omit to disable.
+        ///   - applicationId: UUID of the RUM application
+        ///   - env:
+        ///   - longTaskThresholdMs: Minimum main-thread task duration to report as a long task
+        ///   - service:
+        ///   - telemetrySampleRate:
+        ///   - trackAnonymousUser:
+        ///   - trackBackgroundEvents:
+        ///   - trackFrustrations:
+        ///   - trackMemoryWarnings:
+        ///   - trackResources:
+        ///   - trackSlowFrames:
+        ///   - trackUserInteractions:
+        ///   - trackWatchdogTerminations:
+        ///   - vitalsUpdateFrequency:
+        public init(
+            appHangThresholdMs: Double? = nil,
+            applicationId: String,
+            env: String? = nil,
+            longTaskThresholdMs: Double? = nil,
+            service: String? = nil,
+            telemetrySampleRate: Double? = nil,
+            trackAnonymousUser: Bool? = nil,
+            trackBackgroundEvents: Bool? = nil,
+            trackFrustrations: Bool? = nil,
+            trackMemoryWarnings: Bool? = nil,
+            trackResources: Bool? = nil,
+            trackSlowFrames: Bool? = nil,
+            trackUserInteractions: Bool? = nil,
+            trackWatchdogTerminations: Bool? = nil,
+            vitalsUpdateFrequency: VitalsUpdateFrequency? = nil
+        ) {
+            self.appHangThresholdMs = appHangThresholdMs
             self.applicationId = applicationId
-            self.context = context
-            self.defaultPrivacyLevel = defaultPrivacyLevel
-            self.enablePrivacyForActionName = enablePrivacyForActionName
             self.env = env
+            self.longTaskThresholdMs = longTaskThresholdMs
             self.service = service
-            self.sessionReplaySampleRate = sessionReplaySampleRate
-            self.sessionSampleRate = sessionSampleRate
-            self.traceSampleRate = traceSampleRate
-            self.trackSessionAcrossSubdomains = trackSessionAcrossSubdomains
-            self.user = user
-            self.version = version
+            self.telemetrySampleRate = telemetrySampleRate
+            self.trackAnonymousUser = trackAnonymousUser
+            self.trackBackgroundEvents = trackBackgroundEvents
+            self.trackFrustrations = trackFrustrations
+            self.trackMemoryWarnings = trackMemoryWarnings
+            self.trackResources = trackResources
+            self.trackSlowFrames = trackSlowFrames
+            self.trackUserInteractions = trackUserInteractions
+            self.trackWatchdogTerminations = trackWatchdogTerminations
+            self.vitalsUpdateFrequency = vitalsUpdateFrequency
         }
 
-        public struct AllowedTracingUrls: Codable {
-            public let match: Match
+        public enum VitalsUpdateFrequency: String, Codable {
+            case frequent = "frequent"
+            case average = "average"
+            case rare = "rare"
+            case never = "never"
+        }
+    }
 
-            /// List of propagator types
-            public let propagatorTypes: [PropagatorTypes]?
+    public struct SessionReplay: Codable {
+        public let imagePrivacy: ImagePrivacy?
 
-            public enum CodingKeys: String, CodingKey {
-                case match = "match"
-                case propagatorTypes = "propagatorTypes"
-            }
+        public let sampleRate: Double?
 
-            ///
-            /// - Parameters:
-            ///   - match:
-            ///   - propagatorTypes: List of propagator types
-            public init(
-                match: Match,
-                propagatorTypes: [PropagatorTypes]? = nil
-            ) {
-                self.match = match
-                self.propagatorTypes = propagatorTypes
-            }
+        /// Whether Session Replay starts recording as soon as the SDK initializes
+        public let startRecordingImmediately: Bool?
 
-            public struct Match: Codable {
-                /// Remote config serialized type of match
-                public let rcSerializedType: RcSerializedType
+        public let textAndInputPrivacy: TextAndInputPrivacy?
 
-                /// Match value
-                public let value: String
+        public let touchPrivacy: TouchPrivacy?
 
-                public enum CodingKeys: String, CodingKey {
-                    case rcSerializedType = "rcSerializedType"
-                    case value = "value"
-                }
-
-                ///
-                /// - Parameters:
-                ///   - rcSerializedType: Remote config serialized type of match
-                ///   - value: Match value
-                public init(
-                    rcSerializedType: RcSerializedType,
-                    value: String
-                ) {
-                    self.rcSerializedType = rcSerializedType
-                    self.value = value
-                }
-
-                /// Remote config serialized type of match
-                public enum RcSerializedType: String, Codable {
-                    case string = "string"
-                    case regex = "regex"
-                }
-            }
-
-            public enum PropagatorTypes: String, Codable {
-                case datadog = "datadog"
-                case b3 = "b3"
-                case b3multi = "b3multi"
-                case tracecontext = "tracecontext"
-            }
+        public enum CodingKeys: String, CodingKey {
+            case imagePrivacy = "imagePrivacy"
+            case sampleRate = "sampleRate"
+            case startRecordingImmediately = "startRecordingImmediately"
+            case textAndInputPrivacy = "textAndInputPrivacy"
+            case touchPrivacy = "touchPrivacy"
         }
 
-        public struct AllowedTrackingOrigins: Codable {
-            /// Remote config serialized type of match
-            public let rcSerializedType: RcSerializedType
-
-            /// Match value
-            public let value: String
-
-            public enum CodingKeys: String, CodingKey {
-                case rcSerializedType = "rcSerializedType"
-                case value = "value"
-            }
-
-            ///
-            /// - Parameters:
-            ///   - rcSerializedType: Remote config serialized type of match
-            ///   - value: Match value
-            public init(
-                rcSerializedType: RcSerializedType,
-                value: String
-            ) {
-                self.rcSerializedType = rcSerializedType
-                self.value = value
-            }
-
-            /// Remote config serialized type of match
-            public enum RcSerializedType: String, Codable {
-                case string = "string"
-                case regex = "regex"
-            }
+        ///
+        /// - Parameters:
+        ///   - imagePrivacy:
+        ///   - sampleRate:
+        ///   - startRecordingImmediately: Whether Session Replay starts recording as soon as the SDK initializes
+        ///   - textAndInputPrivacy:
+        ///   - touchPrivacy:
+        public init(
+            imagePrivacy: ImagePrivacy? = nil,
+            sampleRate: Double? = nil,
+            startRecordingImmediately: Bool? = nil,
+            textAndInputPrivacy: TextAndInputPrivacy? = nil,
+            touchPrivacy: TouchPrivacy? = nil
+        ) {
+            self.imagePrivacy = imagePrivacy
+            self.sampleRate = sampleRate
+            self.startRecordingImmediately = startRecordingImmediately
+            self.textAndInputPrivacy = textAndInputPrivacy
+            self.touchPrivacy = touchPrivacy
         }
 
-        public struct Context: Codable {
-            public let key: String
-
-            public let value: Value
-
-            public enum CodingKeys: String, CodingKey {
-                case key = "key"
-                case value = "value"
-            }
-
-            ///
-            /// - Parameters:
-            ///   - key:
-            ///   - value:
-            public init(
-                key: String,
-                value: Value
-            ) {
-                self.key = key
-                self.value = value
-            }
-
-            public enum Value: Codable {
-                case js(value: Js)
-                case cookie(value: Cookie)
-                case dom(value: Dom)
-                case localStorage(value: LocalStorage)
-
-                // MARK: - Codable
-
-                public func encode(to encoder: Encoder) throws {
-                    // Encode only the associated value, without encoding enum case
-                    var container = encoder.singleValueContainer()
-
-                    switch self {
-                    case .js(let value):
-                        try container.encode(value)
-                    case .cookie(let value):
-                        try container.encode(value)
-                    case .dom(let value):
-                        try container.encode(value)
-                    case .localStorage(let value):
-                        try container.encode(value)
-                    }
-                }
-
-                public init(from decoder: Decoder) throws {
-                    // Decode enum case from associated value
-                    let container = try decoder.singleValueContainer()
-
-                    if let value = try? container.decode(Js.self) {
-                        self = .js(value: value)
-                        return
-                    }
-                    if let value = try? container.decode(Cookie.self) {
-                        self = .cookie(value: value)
-                        return
-                    }
-                    if let value = try? container.decode(Dom.self) {
-                        self = .dom(value: value)
-                        return
-                    }
-                    if let value = try? container.decode(LocalStorage.self) {
-                        self = .localStorage(value: value)
-                        return
-                    }
-                    let error = DecodingError.Context(
-                        codingPath: container.codingPath,
-                        debugDescription: """
-                        Failed to decode `Value`.
-                        Ran out of possibilities when trying to decode the value of associated type.
-                        """
-                    )
-                    throw DecodingError.typeMismatch(Value.self, error)
-                }
-
-                public struct Js: Codable {
-                    public let extractor: Extractor?
-
-                    public let path: String
-
-                    public let rcSerializedType: String = "dynamic"
-
-                    public let strategy: String = "js"
-
-                    public enum CodingKeys: String, CodingKey {
-                        case extractor = "extractor"
-                        case path = "path"
-                        case rcSerializedType = "rcSerializedType"
-                        case strategy = "strategy"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - extractor:
-                    ///   - path:
-                    public init(
-                        extractor: Extractor? = nil,
-                        path: String
-                    ) {
-                        self.extractor = extractor
-                        self.path = path
-                    }
-
-                    public struct Extractor: Codable {
-                        /// Remote config serialized type for regex extraction
-                        public let rcSerializedType: String = "regex"
-
-                        /// Regex pattern for value extraction
-                        public let value: String
-
-                        public enum CodingKeys: String, CodingKey {
-                            case rcSerializedType = "rcSerializedType"
-                            case value = "value"
-                        }
-
-                        ///
-                        /// - Parameters:
-                        ///   - value: Regex pattern for value extraction
-                        public init(
-                            value: String
-                        ) {
-                            self.value = value
-                        }
-                    }
-                }
-
-                public struct Cookie: Codable {
-                    public let extractor: Extractor?
-
-                    public let name: String
-
-                    public let rcSerializedType: String = "dynamic"
-
-                    public let strategy: String = "cookie"
-
-                    public enum CodingKeys: String, CodingKey {
-                        case extractor = "extractor"
-                        case name = "name"
-                        case rcSerializedType = "rcSerializedType"
-                        case strategy = "strategy"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - extractor:
-                    ///   - name:
-                    public init(
-                        extractor: Extractor? = nil,
-                        name: String
-                    ) {
-                        self.extractor = extractor
-                        self.name = name
-                    }
-
-                    public struct Extractor: Codable {
-                        /// Remote config serialized type for regex extraction
-                        public let rcSerializedType: String = "regex"
-
-                        /// Regex pattern for value extraction
-                        public let value: String
-
-                        public enum CodingKeys: String, CodingKey {
-                            case rcSerializedType = "rcSerializedType"
-                            case value = "value"
-                        }
-
-                        ///
-                        /// - Parameters:
-                        ///   - value: Regex pattern for value extraction
-                        public init(
-                            value: String
-                        ) {
-                            self.value = value
-                        }
-                    }
-                }
-
-                public struct Dom: Codable {
-                    public let attribute: String?
-
-                    public let extractor: Extractor?
-
-                    public let rcSerializedType: String = "dynamic"
-
-                    public let selector: String
-
-                    public let strategy: String = "dom"
-
-                    public enum CodingKeys: String, CodingKey {
-                        case attribute = "attribute"
-                        case extractor = "extractor"
-                        case rcSerializedType = "rcSerializedType"
-                        case selector = "selector"
-                        case strategy = "strategy"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - attribute:
-                    ///   - extractor:
-                    ///   - selector:
-                    public init(
-                        attribute: String? = nil,
-                        extractor: Extractor? = nil,
-                        selector: String
-                    ) {
-                        self.attribute = attribute
-                        self.extractor = extractor
-                        self.selector = selector
-                    }
-
-                    public struct Extractor: Codable {
-                        /// Remote config serialized type for regex extraction
-                        public let rcSerializedType: String = "regex"
-
-                        /// Regex pattern for value extraction
-                        public let value: String
-
-                        public enum CodingKeys: String, CodingKey {
-                            case rcSerializedType = "rcSerializedType"
-                            case value = "value"
-                        }
-
-                        ///
-                        /// - Parameters:
-                        ///   - value: Regex pattern for value extraction
-                        public init(
-                            value: String
-                        ) {
-                            self.value = value
-                        }
-                    }
-                }
-
-                public struct LocalStorage: Codable {
-                    public let extractor: Extractor?
-
-                    public let key: String
-
-                    public let rcSerializedType: String = "dynamic"
-
-                    public let strategy: String = "localStorage"
-
-                    public enum CodingKeys: String, CodingKey {
-                        case extractor = "extractor"
-                        case key = "key"
-                        case rcSerializedType = "rcSerializedType"
-                        case strategy = "strategy"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - extractor:
-                    ///   - key:
-                    public init(
-                        extractor: Extractor? = nil,
-                        key: String
-                    ) {
-                        self.extractor = extractor
-                        self.key = key
-                    }
-
-                    public struct Extractor: Codable {
-                        /// Remote config serialized type for regex extraction
-                        public let rcSerializedType: String = "regex"
-
-                        /// Regex pattern for value extraction
-                        public let value: String
-
-                        public enum CodingKeys: String, CodingKey {
-                            case rcSerializedType = "rcSerializedType"
-                            case value = "value"
-                        }
-
-                        ///
-                        /// - Parameters:
-                        ///   - value: Regex pattern for value extraction
-                        public init(
-                            value: String
-                        ) {
-                            self.value = value
-                        }
-                    }
-                }
-            }
+        public enum ImagePrivacy: String, Codable {
+            case maskNone = "mask_none"
+            case maskNonBundledOnly = "mask_non_bundled_only"
+            case maskAll = "mask_all"
         }
 
-        public struct User: Codable {
-            public let key: String
-
-            public let value: Value
-
-            public enum CodingKeys: String, CodingKey {
-                case key = "key"
-                case value = "value"
-            }
-
-            ///
-            /// - Parameters:
-            ///   - key:
-            ///   - value:
-            public init(
-                key: String,
-                value: Value
-            ) {
-                self.key = key
-                self.value = value
-            }
-
-            public enum Value: Codable {
-                case js(value: Js)
-                case cookie(value: Cookie)
-                case dom(value: Dom)
-                case localStorage(value: LocalStorage)
-
-                // MARK: - Codable
-
-                public func encode(to encoder: Encoder) throws {
-                    // Encode only the associated value, without encoding enum case
-                    var container = encoder.singleValueContainer()
-
-                    switch self {
-                    case .js(let value):
-                        try container.encode(value)
-                    case .cookie(let value):
-                        try container.encode(value)
-                    case .dom(let value):
-                        try container.encode(value)
-                    case .localStorage(let value):
-                        try container.encode(value)
-                    }
-                }
-
-                public init(from decoder: Decoder) throws {
-                    // Decode enum case from associated value
-                    let container = try decoder.singleValueContainer()
-
-                    if let value = try? container.decode(Js.self) {
-                        self = .js(value: value)
-                        return
-                    }
-                    if let value = try? container.decode(Cookie.self) {
-                        self = .cookie(value: value)
-                        return
-                    }
-                    if let value = try? container.decode(Dom.self) {
-                        self = .dom(value: value)
-                        return
-                    }
-                    if let value = try? container.decode(LocalStorage.self) {
-                        self = .localStorage(value: value)
-                        return
-                    }
-                    let error = DecodingError.Context(
-                        codingPath: container.codingPath,
-                        debugDescription: """
-                        Failed to decode `Value`.
-                        Ran out of possibilities when trying to decode the value of associated type.
-                        """
-                    )
-                    throw DecodingError.typeMismatch(Value.self, error)
-                }
-
-                public struct Js: Codable {
-                    public let extractor: Extractor?
-
-                    public let path: String
-
-                    public let rcSerializedType: String = "dynamic"
-
-                    public let strategy: String = "js"
-
-                    public enum CodingKeys: String, CodingKey {
-                        case extractor = "extractor"
-                        case path = "path"
-                        case rcSerializedType = "rcSerializedType"
-                        case strategy = "strategy"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - extractor:
-                    ///   - path:
-                    public init(
-                        extractor: Extractor? = nil,
-                        path: String
-                    ) {
-                        self.extractor = extractor
-                        self.path = path
-                    }
-
-                    public struct Extractor: Codable {
-                        /// Remote config serialized type for regex extraction
-                        public let rcSerializedType: String = "regex"
-
-                        /// Regex pattern for value extraction
-                        public let value: String
-
-                        public enum CodingKeys: String, CodingKey {
-                            case rcSerializedType = "rcSerializedType"
-                            case value = "value"
-                        }
-
-                        ///
-                        /// - Parameters:
-                        ///   - value: Regex pattern for value extraction
-                        public init(
-                            value: String
-                        ) {
-                            self.value = value
-                        }
-                    }
-                }
-
-                public struct Cookie: Codable {
-                    public let extractor: Extractor?
-
-                    public let name: String
-
-                    public let rcSerializedType: String = "dynamic"
-
-                    public let strategy: String = "cookie"
-
-                    public enum CodingKeys: String, CodingKey {
-                        case extractor = "extractor"
-                        case name = "name"
-                        case rcSerializedType = "rcSerializedType"
-                        case strategy = "strategy"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - extractor:
-                    ///   - name:
-                    public init(
-                        extractor: Extractor? = nil,
-                        name: String
-                    ) {
-                        self.extractor = extractor
-                        self.name = name
-                    }
-
-                    public struct Extractor: Codable {
-                        /// Remote config serialized type for regex extraction
-                        public let rcSerializedType: String = "regex"
-
-                        /// Regex pattern for value extraction
-                        public let value: String
-
-                        public enum CodingKeys: String, CodingKey {
-                            case rcSerializedType = "rcSerializedType"
-                            case value = "value"
-                        }
-
-                        ///
-                        /// - Parameters:
-                        ///   - value: Regex pattern for value extraction
-                        public init(
-                            value: String
-                        ) {
-                            self.value = value
-                        }
-                    }
-                }
-
-                public struct Dom: Codable {
-                    public let attribute: String?
-
-                    public let extractor: Extractor?
-
-                    public let rcSerializedType: String = "dynamic"
-
-                    public let selector: String
-
-                    public let strategy: String = "dom"
-
-                    public enum CodingKeys: String, CodingKey {
-                        case attribute = "attribute"
-                        case extractor = "extractor"
-                        case rcSerializedType = "rcSerializedType"
-                        case selector = "selector"
-                        case strategy = "strategy"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - attribute:
-                    ///   - extractor:
-                    ///   - selector:
-                    public init(
-                        attribute: String? = nil,
-                        extractor: Extractor? = nil,
-                        selector: String
-                    ) {
-                        self.attribute = attribute
-                        self.extractor = extractor
-                        self.selector = selector
-                    }
-
-                    public struct Extractor: Codable {
-                        /// Remote config serialized type for regex extraction
-                        public let rcSerializedType: String = "regex"
-
-                        /// Regex pattern for value extraction
-                        public let value: String
-
-                        public enum CodingKeys: String, CodingKey {
-                            case rcSerializedType = "rcSerializedType"
-                            case value = "value"
-                        }
-
-                        ///
-                        /// - Parameters:
-                        ///   - value: Regex pattern for value extraction
-                        public init(
-                            value: String
-                        ) {
-                            self.value = value
-                        }
-                    }
-                }
-
-                public struct LocalStorage: Codable {
-                    public let extractor: Extractor?
-
-                    public let key: String
-
-                    public let rcSerializedType: String = "dynamic"
-
-                    public let strategy: String = "localStorage"
-
-                    public enum CodingKeys: String, CodingKey {
-                        case extractor = "extractor"
-                        case key = "key"
-                        case rcSerializedType = "rcSerializedType"
-                        case strategy = "strategy"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - extractor:
-                    ///   - key:
-                    public init(
-                        extractor: Extractor? = nil,
-                        key: String
-                    ) {
-                        self.extractor = extractor
-                        self.key = key
-                    }
-
-                    public struct Extractor: Codable {
-                        /// Remote config serialized type for regex extraction
-                        public let rcSerializedType: String = "regex"
-
-                        /// Regex pattern for value extraction
-                        public let value: String
-
-                        public enum CodingKeys: String, CodingKey {
-                            case rcSerializedType = "rcSerializedType"
-                            case value = "value"
-                        }
-
-                        ///
-                        /// - Parameters:
-                        ///   - value: Regex pattern for value extraction
-                        public init(
-                            value: String
-                        ) {
-                            self.value = value
-                        }
-                    }
-                }
-            }
+        public enum TextAndInputPrivacy: String, Codable {
+            case maskSensitiveInputs = "mask_sensitive_inputs"
+            case maskAllInputs = "mask_all_inputs"
+            case maskAll = "mask_all"
         }
 
-        /// The version for this application
-        public enum Version: Codable {
-            case js(value: Js)
-            case cookie(value: Cookie)
-            case dom(value: Dom)
-            case localStorage(value: LocalStorage)
+        public enum TouchPrivacy: String, Codable {
+            case show = "show"
+            case hide = "hide"
+        }
+    }
 
-            // MARK: - Codable
+    public struct Trace: Codable {
+        public let sampleRate: Double?
 
-            public func encode(to encoder: Encoder) throws {
-                // Encode only the associated value, without encoding enum case
-                var container = encoder.singleValueContainer()
+        public let traceContextInjection: TraceContextInjection?
 
-                switch self {
-                case .js(let value):
-                    try container.encode(value)
-                case .cookie(let value):
-                    try container.encode(value)
-                case .dom(let value):
-                    try container.encode(value)
-                case .localStorage(let value):
-                    try container.encode(value)
-                }
-            }
+        /// Hostnames for which distributed tracing headers are injected
+        public let tracedHosts: [String]?
 
-            public init(from decoder: Decoder) throws {
-                // Decode enum case from associated value
-                let container = try decoder.singleValueContainer()
+        /// Tracing header formats injected on requests to all traced hosts
+        public let tracingHeaderTypes: [TracingHeaderTypes]?
 
-                if let value = try? container.decode(Js.self) {
-                    self = .js(value: value)
-                    return
-                }
-                if let value = try? container.decode(Cookie.self) {
-                    self = .cookie(value: value)
-                    return
-                }
-                if let value = try? container.decode(Dom.self) {
-                    self = .dom(value: value)
-                    return
-                }
-                if let value = try? container.decode(LocalStorage.self) {
-                    self = .localStorage(value: value)
-                    return
-                }
-                let error = DecodingError.Context(
-                    codingPath: container.codingPath,
-                    debugDescription: """
-                    Failed to decode `Version`.
-                    Ran out of possibilities when trying to decode the value of associated type.
-                    """
-                )
-                throw DecodingError.typeMismatch(Version.self, error)
-            }
+        public enum CodingKeys: String, CodingKey {
+            case sampleRate = "sampleRate"
+            case traceContextInjection = "traceContextInjection"
+            case tracedHosts = "tracedHosts"
+            case tracingHeaderTypes = "tracingHeaderTypes"
+        }
 
-            public struct Js: Codable {
-                public let extractor: Extractor?
+        ///
+        /// - Parameters:
+        ///   - sampleRate:
+        ///   - traceContextInjection:
+        ///   - tracedHosts: Hostnames for which distributed tracing headers are injected
+        ///   - tracingHeaderTypes: Tracing header formats injected on requests to all traced hosts
+        public init(
+            sampleRate: Double? = nil,
+            traceContextInjection: TraceContextInjection? = nil,
+            tracedHosts: [String]? = nil,
+            tracingHeaderTypes: [TracingHeaderTypes]? = nil
+        ) {
+            self.sampleRate = sampleRate
+            self.traceContextInjection = traceContextInjection
+            self.tracedHosts = tracedHosts
+            self.tracingHeaderTypes = tracingHeaderTypes
+        }
 
-                public let path: String
+        public enum TraceContextInjection: String, Codable {
+            case all = "all"
+            case sampled = "sampled"
+        }
 
-                public let rcSerializedType: String = "dynamic"
-
-                public let strategy: String = "js"
-
-                public enum CodingKeys: String, CodingKey {
-                    case extractor = "extractor"
-                    case path = "path"
-                    case rcSerializedType = "rcSerializedType"
-                    case strategy = "strategy"
-                }
-
-                ///
-                /// - Parameters:
-                ///   - extractor:
-                ///   - path:
-                public init(
-                    extractor: Extractor? = nil,
-                    path: String
-                ) {
-                    self.extractor = extractor
-                    self.path = path
-                }
-
-                public struct Extractor: Codable {
-                    /// Remote config serialized type for regex extraction
-                    public let rcSerializedType: String = "regex"
-
-                    /// Regex pattern for value extraction
-                    public let value: String
-
-                    public enum CodingKeys: String, CodingKey {
-                        case rcSerializedType = "rcSerializedType"
-                        case value = "value"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - value: Regex pattern for value extraction
-                    public init(
-                        value: String
-                    ) {
-                        self.value = value
-                    }
-                }
-            }
-
-            public struct Cookie: Codable {
-                public let extractor: Extractor?
-
-                public let name: String
-
-                public let rcSerializedType: String = "dynamic"
-
-                public let strategy: String = "cookie"
-
-                public enum CodingKeys: String, CodingKey {
-                    case extractor = "extractor"
-                    case name = "name"
-                    case rcSerializedType = "rcSerializedType"
-                    case strategy = "strategy"
-                }
-
-                ///
-                /// - Parameters:
-                ///   - extractor:
-                ///   - name:
-                public init(
-                    extractor: Extractor? = nil,
-                    name: String
-                ) {
-                    self.extractor = extractor
-                    self.name = name
-                }
-
-                public struct Extractor: Codable {
-                    /// Remote config serialized type for regex extraction
-                    public let rcSerializedType: String = "regex"
-
-                    /// Regex pattern for value extraction
-                    public let value: String
-
-                    public enum CodingKeys: String, CodingKey {
-                        case rcSerializedType = "rcSerializedType"
-                        case value = "value"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - value: Regex pattern for value extraction
-                    public init(
-                        value: String
-                    ) {
-                        self.value = value
-                    }
-                }
-            }
-
-            public struct Dom: Codable {
-                public let attribute: String?
-
-                public let extractor: Extractor?
-
-                public let rcSerializedType: String = "dynamic"
-
-                public let selector: String
-
-                public let strategy: String = "dom"
-
-                public enum CodingKeys: String, CodingKey {
-                    case attribute = "attribute"
-                    case extractor = "extractor"
-                    case rcSerializedType = "rcSerializedType"
-                    case selector = "selector"
-                    case strategy = "strategy"
-                }
-
-                ///
-                /// - Parameters:
-                ///   - attribute:
-                ///   - extractor:
-                ///   - selector:
-                public init(
-                    attribute: String? = nil,
-                    extractor: Extractor? = nil,
-                    selector: String
-                ) {
-                    self.attribute = attribute
-                    self.extractor = extractor
-                    self.selector = selector
-                }
-
-                public struct Extractor: Codable {
-                    /// Remote config serialized type for regex extraction
-                    public let rcSerializedType: String = "regex"
-
-                    /// Regex pattern for value extraction
-                    public let value: String
-
-                    public enum CodingKeys: String, CodingKey {
-                        case rcSerializedType = "rcSerializedType"
-                        case value = "value"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - value: Regex pattern for value extraction
-                    public init(
-                        value: String
-                    ) {
-                        self.value = value
-                    }
-                }
-            }
-
-            public struct LocalStorage: Codable {
-                public let extractor: Extractor?
-
-                public let key: String
-
-                public let rcSerializedType: String = "dynamic"
-
-                public let strategy: String = "localStorage"
-
-                public enum CodingKeys: String, CodingKey {
-                    case extractor = "extractor"
-                    case key = "key"
-                    case rcSerializedType = "rcSerializedType"
-                    case strategy = "strategy"
-                }
-
-                ///
-                /// - Parameters:
-                ///   - extractor:
-                ///   - key:
-                public init(
-                    extractor: Extractor? = nil,
-                    key: String
-                ) {
-                    self.extractor = extractor
-                    self.key = key
-                }
-
-                public struct Extractor: Codable {
-                    /// Remote config serialized type for regex extraction
-                    public let rcSerializedType: String = "regex"
-
-                    /// Regex pattern for value extraction
-                    public let value: String
-
-                    public enum CodingKeys: String, CodingKey {
-                        case rcSerializedType = "rcSerializedType"
-                        case value = "value"
-                    }
-
-                    ///
-                    /// - Parameters:
-                    ///   - value: Regex pattern for value extraction
-                    public init(
-                        value: String
-                    ) {
-                        self.value = value
-                    }
-                }
-            }
+        public enum TracingHeaderTypes: String, Codable {
+            case datadog = "datadog"
+            case b3 = "b3"
+            case b3multi = "b3multi"
+            case tracecontext = "tracecontext"
         }
     }
 }
 
-// Generated from https://github.com/DataDog/dd-go/blob/0e826636c2da5ed0223e01e537c3f4b96d6e347f/remote-config/apps/rc-schema-validation/schemas/rum-sdk-config.json
+// Generated from https://github.com/DataDog/dd-go/blob/2fc3a72fc0222d5275db1c478dbfee942dd0f816/remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/STAGING/ios.json

--- a/tools/rum-models-generator/Sources/CodeDecoration/RCCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/RCCodeDecorator.swift
@@ -33,7 +33,7 @@ public class RCCodeDecorator: SwiftCodeDecorator {
         }
 
         // Rename the root schema type to a product-neutral name.
-        if fixedName == "RUMSdkConfig" {
+        if fixedName.hasPrefix("RUMSdkConfig") {
             fixedName = "RemoteConfiguration"
         }
 

--- a/tools/rum-models-generator/Sources/CodeGeneration/Generate/JSONSchema.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Generate/JSONSchema.swift
@@ -25,6 +25,7 @@ internal class JSONSchema: Decodable {
         case readOnly = "readOnly"
         case ref = "$ref"
         case defs = "$defs"
+        case definitions = "definitions"
         case oneOf = "oneOf"
         case anyOf = "anyOf"
         case allOf = "allOf"
@@ -90,6 +91,7 @@ internal class JSONSchema: Decodable {
         self.readOnly = try container.decodeIfPresent(Bool.self, forKey: .readOnly)
         self.ref = try container.decodeIfPresent(String.self, forKey: .ref)
         self.defs = try container.decodeIfPresent([String: JSONSchema].self, forKey: .defs)
+        self.definitions = try container.decodeIfPresent([String: JSONSchema].self, forKey: .definitions)
         self.allOf = try container.decodeIfPresent([JSONSchema].self, forKey: .allOf)
         self.oneOf = try container.decodeIfPresent([JSONSchema].self, forKey: .oneOf)
         self.anyOf = try container.decodeIfPresent([JSONSchema].self, forKey: .anyOf)
@@ -169,6 +171,9 @@ internal class JSONSchema: Decodable {
     /// https://json-schema.org/draft/2019-09/json-schema-core.html#defs
     private(set) var defs: [String: JSONSchema]?
 
+    /// In-document schema definitions (draft-07 `definitions` keyword, equivalent to `$defs`).
+    private(set) var definitions: [String: JSONSchema]?
+
     /// Subschemas to be resolved.
     /// https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.2.1.1
     private(set) var allOf: [JSONSchema]?
@@ -191,6 +196,8 @@ internal class JSONSchema: Decodable {
         switch key {
         case "$defs":
             return path.dropFirst().first.flatMap { schema.defs?[$0] }.flatMap { navigate(path.dropFirst(2), in: $0) }
+        case "definitions":
+            return path.dropFirst().first.flatMap { schema.definitions?[$0] }.flatMap { navigate(path.dropFirst(2), in: $0) }
         case "properties":
             return path.dropFirst().first.flatMap { schema.properties?[$0] }.flatMap { navigate(path.dropFirst(2), in: $0) }
         case "items":
@@ -247,16 +254,25 @@ internal class JSONSchema: Decodable {
         }
 
         // resolve `$ref`
+        // Refs follow the JSON Reference format: `[file]#[/json/pointer]`
+        // Both parts are optional: `#/foo` (in-document), `other.json` (whole file), `other.json#/foo` (cross-file).
         try ref.map { ref in
-            if ref.hasPrefix("#") {
-                // In-document reference using JSON Pointer (e.g. `#/$defs/TypeName`, `#/properties/foo`, `#`)
-                let parts = ref.dropFirst().split(separator: "/").map(String.init)
-                guard let resolved = Self.navigate(parts[...], in: effectiveRoot) else {
-                    throw Exception.unimplemented("Unsupported in-document $ref path: \(ref)")
+            let range = ref.range(of: "#")
+            let file = range.map { String(ref[ref.startIndex..<$0.lowerBound]) } ?? ref
+            let fragment = range.map { String(ref[$0.upperBound...]) }
+
+            let root = file.isEmpty
+                ? effectiveRoot
+                : try reader.read(directory.appendingPathComponent(file))
+
+            if let fragment, !fragment.isEmpty {
+                let parts = fragment.split(separator: "/").map(String.init)
+                guard let resolved = Self.navigate(parts[...], in: root) else {
+                    throw Exception.unimplemented("Unsupported $ref path: \(ref)")
                 }
                 merge(with: resolved)
             } else {
-                merge(with: try reader.read(directory.appendingPathComponent(ref)))
+                merge(with: root)
             }
         }
 

--- a/tools/rum-models-generator/run.py
+++ b/tools/rum-models-generator/run.py
@@ -23,7 +23,7 @@ SR_SCHEMA_PATH = '/rum-events-format/schemas/session-replay-mobile-schema.json'
 
 # RC schema lives in the private dd-go repo; cloned sparsely using GITHUB_TOKEN
 DD_GO_REPO = 'https://github.com/DataDog/dd-go.git'
-RC_SCHEMA_REPO_PATH = 'remote-config/apps/rc-schema-validation/schemas/rum-sdk-config.json'
+RC_SCHEMA_REPO_PATH = 'remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/STAGING/ios.json'
 RC_SCHEMA_SPARSE_DIR = 'remote-config/apps/rc-schema-validation/schemas'
 RC_SCHEMA_LOCAL_PATH = f'dd-go/{RC_SCHEMA_REPO_PATH}'  # relative to cwd (script_dir)
 


### PR DESCRIPTION
### What and why?

This PR builds on `feature/remote-config` and has two related parts.

**1. RC models from the iOS-specific staging schema**

Updates `RCDataModels.swift` with the models generated from the new iOS-specific Remote Configuration schema (`rum-sdk-config/STAGING/ios.json` in dd-go). The new schema is iOS-specific and introduces `sessionReplay`, `trace`, and `profiling` configuration alongside the existing `rum` config.

**2. RemoteConfigurationProvider error handling & ETag caching**

Refines `RemoteConfigurationProvider.sync`: typed errors and ETag conditional-request handling. ETag caching is **best-effort** — a failed ETag read/write is surfaced for observability (via a dedicated `etagError`) **without** blocking delivery of a successfully fetched configuration. `If-None-Match` is sent whenever an ETag is stored, so a known-bad payload is not re-fetched (a `304` means it is unchanged; a `200` with a new ETag lets us recover).

### How?

**Model generation:** Regenerated RC models using `make rc-models-generate GIT_REF=aleksandr-gringauz/RUM-16913/rum-sdk-config-staging-schema`. The generator required a few fixes to handle the new schema structure (cross-file `$ref` to `mobile.json`, draft-07 `definitions` keyword, updated root type rename) — included as tool changes.

**Provider:**
- Added `RemoteConfigurationError.etagError`; the caller (`DatadogCore`) logs it under a distinct telemetry prefix (`[RemoteConfig] ETag caching failed`) so a non-blocking cache hiccup is distinguishable from a real sync failure.
- Renamed the `start(_:)` callback parameter to `handler` and clarified that it fires on **every** result (cache, network, and each foreground refresh), not once.
- Migrated foreground tests off `MockURLProtocol` to `HTTPClientMock`; added tests for ETag-less success and for config delivery when an ETag write fails.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs
