### PR TITLE
[RUM-16753] Add TTL-based rate limiting to RemoteConfigurationProvider foreground refresh

### DIFF
--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -54,9 +54,11 @@ internal final class RemoteConfigurationProvider {
             guard let self else {
                 return
             }
-            if let last = self.lastSyncDate,
-               self.dateProvider.now.timeIntervalSince(last) < self.minimumSyncInterval {
-                return
+            if let last = self.lastSyncDate {
+                let elapsed = self.dateProvider.now.timeIntervalSince(last)
+                if elapsed >= 0, elapsed < self.minimumSyncInterval {
+                    return
+                }
             }
             self.sync(completionHandler)
         }

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -14,6 +14,10 @@ internal final class RemoteConfigurationProvider {
     let directory: Directory
     let httpClient: HTTPClient
     private let notificationCenter: NotificationCenter
+    private let dateProvider: DateProvider
+    @ReadWriteLock
+    private var lastSyncDate: Date? = nil
+    private let minimumSyncInterval: TimeInterval = 300
     @ReadWriteLock
     private var foregroundObserver: NSObjectProtocol?
 
@@ -22,13 +26,15 @@ internal final class RemoteConfigurationProvider {
         site: DatadogSite,
         directory: Directory,
         httpClient: HTTPClient,
-        notificationCenter: NotificationCenter
+        notificationCenter: NotificationCenter,
+        dateProvider: DateProvider = SystemDateProvider()
     ) {
         self.id = id
         self.site = site
         self.directory = directory
         self.httpClient = httpClient
         self.notificationCenter = notificationCenter
+        self.dateProvider = dateProvider
     }
 
     func start(_ completionHandler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
@@ -45,7 +51,14 @@ internal final class RemoteConfigurationProvider {
             object: nil,
             queue: nil
         ) { [weak self] _ in
-            self?.sync(completionHandler)
+            guard let self else {
+                return
+            }
+            if let last = self.lastSyncDate,
+               self.dateProvider.now.timeIntervalSince(last) < self.minimumSyncInterval {
+                return
+            }
+            self.sync(completionHandler)
         }
 #endif
 
@@ -116,6 +129,7 @@ internal final class RemoteConfigurationProvider {
             case .success(let (http, data)):
                 // 1. Not Modified — existing persisted configuration is still valid.
                 if http.statusCode == 304 {
+                    self.lastSyncDate = self.dateProvider.now
                     return
                 }
 
@@ -145,6 +159,7 @@ internal final class RemoteConfigurationProvider {
                 // all-or-nothing: the existing file is never left in a truncated state.
                 do {
                     try File(url: self.directory.url.appendingPathComponent("\(self.id).json")).write(data: data)
+                    self.lastSyncDate = self.dateProvider.now
                     // Store ETag for conditional requests on the next sync.
                     // If the response has no ETag, delete any stale validator so we
                     // never send If-None-Match for a different representation.

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -430,7 +430,8 @@ extension DatadogCore {
                 site: configuration.site,
                 directory: directory.coreDirectory,
                 httpClient: httpClient,
-                notificationCenter: configuration.notificationCenter
+                notificationCenter: configuration.notificationCenter,
+                dateProvider: configuration.dateProvider
             )
         }
 

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -540,6 +540,7 @@ class RemoteConfigurationTests: XCTestCase {
 #if canImport(UIKit)
     func testWillEnterForegroundSyncsRemoteConfiguration() {
         let notificationCenter = NotificationCenter()
+        let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0)
         let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
         let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
         let requestLock = NSLock()
@@ -551,9 +552,11 @@ class RemoteConfigurationTests: XCTestCase {
             requestLock.unlock()
             return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
         }
-        let rc = makeProvider(notificationCenter: notificationCenter)
+        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider)
         waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
 
+        // Advance past TTL so the foreground sync is not suppressed
+        dateProvider.advance(bySeconds: 360)
         notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
 
         waitForPersistedConfiguration(applicationID: "foreground-application-id", fileData: foregroundPayload)
@@ -562,6 +565,7 @@ class RemoteConfigurationTests: XCTestCase {
 
     func testWillEnterForegroundCallsCompletionAgain() {
         let notificationCenter = NotificationCenter()
+        let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0)
         let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
         let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
         let requestLock = NSLock()
@@ -578,7 +582,7 @@ class RemoteConfigurationTests: XCTestCase {
         var completionCount = 0
         let completionExpectation = expectation(description: "completion is called for each sync")
         completionExpectation.expectedFulfillmentCount = 2
-        let rc = makeProvider(notificationCenter: notificationCenter, start: false)
+        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider, start: false)
         rc.start { result in
             guard case .success = result else {
                 return
@@ -592,6 +596,8 @@ class RemoteConfigurationTests: XCTestCase {
         }
         waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
 
+        // Advance past TTL so the foreground sync is not suppressed
+        dateProvider.advance(bySeconds: 360)
         notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
         waitForPersistedConfiguration(applicationID: "foreground-application-id", fileData: foregroundPayload)
 

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -74,6 +74,7 @@ class RemoteConfigurationTests: XCTestCase {
         id: String = "test-id",
         httpClient: HTTPClient? = nil,
         notificationCenter: NotificationCenter = NotificationCenter(),
+        dateProvider: DateProvider = SystemDateProvider(),
         start: Bool = true
     ) -> RemoteConfigurationProvider {
         let provider = RemoteConfigurationProvider(
@@ -81,7 +82,8 @@ class RemoteConfigurationTests: XCTestCase {
             site: .us1,
             directory: coreDir.coreDirectory,
             httpClient: httpClient ?? self.httpClient,
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            dateProvider: dateProvider
         )
         if start {
             provider.start { _ in }
@@ -595,6 +597,129 @@ class RemoteConfigurationTests: XCTestCase {
 
         wait(for: [completionExpectation], timeout: 2)
         XCTAssertEqual(completionLock.withLock { completionCount }, 2)
+        withExtendedLifetime(rc) {}
+    }
+
+    func testForegroundSyncsWhenLastSyncDateIsNil() {
+        // Given — init sync fails, lastSyncDate stays nil
+        let notificationCenter = NotificationCenter()
+        let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
+        let requestLock = NSLock()
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestLock.lock()
+            requestCount += 1
+            let count = requestCount
+            requestLock.unlock()
+            if count == 1 {
+                throw URLError(.networkConnectionLost)
+            }
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, foregroundPayload)
+        }
+        let rc = makeProvider(notificationCenter: notificationCenter)
+
+        // When — foreground fires immediately after a failed init sync
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+
+        // Then — sync fires because lastSyncDate is nil
+        waitForPersistedConfiguration(applicationID: "foreground-application-id")
+        withExtendedLifetime(rc) {}
+    }
+
+    func testForegroundSyncsWhenTTLElapsed() {
+        // Given — init sync succeeds, then TTL elapses
+        let notificationCenter = NotificationCenter()
+        let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0)
+        let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
+        let foregroundPayload = remoteConfigurationData(applicationID: "foreground-application-id")
+        let requestLock = NSLock()
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestLock.lock()
+            requestCount += 1
+            let payload = requestCount == 1 ? initialPayload : foregroundPayload
+            requestLock.unlock()
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, payload)
+        }
+        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider)
+        waitForPersistedConfiguration(applicationID: "initial-application-id")
+
+        // When — TTL elapses and foreground fires
+        dateProvider.advance(bySeconds: 360)
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+
+        // Then — sync fires
+        waitForPersistedConfiguration(applicationID: "foreground-application-id")
+        withExtendedLifetime(rc) {}
+    }
+
+    func testForegroundDoesNotSyncWhenTTLNotElapsed() {
+        // Given — init sync succeeds, TTL not elapsed
+        let notificationCenter = NotificationCenter()
+        let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0)
+        let initialPayload = remoteConfigurationData(applicationID: "initial-application-id")
+        let requestLock = NSLock()
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestLock.lock()
+            requestCount += 1
+            requestLock.unlock()
+            return (HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!, initialPayload)
+        }
+        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider)
+        waitForPersistedConfiguration(applicationID: "initial-application-id")
+
+        let countAfterInit = requestLock.withLock { requestCount }
+
+        // When — only 1 minute passes and foreground fires
+        dateProvider.advance(bySeconds: 60)
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+
+        // Then — no additional sync fires within TTL
+        let noSyncExpectation = expectation(description: "no foreground sync within TTL")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertEqual(requestLock.withLock { requestCount }, countAfterInit, "No sync should fire within TTL")
+            noSyncExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+        withExtendedLifetime(rc) {}
+    }
+
+    func testForegroundDoesNotSyncAfter304WithinTTL() throws {
+        // Given — init sync returns 304, TTL not elapsed
+        let notificationCenter = NotificationCenter()
+        let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0)
+        let cachedPayload = remoteConfigurationData(applicationID: "cached-application-id")
+        try cachedPayload.write(
+            to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
+            options: .atomic
+        )
+        let requestLock = NSLock()
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestLock.lock()
+            requestCount += 1
+            requestLock.unlock()
+            return (HTTPURLResponse(url: request.url!, statusCode: 304, httpVersion: nil, headerFields: nil)!, nil)
+        }
+        let rc = makeProvider(notificationCenter: notificationCenter, dateProvider: dateProvider)
+
+        // Wait for init sync (304)
+        let initExpectation = expectation(description: "init sync completes")
+        wait(until: { requestLock.withLock { requestCount } == 1 }, andThenFulfill: initExpectation)
+        waitForExpectations(timeout: 2)
+
+        // When — foreground fires within TTL
+        dateProvider.advance(bySeconds: 60)
+        notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+
+        // Then — no additional request fires
+        let noSyncExpectation = expectation(description: "no foreground sync after 304 within TTL")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertEqual(requestLock.withLock { requestCount }, 1, "No sync should fire within TTL after 304")
+            noSyncExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
         withExtendedLifetime(rc) {}
     }
 


### PR DESCRIPTION
### What and why?

Adds TTL-based rate limiting to the foreground refresh introduced in RUM-16711. Without a TTL, the RemoteConfigurationProvider would make a CDN request on every app foreground transition, even when the app was only briefly backgrounded. This reduces unnecessary network requests by suppressing foreground syncs that happen within 5 minutes of the last successful revalidation, following the RFC's recommended caching strategy.

### How?

- dateProvider: DateProvider is injected in RemoteConfigurationProvider.init following the same pattern as DatadogCore, allowing tests to control time without waiting.
- lastSyncDate: Date? (protected by @ReadWriteLock) tracks when the last successful sync occurred.
- The foreground observer checks dateProvider.now.timeIntervalSince(lastSyncDate) < minimumSyncInterval before firing a sync — if within 5 minutes, it skips.
- lastSyncDate is updated after a successful 200 response (disk write) and after a 304 (cache still valid). Failed syncs do not update it, so the next foreground attempt is not blocked.
- minimumSyncInterval = 300 seconds (5 minutes) is a private constant per the RFC.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
