### PR TITLE
Fixes flaky WebViewTrackingTests.testItChangesBridgeDecisionOnSessionRollover

### DIFF
--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -283,6 +283,7 @@ class WebViewTrackingTests: XCTestCase {
     }
 
     /// Loads a simulated request on a WebView, and waits for the page to finish loading.
+    @available(iOS 15.0, *)
     private func loadAndWait(on webView: WKWebView, request: URLRequest, responseHTML: String) {
         final class NavigationDelegate: NSObject, WKNavigationDelegate {
             let expectation: XCTestExpectation

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -255,31 +255,52 @@ class WebViewTrackingTests: XCTestCase {
     }
 
     private func waitForJS(_ js: String, toReturn expectedResult: String, webView: WKWebView, description: String) {
-        let outerExpectation = XCTestExpectation(description: "\(description) should be \(expectedResult)")
+        var runs = 0
+        let maxDuration: TimeInterval = 10
 
-        var isDone = false
+        func runAndWait() -> Bool? {
+            runs += 1
+            print("Attempt \(runs): \(description)")
 
-        while !isDone {
-            let innerExpectation = XCTestExpectation()
+            // Passed means:
+            //   nil: The block didn't execute
+            //   true: The block executed and the expected condition was asserted.
+            //   false: The block executed and the expected condition failed to be asserted.
+            var passed: Bool? = nil // No need for sync since the handler is MainActor
 
             webView.evaluateJavaScript(js) { result, error in
-                if error == nil && (result as? String) == expectedResult {
-                    isDone = true
-                    outerExpectation.fulfill()
-                }
-                innerExpectation.fulfill()
+                passed = (error == nil && (result as? String) == expectedResult)
             }
 
-            wait(for: [innerExpectation], timeout: 5.0)
+            // We can't use an XCTExpectation here since a timeout would cause the test to fail,
+            // which is not necessarily the case. We also can't use a DispatchSemaphore since both
+            // the wait and signal (inside the evaluateJavaScript handler) run on the same thread,
+            // meaning the thread would be blocked by the wait call and the handler would never run.
+            // So we do polling.
+            let timeout = Date(timeIntervalSinceNow: 2)
+            while passed == nil && Date() < timeout {
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
+            }
+
+            let endDescription = passed.map { "\($0)" } ?? "timeout"
+            print("  Attempt \(runs) of \(description) ended with \(endDescription)")
+            return passed
+        }
+
+        let startDate = Date()
+        let endDate = startDate + maxDuration
+
+        while Date() < endDate {
+            if runAndWait() == true {
+                return
+            }
 
             // Throttle: pump the run loop briefly between polls instead of busy-spinning
             // `evaluateJavaScript`, which otherwise floods the WebContent process with IPC.
-            if !isDone {
-                RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
-            }
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
         }
 
-        wait(for: [outerExpectation], timeout: 10.0)
+        XCTFail("\(description) failed after trying for \(maxDuration) secs.")
     }
 
     /// Loads a simulated request on a WebView, and waits for the page to finish loading.

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -34,12 +34,14 @@ class WebViewTrackingTests: XCTestCase {
             let delegate = WarmUpNavigationDelegate {
                 loaded.fulfill()
             }
-            let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
-            webView.navigationDelegate = delegate
-            Self.warmUpWebView = webView
+            withExtendedLifetime(delegate) {
+                let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+                webView.navigationDelegate = delegate
+                Self.warmUpWebView = webView
 
-            webView.loadHTMLString("<html><body>warmup</body></html>", baseURL: nil)
-            wait(for: [loaded], timeout: 60.0)
+                webView.loadHTMLString("<html><body>warmup</body></html>", baseURL: nil)
+                wait(for: [loaded], timeout: 60.0)
+            }
         }
     }
 

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -25,22 +25,37 @@ class WebViewTrackingTests: XCTestCase {
     ///
     /// - Note: This should be a class `setUp` method but can't because it calls `wait(for:timeout:)`
     /// which is a class method.
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
 
         if Self.warmUpWebView == nil {
+            struct WarmUpError: LocalizedError {
+                var errorDescription: String?
+            }
+
             // WebKit not warmed up yet, let's do that now.
             let loaded = XCTestExpectation(description: "WebKit warm-up")
             let delegate = WarmUpNavigationDelegate {
                 loaded.fulfill()
             }
-            withExtendedLifetime(delegate) {
+            try withExtendedLifetime(delegate) {
                 let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
                 webView.navigationDelegate = delegate
                 Self.warmUpWebView = webView
 
                 webView.loadHTMLString("<html><body>warmup</body></html>", baseURL: nil)
-                wait(for: [loaded], timeout: 60.0)
+                let jsExpectation = XCTestExpectation(description: "JS engine warm-up")
+                var warmUpError: WarmUpError?
+                webView.evaluateJavaScript("String(41 + 1)") { result, error in
+                    if error != nil || (result as? String) != "42" {
+                        warmUpError = WarmUpError(errorDescription: "Failed warm-up JS run. Error: \(String(describing: error)); Result: \(String(describing: result))")
+                    }
+                    jsExpectation.fulfill()
+                }
+                wait(for: [loaded, jsExpectation], timeout: 60.0)
+                if let warmUpError {
+                    throw warmUpError
+                }
             }
         }
     }
@@ -267,6 +282,34 @@ class WebViewTrackingTests: XCTestCase {
         wait(for: [outerExpectation], timeout: 10.0)
     }
 
+    /// Loads a simulated request on a WebView, and waits for the page to finish loading.
+    private func loadAndWait(on webView: WKWebView, request: URLRequest, responseHTML: String) {
+        final class NavigationDelegate: NSObject, WKNavigationDelegate {
+            let expectation: XCTestExpectation
+
+            var expectedNavigation: WKNavigation?
+
+            init(expectation: XCTestExpectation) {
+                self.expectation = expectation
+            }
+
+            func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { // swiftlint:disable:this implicitly_unwrapped_optional
+                if navigation == expectedNavigation {
+                    expectation.fulfill()
+                }
+            }
+        }
+
+        let expectation = XCTestExpectation(description: "Load request")
+        let delegate = NavigationDelegate(expectation: expectation)
+        webView.navigationDelegate = delegate
+        withExtendedLifetime(delegate) {
+            delegate.expectedNavigation = webView.loadSimulatedRequest(request, responseHTML: responseHTML)
+            wait(for: [expectation], timeout: 10)
+            webView.navigationDelegate = nil
+        }
+    }
+
     @available(iOS 15.0, *)
     func testItChangesBridgeDecisionOnSessionRollover() throws {
         // Given
@@ -311,9 +354,7 @@ class WebViewTrackingTests: XCTestCase {
             in: core
         )
 
-        Thread.sleep(forTimeInterval: 1.0)
-
-        webView.loadSimulatedRequest(URLRequest(url: URL(string: "http://localhost")!), responseHTML: "<html><body>Hello world</body></html>")
+        loadAndWait(on: webView, request: URLRequest(url: URL(string: "http://localhost")!), responseHTML: "<html><body>Hello world</body></html>")
 
         waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "false", webView: webView, description: "sessionUUID1")
 
@@ -332,19 +373,9 @@ class WebViewTrackingTests: XCTestCase {
 
         waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2")
 
-        let loadedAboutPage = XCTestExpectation(description: "About page loaded")
-        let delegate = WarmUpNavigationDelegate {
-            loadedAboutPage.fulfill()
-        }
-        webView.navigationDelegate = delegate
+        loadAndWait(on: webView, request: URLRequest(url: URL(string: "http://localhost/about.html")!), responseHTML: "<html><body>About us</body></html>")
 
-        withExtendedLifetime(delegate) {
-            webView.loadSimulatedRequest(URLRequest(url: URL(string: "http://localhost/about.html")!), responseHTML: "<html><body>About us</body></html>")
-
-            wait(for: [loadedAboutPage], timeout: 10)
-
-            waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2 after loading a new page")
-        }
+        waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2 after loading a new page")
     }
 
     @available(iOS 15.0, *)
@@ -391,8 +422,6 @@ class WebViewTrackingTests: XCTestCase {
             in: core
         )
 
-        Thread.sleep(forTimeInterval: 1.0)
-
         // Load a page containing a same-origin iframe with a nested iframe
         let html = """
         <html><body>
@@ -400,10 +429,7 @@ class WebViewTrackingTests: XCTestCase {
             <iframe srcdoc="<html><body>Outer iframe<iframe srcdoc='<html><body>Nested iframe</body></html>'></iframe></body></html>"></iframe>
         </body></html>
         """
-        webView.loadSimulatedRequest(
-            URLRequest(url: URL(string: "http://localhost")!),
-            responseHTML: html
-        )
+        loadAndWait(on: webView, request: URLRequest(url: URL(string: "http://localhost")!), responseHTML: html)
 
         let mainJS = "window.DatadogEventBridge.getIsTraceSampled()"
         let iframeJS = "window.frames[0].DatadogEventBridge.getIsTraceSampled()"

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -15,6 +15,47 @@ import DatadogInternal
 
 @MainActor
 class WebViewTrackingTests: XCTestCase {
+    private static var warmUpWebView: WKWebView?
+
+    /// Warms up WebKit before running tests.
+    ///
+    /// WebKit takes a while to load on slow CI servers, and causes tests to be flaky. This setup method
+    /// warms up WebKit (rendering and JS engines) before proceeding. This way, tests like
+    /// `testItChangesBridgeDecisionOnSessionRollover` should not fail randomly.
+    ///
+    /// - Note: This should be a class `setUp` method but can't because it calls `wait(for:timeout:)`
+    /// which is a class method.
+    override func setUp() {
+        super.setUp()
+
+        if Self.warmUpWebView == nil {
+            // WebKit not warmed up yet, let's do that now.
+            let loaded = XCTestExpectation(description: "WebKit warm-up")
+            let delegate = WarmUpNavigationDelegate {
+                loaded.fulfill()
+            }
+            let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+            webView.navigationDelegate = delegate
+            Self.warmUpWebView = webView
+
+            webView.loadHTMLString("<html><body>warmup</body></html>", baseURL: nil)
+            wait(for: [loaded], timeout: 60.0)
+        }
+    }
+
+    /// Fulfills a closure when the warm-up navigation finishes loading.
+    private final class WarmUpNavigationDelegate: NSObject, WKNavigationDelegate {
+        private let onFinish: () -> Void
+
+        init(onFinish: @escaping () -> Void) {
+            self.onFinish = onFinish
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {         // swiftlint:disable:this implicitly_unwrapped_optional
+            onFinish()
+        }
+    }
+
     func testItAddsUserScript() throws {
         let mockSanitizer = HostsSanitizerMock()
         let config = WKWebViewConfiguration()
@@ -213,6 +254,12 @@ class WebViewTrackingTests: XCTestCase {
             }
 
             wait(for: [innerExpectation], timeout: 5.0)
+
+            // Throttle: pump the run loop briefly between polls instead of busy-spinning
+            // `evaluateJavaScript`, which otherwise floods the WebContent process with IPC.
+            if !isDone {
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+            }
         }
 
         wait(for: [outerExpectation], timeout: 10.0)
@@ -249,9 +296,6 @@ class WebViewTrackingTests: XCTestCase {
 
         core.flush()
 
-        // Necessary for RUM to set the session sampler in the feature, since it's an async process.
-//        Thread.sleep(forTimeInterval: 1.0)
-
         let config = WKWebViewConfiguration()
         let controller = DDUserContentController()
         config.userContentController = controller
@@ -268,8 +312,6 @@ class WebViewTrackingTests: XCTestCase {
         Thread.sleep(forTimeInterval: 1.0)
 
         webView.loadSimulatedRequest(URLRequest(url: URL(string: "http://localhost")!), responseHTML: "<html><body>Hello world</body></html>")
-
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
 
         waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "false", webView: webView, description: "sessionUUID1")
 
@@ -288,9 +330,7 @@ class WebViewTrackingTests: XCTestCase {
 
         waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2")
 
-        webView.loadSimulatedRequest(URLRequest(url: URL(string: "http://localhost/about.htmk")!), responseHTML: "<html><body>About us</body></html>")
-
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
+        webView.loadSimulatedRequest(URLRequest(url: URL(string: "http://localhost/about.html")!), responseHTML: "<html><body>About us</body></html>")
 
         waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2 after loading a new page")
     }

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -332,9 +332,19 @@ class WebViewTrackingTests: XCTestCase {
 
         waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2")
 
-        webView.loadSimulatedRequest(URLRequest(url: URL(string: "http://localhost/about.html")!), responseHTML: "<html><body>About us</body></html>")
+        let loadedAboutPage = XCTestExpectation(description: "About page loaded")
+        let delegate = WarmUpNavigationDelegate {
+            loadedAboutPage.fulfill()
+        }
+        webView.navigationDelegate = delegate
 
-        waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2 after loading a new page")
+        withExtendedLifetime(delegate) {
+            webView.loadSimulatedRequest(URLRequest(url: URL(string: "http://localhost/about.html")!), responseHTML: "<html><body>About us</body></html>")
+
+            wait(for: [loadedAboutPage], timeout: 10)
+
+            waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2 after loading a new page")
+        }
     }
 
     @available(iOS 15.0, *)


### PR DESCRIPTION
### What and why?

Fixes flaky `WebViewTrackingTests`.

### How?

`testItChangesBridgeDecisionOnSessionRollover` takes too long to run due to slow WebKit initialization (HTML and JS engines) on slow CI runners. To work around this, we now pre-warm WebKit in the Setup method.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
