### PR TITLE
[PANA-7784] Build composition tree from layer snapshots

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 		5BB771AC2FE8769B00C95960 /* CompositionTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AB2FE8769B00C95960 /* CompositionTreeBuilderTests.swift */; };
 		5BB771AE2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */; };
 		5BB771B02FE876D600C95960 /* PathCornerRadiiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */; };
+		5BB771B42FE9848900C95960 /* WKWebView+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */; };
 		5BBDF1C32E97B33800670CEB /* FallbackFlagsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBDF1C22E97B33300670CEB /* FallbackFlagsClient.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
 		5BD6C6572E8AC5E900F5D2CC /* FlagsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD6C6552E8AC5E000F5D2CC /* FlagsRepository.swift */; };
@@ -2128,6 +2129,7 @@
 		5BB771AB2FE8769B00C95960 /* CompositionTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionTreeBuilderTests.swift; sourceTree = "<group>"; };
 		5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerSnapshotSRCompositionLayerTests.swift; sourceTree = "<group>"; };
 		5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathCornerRadiiTests.swift; sourceTree = "<group>"; };
+		5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+SessionReplay.swift"; sourceTree = "<group>"; };
 		5BBDF1C22E97B33300670CEB /* FallbackFlagsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbackFlagsClient.swift; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
 		5BD6C6552E8AC5E000F5D2CC /* FlagsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsRepository.swift; sourceTree = "<group>"; };
@@ -4069,6 +4071,7 @@
 				962D72BE2CF7538800F86EF0 /* CGImage+SessionReplay.swift */,
 				D22442C42CA301DA002E71E4 /* UIColor+SessionReplay.swift */,
 				61054E152A6EE10A00AAA894 /* UIView+SessionReplay.swift */,
+				5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */,
 				61054E162A6EE10A00AAA894 /* CFType+Safety.swift */,
 				61054E172A6EE10A00AAA894 /* SystemColors.swift */,
 				61054E182A6EE10A00AAA894 /* CGRect+SessionReplay.swift */,
@@ -8326,6 +8329,7 @@
 				61054E802A6EE10A00AAA894 /* UIPickerViewRecorder.swift in Sources */,
 				61054E612A6EE10A00AAA894 /* SRCompression.swift in Sources */,
 				B73450212F9F200100000001 /* LayerRecording.swift in Sources */,
+				5BB771B42FE9848900C95960 /* WKWebView+SessionReplay.swift in Sources */,
 				5BF2BC772FC4D8E0000E999C /* LayerProvider.swift in Sources */,
 				5B1877CB2FDC4737005AC2CE /* UIImage+Redaction.swift in Sources */,
 				5B9CB9E32E41F6F9005485E6 /* ImageRepresentable.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -353,6 +353,12 @@
 		5BB294B02E82CCA400CAA44B /* ExposureRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */; };
 		5BB294BD2E82E66500CAA44B /* FlagValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BC2E82E66200CAA44B /* FlagValue.swift */; };
 		5BB294C02E83E02900CAA44B /* ExposureLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */; };
+		5BB771A62FE5917900C95960 /* CompositionTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771A52FE5916E00C95960 /* CompositionTreeBuilder.swift */; };
+		5BB771A82FE59F9000C95960 /* Path+CornerRadii.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771A72FE59F8500C95960 /* Path+CornerRadii.swift */; };
+		5BB771AA2FE7E85100C95960 /* CALayerSnapshot+SRCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771A92FE7E84500C95960 /* CALayerSnapshot+SRCompositionLayer.swift */; };
+		5BB771AC2FE8769B00C95960 /* CompositionTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AB2FE8769B00C95960 /* CompositionTreeBuilderTests.swift */; };
+		5BB771AE2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */; };
+		5BB771B02FE876D600C95960 /* PathCornerRadiiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */; };
 		5BBDF1C32E97B33800670CEB /* FallbackFlagsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBDF1C22E97B33300670CEB /* FallbackFlagsClient.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
 		5BD6C6572E8AC5E900F5D2CC /* FlagsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD6C6552E8AC5E000F5D2CC /* FlagsRepository.swift */; };
@@ -2116,6 +2122,12 @@
 		5BB294AF2E82CCA100CAA44B /* ExposureRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureRequestBuilderTests.swift; sourceTree = "<group>"; };
 		5BB294BC2E82E66200CAA44B /* FlagValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagValue.swift; sourceTree = "<group>"; };
 		5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLogger.swift; sourceTree = "<group>"; };
+		5BB771A52FE5916E00C95960 /* CompositionTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionTreeBuilder.swift; sourceTree = "<group>"; };
+		5BB771A72FE59F8500C95960 /* Path+CornerRadii.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+CornerRadii.swift"; sourceTree = "<group>"; };
+		5BB771A92FE7E84500C95960 /* CALayerSnapshot+SRCompositionLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayerSnapshot+SRCompositionLayer.swift"; sourceTree = "<group>"; };
+		5BB771AB2FE8769B00C95960 /* CompositionTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionTreeBuilderTests.swift; sourceTree = "<group>"; };
+		5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerSnapshotSRCompositionLayerTests.swift; sourceTree = "<group>"; };
+		5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathCornerRadiiTests.swift; sourceTree = "<group>"; };
 		5BBDF1C22E97B33300670CEB /* FallbackFlagsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbackFlagsClient.swift; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
 		5BD6C6552E8AC5E000F5D2CC /* FlagsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsRepository.swift; sourceTree = "<group>"; };
@@ -3951,6 +3963,9 @@
 				5BF2BC662FC10001000E999C /* CALayerSnapshotTests.swift */,
 				5BF2BC742FC4D520000E999C /* LayerTreeSnapshotBuilderTests.swift */,
 				3F2ED47E396E4030BF5D0469 /* OcclusionMapTests.swift */,
+				5BB771AB2FE8769B00C95960 /* CompositionTreeBuilderTests.swift */,
+				5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */,
+				5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */,
 			);
 			path = LayerTreeRecorder;
 			sourceTree = "<group>";
@@ -4045,6 +4060,7 @@
 		61054E132A6EE10A00AAA894 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				5BB771A72FE59F8500C95960 /* Path+CornerRadii.swift */,
 				5BE0EA2C2E66EF9B00216E1C /* Path+SessionReplay.swift */,
 				61054E142A6EE10A00AAA894 /* UIImage+SessionReplay.swift */,
 				5B1877C82FDC3EE6005AC2CE /* UIImage+FeatureDetection.swift */,
@@ -6016,6 +6032,8 @@
 				759200032FD2000100000001 /* CALayerSnapshot+ImageSnapshot.swift */,
 				CD3456EF7890AB123456CDEF /* CALayerSnapshot+Occlusion.swift */,
 				5BF2BA9C2FBDC047000E999C /* CALayerSnapshot+SemanticObservation.swift */,
+				5BB771A92FE7E84500C95960 /* CALayerSnapshot+SRCompositionLayer.swift */,
+				5BB771A52FE5916E00C95960 /* CompositionTreeBuilder.swift */,
 				759200052FD2000100000001 /* ImageSnapshot.swift */,
 				5B1877C02FDC0607005AC2CE /* ImageSnapshot+Redaction.swift */,
 				759200072FD2000100000001 /* ImageSnapshotCache.swift */,
@@ -8277,7 +8295,9 @@
 				5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */,
 				5BF2BC6A2FC085E2000E999C /* CALayerSnapshot+Context.swift in Sources */,
 				D2AD1CC92CE4AE6600106C74 /* SwiftUIWireframesBuilder.swift in Sources */,
+				5BB771A82FE59F9000C95960 /* Path+CornerRadii.swift in Sources */,
 				969B3B212C33F80500D62400 /* UIActivityIndicatorRecorder.swift in Sources */,
+				5BB771A62FE5917900C95960 /* CompositionTreeBuilder.swift in Sources */,
 				61054EA22A6EE10B00AAA894 /* Scheduler.swift in Sources */,
 				A7EA88562B17639A00FE2580 /* ResourcesWriter.swift in Sources */,
 				5BF2BA9F2FBF1393000E999C /* CALayer+ReplayID.swift in Sources */,
@@ -8315,6 +8335,7 @@
 				B73450222F9F200100000001 /* LayerTreeRecordingCoordinator.swift in Sources */,
 				B73450232F9F200100000001 /* LayerRecorder.swift in Sources */,
 				5BF2BC792FC4D8E0000E999C /* LayerTreeSnapshotBuilder.swift in Sources */,
+				5BB771AA2FE7E85100C95960 /* CALayerSnapshot+SRCompositionLayer.swift in Sources */,
 				7592000A2FD2000100000001 /* ImageSnapshotter.swift in Sources */,
 				CC33CC1DDED24454BB35E631 /* OcclusionMap.swift in Sources */,
 				AB1234CD5678EF901234ABCD /* CALayerSnapshot+Occlusion.swift in Sources */,
@@ -8466,6 +8487,7 @@
 				5BF2BC672FC10001000E999C /* CALayerSnapshotTests.swift in Sources */,
 				5BF2BC752FC4D520000E999C /* LayerTreeSnapshotBuilderTests.swift in Sources */,
 				17EFC9D8185942399E05BDB4 /* OcclusionMapTests.swift in Sources */,
+				5BB771AC2FE8769B00C95960 /* CompositionTreeBuilderTests.swift in Sources */,
 				EF5678AB9012CD345678EFAB /* CALayerSnapshotOcclusionTests.swift in Sources */,
 				BC9876FA1234CDEF56789ABC /* NSObject+CAFilter.swift in Sources */,
 				7592000E2FD2000100000001 /* ImageSnapshotCacheTests.swift in Sources */,
@@ -8476,6 +8498,7 @@
 				759200142FD2000100000001 /* CALayerChangesetMock.swift in Sources */,
 				61054FB82A6EE1BA00AAA894 /* UIDatePickerRecorderTests.swift in Sources */,
 				962D72C52CF7806300F86EF0 /* GraphicsImageReflectionTests.swift in Sources */,
+				5BB771B02FE876D600C95960 /* PathCornerRadiiTests.swift in Sources */,
 				61054FA32A6EE1BA00AAA894 /* Diff+SRWireframesTests.swift in Sources */,
 				96867B9B2D0883DD004AE0BC /* ColorReflectionTests.swift in Sources */,
 				5B69166F2F3B89060074A909 /* TestTimerScheduler.swift in Sources */,
@@ -8498,6 +8521,7 @@
 				5B7448372EFAED99003E622C /* CALayerSwizzlerTests.swift in Sources */,
 				61054F9C2A6EE1BA00AAA894 /* SwiftExtensionsTests.swift in Sources */,
 				61054FA72A6EE1BA00AAA894 /* NodesFlattenerTests.swift in Sources */,
+				5BB771AE2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift in Sources */,
 				61054FAA2A6EE1BA00AAA894 /* UIView+SessionReplayTests.swift in Sources */,
 				61054FA52A6EE1BA00AAA894 /* RecordsBuilderTests.swift in Sources */,
 				61054FD02A6EE1BA00AAA894 /* SRContextPublisherTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -360,6 +360,8 @@
 		5BB771AE2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */; };
 		5BB771B02FE876D600C95960 /* PathCornerRadiiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */; };
 		5BB771B42FE9848900C95960 /* WKWebView+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */; };
+		5BB771B62FEA7A0E00C95960 /* ImageSnapshotResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B52FEA7A0E00C95960 /* ImageSnapshotResource.swift */; };
+		5BB771B82FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */; };
 		5BBDF1C32E97B33800670CEB /* FallbackFlagsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBDF1C22E97B33300670CEB /* FallbackFlagsClient.swift */; };
 		5BCBC0CD2DF85B6A0094DCC2 /* SessionReplayPrivacyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */; };
 		5BD6C6572E8AC5E900F5D2CC /* FlagsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD6C6552E8AC5E000F5D2CC /* FlagsRepository.swift */; };
@@ -2130,6 +2132,8 @@
 		5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerSnapshotSRCompositionLayerTests.swift; sourceTree = "<group>"; };
 		5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathCornerRadiiTests.swift; sourceTree = "<group>"; };
 		5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+SessionReplay.swift"; sourceTree = "<group>"; };
+		5BB771B52FEA7A0E00C95960 /* ImageSnapshotResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotResource.swift; sourceTree = "<group>"; };
+		5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRWireframe+CALayerSnapshot.swift"; sourceTree = "<group>"; };
 		5BBDF1C22E97B33300670CEB /* FallbackFlagsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FallbackFlagsClient.swift; sourceTree = "<group>"; };
 		5BCBC0CC2DF85AFE0094DCC2 /* SessionReplayPrivacyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayPrivacyView.swift; sourceTree = "<group>"; };
 		5BD6C6552E8AC5E000F5D2CC /* FlagsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsRepository.swift; sourceTree = "<group>"; };
@@ -6048,6 +6052,8 @@
 				B73450132F9F200100000001 /* LayerRecorder.swift */,
 				5BF2BC782FC4D8E0000E999C /* LayerTreeSnapshotBuilder.swift */,
 				7C61BC8C730F46F1A8EF112E /* OcclusionMap.swift */,
+				5BB771B52FEA7A0E00C95960 /* ImageSnapshotResource.swift */,
+				5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */,
 			);
 			path = LayerTreeRecorder;
 			sourceTree = "<group>";
@@ -8346,6 +8352,7 @@
 				61054E8B2A6EE10A00AAA894 /* SessionReplayFeature.swift in Sources */,
 				759200062FD2000100000001 /* ImageSnapshot.swift in Sources */,
 				5B1877C12FDC060E005AC2CE /* ImageSnapshot+Redaction.swift in Sources */,
+				5BB771B62FEA7A0E00C95960 /* ImageSnapshotResource.swift in Sources */,
 				61054E992A6EE10A00AAA894 /* WireframesBuilder.swift in Sources */,
 				61054E892A6EE10A00AAA894 /* NodeIDGenerator.swift in Sources */,
 				5BE0EA2B2E66E8A800216E1C /* ShapeResourceBuilder.swift in Sources */,
@@ -8390,6 +8397,7 @@
 				5B1877CD2FDC5744005AC2CE /* UIImage+DominantColor.swift in Sources */,
 				759200042FD2000100000001 /* CALayerSnapshot+ImageSnapshot.swift in Sources */,
 				962D72BC2CF6436700F86EF0 /* GraphicsImage.swift in Sources */,
+				5BB771B82FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift in Sources */,
 				61054E6F2A6EE10A00AAA894 /* UIApplicationSwizzler.swift in Sources */,
 				61054E6D2A6EE10A00AAA894 /* CGRect+SessionReplay.swift in Sources */,
 				D274FD1C2CBFEF6D005270B5 /* CGSize+SessionReplay.swift in Sources */,

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+CornerRadii.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+CornerRadii.swift
@@ -42,4 +42,19 @@ extension CALayerSnapshot {
         }
     }
 }
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot.CornerRadii {
+    var uniformCornerRadius: CGFloat? {
+        guard
+            topLeft.width == topLeft.height,
+            topLeft == topRight,
+            topRight == bottomLeft,
+            bottomLeft == bottomRight
+        else {
+            return nil
+        }
+        return topLeft.width
+    }
+}
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -115,6 +115,8 @@ extension ImageSnapshotRequest {
 extension CALayerSnapshot.SemanticObservation {
     fileprivate func allowsImageSnapshot(imagePrivacyLevel: ImagePrivacyLevel) -> Bool {
         switch semantics {
+        case .image(let image) where !image.hasContent:
+            return false
         case .image where imagePrivacyLevel == .maskNone:
             return true
         case .image(let image) where imagePrivacyLevel == .maskNonBundledOnly && image.isContextual:

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -7,7 +7,6 @@
 #if os(iOS)
 import Foundation
 import QuartzCore
-import UIKit
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
@@ -125,20 +124,6 @@ extension CALayerSnapshot.SemanticObservation {
         default:
             return false
         }
-    }
-}
-
-@available(iOS 13.0, tvOS 13.0, *)
-extension CALayerSnapshot.SemanticObservation.ImageSemantics {
-    fileprivate var isContextual: Bool {
-        guard let resolvedImage else {
-            return false
-        }
-        return resolvedImage.isContextual
-    }
-
-    private var resolvedImage: UIImage? {
-        isHighlighted ? highlightedImage ?? image : image
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Occlusion.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Occlusion.swift
@@ -97,14 +97,14 @@ extension CALayerSnapshot.CornerRadii {
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
-    fileprivate var hasBackgroundColor: Bool {
+    var hasBackgroundColor: Bool {
         guard let backgroundColor else {
             return false
         }
         return backgroundColor.alpha > 0
     }
 
-    fileprivate var hasBorder: Bool {
+    var hasBorder: Bool {
         guard let borderColor, borderWidth > 0 else {
             return false
         }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SRCompositionLayer.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SRCompositionLayer.swift
@@ -1,0 +1,124 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import SwiftUI
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot {
+    var requiresCompositionLayer: Bool {
+        masksToBounds
+            || opacity < 1
+            || filters.contains(where: { SRCompositionLayerModifier(filter: $0) != nil })
+            || compositingFilter.flatMap(SRCompositionLayer.CompositeOperation.init(compositingFilter:)) != nil
+    }
+
+    func modifiers() -> [SRCompositionLayerModifier] {
+        var result: [SRCompositionLayerModifier] = []
+
+        // Modifiers order determines the final appearance in the player
+
+        // Clipping
+        if masksToBounds {
+            result.append(
+                .compositionLayerClipModifier(
+                    value: .init(
+                        path: SwiftUI.Path(
+                            roundedRect: .init(origin: .zero, size: absoluteFrame.size),
+                            cornerRadii: cornerRadii,
+                            cornerCurve: cornerCurve
+                        ).dd.svgString
+                    )
+                )
+            )
+        }
+
+        // Filters
+        result.append(
+            contentsOf: filters.compactMap(SRCompositionLayerModifier.init(filter:))
+        )
+
+        // Shadow should go here when we add support for it
+
+        // Opacity
+        if opacity < 1 {
+            result.append(.compositionLayerOpacityModifier(value: .init(value: Double(opacity))))
+        }
+
+        return result
+    }
+}
+
+extension SRCompositionLayer.CompositeOperation {
+    @available(iOS 13.0, tvOS 13.0, *)
+    init?(compositingFilter: CALayerSnapshot.CompositingFilter) {
+        switch compositingFilter {
+        case .destinationIn:
+            self = .destinationIn
+        case .plusDarker:
+            self = .plusDarker
+        default:
+            return nil
+        }
+    }
+}
+
+extension SRCompositionLayerModifier {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init?(filter: CALayerSnapshot.Filter) {
+        switch filter {
+        case .glassBackground:
+            self = .compositionLayerBackgroundMaterialModifier(value: .init(kind: .glass))
+        case .gaussianBlur(let radius):
+            self = .compositionLayerGaussianBlurModifier(value: .init(radius: Double(radius)))
+        case .colorMatrix(let colorMatrix):
+            self = .compositionLayerColorMatrixModifier(value: .init(matrix: colorMatrix.values))
+        case .saturate(let value):
+            self = .compositionLayerSaturateModifier(value: .init(value: value))
+        case .brightness(let value):
+            self = .compositionLayerBrightnessBiasModifier(value: .init(value: value))
+        case .multiplyColor(let color):
+            guard let colorMatrix = CALayerSnapshot.ColorMatrix(multiplyColor: color) else {
+                return nil
+            }
+            self = .compositionLayerColorMatrixModifier(value: .init(matrix: colorMatrix.values))
+        case .unknown:
+            return nil
+        }
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot.ColorMatrix {
+    fileprivate var values: [Double] {
+        [
+            m11, m12, m13, m14, m15,
+            m21, m22, m23, m24, m25,
+            m31, m32, m33, m34, m35,
+            m41, m42, m43, m44, m45
+        ].map(Double.init)
+    }
+
+    fileprivate init?(multiplyColor color: CGColor) {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 1
+
+        guard (UIColor(cgColor: color)).getRed(&r, green: &g, blue: &b, alpha: &a) else {
+            return nil
+        }
+
+        self.init(
+            m11: Float(r),
+            m22: Float(g),
+            m33: Float(b),
+            m44: Float(a)
+        )
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -140,22 +140,14 @@ extension NSAttributedString {
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct ImageSemantics: Sendable, Equatable {
-        let image: UIImage?
-        let highlightedImage: UIImage?
-        let isHighlighted: Bool
-        let tintColor: UIColor?
+        let isContextual: Bool
     }
 
     fileprivate init(imageView: UIImageView) {
+        let image = imageView.isHighlighted ? imageView.highlightedImage ?? imageView.image : imageView.image
+
         self.init(
-            semantics: .image(
-                .init(
-                    image: imageView.image,
-                    highlightedImage: imageView.highlightedImage,
-                    isHighlighted: imageView.isHighlighted,
-                    tintColor: imageView.tintColor
-                )
-            ),
+            semantics: .image(.init(isContextual: image?.isContextual ?? false)),
             ignoreSublayers: true
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -70,9 +70,18 @@ extension CALayerSnapshot.SemanticObservation {
             self.init(semantics: .layer)
         }
 
-        if layer.delegate is UIControl || layer.delegate is UIProgressView {
+        // Ignore image privacy for system UI chrome
+        if layer.delegate is UIControl
+            || layer.delegate is UIProgressView
+            || layer.delegate?.isBarBackground == true {
             ignoresImagePrivacy = true
         }
+    }
+}
+
+extension CALayerDelegate {
+    fileprivate var isBarBackground: Bool {
+        "\(type(of: self))" == "_UIBarBackground"
     }
 }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -42,6 +42,11 @@ extension CALayerSnapshot.SemanticObservation {
 extension CALayerSnapshot.SemanticObservation {
     @MainActor
     init(layer: CALayer, context: CALayerSnapshot.Context) {
+        self.init(layer: layer, absoluteFrame: layer.frame, context: context)
+    }
+
+    @MainActor
+    init(layer: CALayer, absoluteFrame: CGRect, context: CALayerSnapshot.Context) {
         switch layer.delegate {
         case _ as UIActivityIndicatorView:
             self.init(semantics: .activityIndicator, ignoreSublayers: true)
@@ -60,7 +65,7 @@ extension CALayerSnapshot.SemanticObservation {
             self.init(switchControl: switchControl)
         case let webView as WKWebView:
             context.webViewCache.add(webView)
-            self.init(webView: webView)
+            self.init(webView: webView, absoluteFrame: absoluteFrame)
         default:
             self.init(semantics: .layer)
         }
@@ -229,11 +234,17 @@ extension CALayerSnapshot.SemanticObservation {
 extension CALayerSnapshot.SemanticObservation {
     struct WebViewSemantics: Sendable, Equatable {
         let slotID: Int
+        let slotFrame: CGRect
     }
 
-    fileprivate init(webView: WKWebView) {
+    fileprivate init(webView: WKWebView, absoluteFrame: CGRect) {
         self.init(
-            semantics: .webView(.init(slotID: webView.hash)),
+            semantics: .webView(
+                .init(
+                    slotID: webView.hash,
+                    slotFrame: webView.sessionReplayContentFrame(from: absoluteFrame)
+                )
+            ),
             ignoreSublayers: true
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SemanticObservation.swift
@@ -140,6 +140,7 @@ extension NSAttributedString {
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct ImageSemantics: Sendable, Equatable {
+        let hasContent: Bool
         let isContextual: Bool
     }
 
@@ -147,7 +148,12 @@ extension CALayerSnapshot.SemanticObservation {
         let image = imageView.isHighlighted ? imageView.highlightedImage ?? imageView.image : imageView.image
 
         self.init(
-            semantics: .image(.init(isContextual: image?.isContextual ?? false)),
+            semantics: .image(
+                .init(
+                    hasContent: image != nil,
+                    isContextual: image?.isContextual ?? false
+                )
+            ),
             ignoreSublayers: true
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
@@ -112,7 +112,7 @@ extension CALayerSnapshot {
 
         let observation = privacy.isPrivate
             ? SemanticObservation(semantics: .layer, ignoreSublayers: true)
-            : SemanticObservation(layer: layer, context: context)
+            : SemanticObservation(layer: layer, absoluteFrame: absoluteFrame, context: context)
 
         if observation.ignoresImagePrivacy, layer.privacyOverrides?.imagePrivacy == nil {
             privacy.imagePrivacyLevel = .maskNone

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -122,6 +122,14 @@ internal class CompositionTreeBuilder {
         parentTextInput _: TextInputSemantics?
     ) -> SRCompositionLayerChild? {
         switch snapshot.observation.semantics {
+        case .label(let label):
+            guard let wireframe = SRWireframe(layerSnapshot: snapshot, label: label) else {
+                return nil
+            }
+
+            wireframes.append(wireframe)
+
+            return SRCompositionLayerChild(id: snapshot.replayID, type: .wireframe)
         case .webView(let webView):
             let wireframe = SRWireframe(layerSnapshot: snapshot, webView: webView)
 
@@ -168,6 +176,35 @@ extension SRWireframe {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init?(
+        layerSnapshot: CALayerSnapshot,
+        label: CALayerSnapshot.SemanticObservation.LabelSemantics
+    ) {
+        let text = layerSnapshot.textAndInputPrivacyLevel.staticTextObfuscator.mask(text: label.text ?? "")
+        let hasVisibleText = !text.isEmpty
+        let hasVisibleAppearance = layerSnapshot.hasBackgroundColor || layerSnapshot.hasBorder
+
+        guard hasVisibleText || hasVisibleAppearance else {
+            return nil
+        }
+
+        self = .textWireframe(
+            value: .init(
+                border: .init(layerSnapshot: layerSnapshot),
+                height: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.height),
+                id: layerSnapshot.replayID,
+                shapeStyle: .init(layerSnapshot: layerSnapshot),
+                text: text,
+                textPosition: .init(label: label),
+                textStyle: .init(label: label, frame: layerSnapshot.absoluteFrame),
+                width: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.width),
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     fileprivate init(
         layerSnapshot: CALayerSnapshot,
         webView: CALayerSnapshot.SemanticObservation.WebViewSemantics
@@ -184,6 +221,40 @@ extension SRWireframe {
                 x: Int64.ddWithNoOverflow(webView.slotFrame.minX),
                 y: Int64.ddWithNoOverflow(webView.slotFrame.minY)
             )
+        )
+    }
+}
+
+extension SRTextPosition {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init(label: CALayerSnapshot.SemanticObservation.LabelSemantics) {
+        self.init(
+            alignment: .init(systemTextAlignment: label.textAlignment)
+        )
+    }
+}
+
+extension SRTextStyle {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init(
+        label: CALayerSnapshot.SemanticObservation.LabelSemantics,
+        frame: CGRect
+    ) {
+        var fontSize = Int64.ddWithNoOverflow(label.font?.pointSize ?? .fallbackFontSize)
+
+        if let text = label.text, !text.isEmpty, label.adjustsFontSizeToFitWidth {
+            let calculatedFontSize = Int64(sqrt(frame.width * frame.height / CGFloat(text.count)))
+
+            if calculatedFontSize < fontSize {
+                fontSize = calculatedFontSize
+            }
+        }
+
+        self.init(
+            color: label.textColor.flatMap { hexString(from: $0.cgColor) } ?? .fallbackColor,
+            family: .fallbackFontFamily,
+            size: fontSize,
+            truncationMode: .init(label.lineBreakMode)
         )
     }
 }
@@ -218,5 +289,10 @@ extension SRShapeStyle {
 
 extension String {
     fileprivate static let fallbackColor = "#FF0000FF"
+    fileprivate static let fallbackFontFamily = "-apple-system, BlinkMacSystemFont, 'Roboto', sans-serif"
+}
+
+extension CGFloat {
+    fileprivate static let fallbackFontSize: Self = 10
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -120,6 +120,11 @@ internal class CompositionTreeBuilder {
         for snapshot: CALayerSnapshot,
         parentTextInput textInput: TextInputSemantics?
     ) -> SRCompositionLayerChild? {
+        guard !snapshot.isPrivate else {
+            wireframes.append(SRWireframe(placeholderFor: snapshot, label: .hiddenPlaceholder))
+            return SRCompositionLayerChild(id: snapshot.wireframeID, type: .wireframe)
+        }
+
         let wireframe: SRWireframe? = switch (
             snapshot.observation.semantics,
             imageSnapshotResults[snapshot.replayID]
@@ -218,6 +223,7 @@ internal class CompositionTreeBuilder {
 }
 
 extension String {
+    fileprivate static let hiddenPlaceholder = "Hidden"
     fileprivate static let imagePlaceholder = "Image"
     fileprivate static let contentImagePlaceholder = "Content Image"
     fileprivate static let timedOutPlaceholder = "Timed out"

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -11,6 +11,8 @@ import UIKit
 /// Builds the composition tree produced by the layer recording pipeline.
 @available(iOS 13.0, tvOS 13.0, *)
 internal class CompositionTreeBuilder {
+    private typealias TextInputSemantics = CALayerSnapshot.SemanticObservation.TextInputSemantics
+
     struct Output {
         let compositionTree: SRCompositionTree
         let wireframes: [SRWireframe]
@@ -42,7 +44,7 @@ internal class CompositionTreeBuilder {
         resources.removeAll(keepingCapacity: true)
         pendingWebViewSlotIDs = webViewSlotIDs
 
-        let rootLayer = makeCompositionLayer(from: root)
+        let rootLayer = makeCompositionLayer(from: root, parentTextInput: nil)
 
         return Output(
             compositionTree: SRCompositionTree(
@@ -54,9 +56,12 @@ internal class CompositionTreeBuilder {
         )
     }
 
-    private func makeCompositionLayer(from snapshot: CALayerSnapshot) -> SRCompositionLayer {
+    private func makeCompositionLayer(
+        from snapshot: CALayerSnapshot,
+        parentTextInput: TextInputSemantics?
+    ) -> SRCompositionLayer {
         SRCompositionLayer(
-            children: children(for: snapshot),
+            children: children(for: snapshot, parentTextInput: parentTextInput),
             compositeOperation: snapshot.compositingFilter
                 .flatMap(SRCompositionLayer.CompositeOperation.init(compositingFilter:)),
             height: Int64.ddWithNoOverflow(snapshot.absoluteFrame.height),
@@ -68,9 +73,14 @@ internal class CompositionTreeBuilder {
         )
     }
 
-    private func children(for snapshot: CALayerSnapshot) -> [SRCompositionLayerChild] {
+    private func children(
+        for snapshot: CALayerSnapshot,
+        parentTextInput: TextInputSemantics?
+    ) -> [SRCompositionLayerChild] {
+        let parentTextInput = snapshot.observation.textInputSemantics ?? parentTextInput
+
         guard !snapshot.sublayers.isEmpty else {
-            return makeWireframeReference(for: snapshot)
+            return makeWireframeReference(for: snapshot, parentTextInput: parentTextInput)
                 .map { [$0] } ?? []
         }
 
@@ -80,31 +90,37 @@ internal class CompositionTreeBuilder {
         // We don't support containers with image or custom content because `CALayer.render(in:)`
         // renders both the layer and its sublayers
         if snapshot.hasBackgroundColor || snapshot.hasBorder,
-           let backgroundWireframe = makeWireframeReference(for: snapshot) {
+           let backgroundWireframe = makeWireframeReference(for: snapshot, parentTextInput: parentTextInput) {
             children.append(backgroundWireframe)
         }
 
         children.append(
             contentsOf: snapshot.sublayers.compactMap { sublayer in
-                childReference(for: sublayer)
+                childReference(for: sublayer, parentTextInput: parentTextInput)
             }
         )
 
         return children
     }
 
-    private func childReference(for snapshot: CALayerSnapshot) -> SRCompositionLayerChild? {
+    private func childReference(
+        for snapshot: CALayerSnapshot,
+        parentTextInput: TextInputSemantics?
+    ) -> SRCompositionLayerChild? {
         guard !snapshot.sublayers.isEmpty || snapshot.requiresCompositionLayer else {
-            return makeWireframeReference(for: snapshot)
+            return makeWireframeReference(for: snapshot, parentTextInput: parentTextInput)
         }
 
-        let layer = makeCompositionLayer(from: snapshot)
+        let layer = makeCompositionLayer(from: snapshot, parentTextInput: parentTextInput)
         layers.append(layer)
 
         return .init(id: layer.id, type: .layer)
     }
 
-    private func makeWireframeReference(for snapshot: CALayerSnapshot) -> SRCompositionLayerChild? {
+    private func makeWireframeReference(
+        for _: CALayerSnapshot,
+        parentTextInput _: TextInputSemantics?
+    ) -> SRCompositionLayerChild? {
         // TBD
         nil
     }
@@ -113,6 +129,16 @@ internal class CompositionTreeBuilder {
         let result = pendingWebViewSlotIDs.map(SRWireframe.init(hiddenWebViewSlotID:))
         pendingWebViewSlotIDs.removeAll()
         return result
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+private extension CALayerSnapshot.SemanticObservation {
+    var textInputSemantics: TextInputSemantics? {
+        guard case .textInput(let textInput) = semantics else {
+            return nil
+        }
+        return textInput
     }
 }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -5,8 +5,7 @@
  */
 
 #if os(iOS)
-import Foundation
-import UIKit
+import DatadogInternal
 
 /// Builds the composition tree produced by the layer recording pipeline.
 @available(iOS 13.0, tvOS 13.0, *)
@@ -130,6 +129,14 @@ internal class CompositionTreeBuilder {
             wireframes.append(wireframe)
 
             return SRCompositionLayerChild(id: snapshot.replayID, type: .wireframe)
+        case .image:
+            guard let wireframe = makeImageWireframe(for: snapshot) else {
+                return nil
+            }
+
+            wireframes.append(wireframe)
+
+            return SRCompositionLayerChild(id: snapshot.replayID, type: .wireframe)
         case .webView(let webView):
             let wireframe = SRWireframe(layerSnapshot: snapshot, webView: webView)
 
@@ -143,11 +150,45 @@ internal class CompositionTreeBuilder {
         }
     }
 
+    private func makeImageWireframe(for layerSnapshot: CALayerSnapshot) -> SRWireframe? {
+        switch imageSnapshotResults[layerSnapshot.replayID] {
+        case .success(let imageSnapshot):
+            let resource = ImageSnapshotResource(image: imageSnapshot.image)
+            resources.append(resource)
+
+            return SRWireframe(
+                id: layerSnapshot.replayID,
+                imageSnapshot: imageSnapshot,
+                resource: resource
+            )
+        case .failure(.timedOut):
+            return SRWireframe(
+                placeholderFor: layerSnapshot,
+                label: .timedOutPlaceholder
+            )
+        case .failure(.discarded):
+            return nil
+        case .none:
+            return SRWireframe(
+                placeholderFor: layerSnapshot,
+                label: layerSnapshot.imagePrivacyLevel == .maskNonBundledOnly
+                    ? .contentImagePlaceholder
+                    : .imagePlaceholder
+            )
+        }
+    }
+
     private func makeHiddenWebViewWireframes() -> [SRWireframe] {
         let result = pendingWebViewSlotIDs.map(SRWireframe.init(hiddenWebViewSlotID:))
         pendingWebViewSlotIDs.removeAll()
         return result
     }
+}
+
+extension String {
+    fileprivate static let imagePlaceholder = "Image"
+    fileprivate static let contentImagePlaceholder = "Content Image"
+    fileprivate static let timedOutPlaceholder = "Timed out"
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
@@ -158,141 +199,5 @@ private extension CALayerSnapshot.SemanticObservation {
         }
         return textInput
     }
-}
-
-extension SRWireframe {
-    fileprivate init(hiddenWebViewSlotID slotID: Int) {
-        self = .webviewWireframe(
-            value: .init(
-                height: 0,
-                id: Int64(slotID),
-                isVisible: false,
-                slotId: String(slotID),
-                width: 0,
-                x: 0,
-                y: 0
-            )
-        )
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    fileprivate init?(
-        layerSnapshot: CALayerSnapshot,
-        label: CALayerSnapshot.SemanticObservation.LabelSemantics
-    ) {
-        let text = layerSnapshot.textAndInputPrivacyLevel.staticTextObfuscator.mask(text: label.text ?? "")
-        let hasVisibleText = !text.isEmpty
-        let hasVisibleAppearance = layerSnapshot.hasBackgroundColor || layerSnapshot.hasBorder
-
-        guard hasVisibleText || hasVisibleAppearance else {
-            return nil
-        }
-
-        self = .textWireframe(
-            value: .init(
-                border: .init(layerSnapshot: layerSnapshot),
-                height: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.height),
-                id: layerSnapshot.replayID,
-                shapeStyle: .init(layerSnapshot: layerSnapshot),
-                text: text,
-                textPosition: .init(label: label),
-                textStyle: .init(label: label, frame: layerSnapshot.absoluteFrame),
-                width: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.width),
-                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
-                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
-            )
-        )
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    fileprivate init(
-        layerSnapshot: CALayerSnapshot,
-        webView: CALayerSnapshot.SemanticObservation.WebViewSemantics
-    ) {
-        self = .webviewWireframe(
-            value: .init(
-                border: .init(layerSnapshot: layerSnapshot),
-                height: Int64.ddWithNoOverflow(webView.slotFrame.height),
-                id: Int64(webView.slotID),
-                isVisible: true,
-                shapeStyle: .init(layerSnapshot: layerSnapshot),
-                slotId: String(webView.slotID),
-                width: Int64.ddWithNoOverflow(webView.slotFrame.width),
-                x: Int64.ddWithNoOverflow(webView.slotFrame.minX),
-                y: Int64.ddWithNoOverflow(webView.slotFrame.minY)
-            )
-        )
-    }
-}
-
-extension SRTextPosition {
-    @available(iOS 13.0, tvOS 13.0, *)
-    fileprivate init(label: CALayerSnapshot.SemanticObservation.LabelSemantics) {
-        self.init(
-            alignment: .init(systemTextAlignment: label.textAlignment)
-        )
-    }
-}
-
-extension SRTextStyle {
-    @available(iOS 13.0, tvOS 13.0, *)
-    fileprivate init(
-        label: CALayerSnapshot.SemanticObservation.LabelSemantics,
-        frame: CGRect
-    ) {
-        var fontSize = Int64.ddWithNoOverflow(label.font?.pointSize ?? .fallbackFontSize)
-
-        if let text = label.text, !text.isEmpty, label.adjustsFontSizeToFitWidth {
-            let calculatedFontSize = Int64(sqrt(frame.width * frame.height / CGFloat(text.count)))
-
-            if calculatedFontSize < fontSize {
-                fontSize = calculatedFontSize
-            }
-        }
-
-        self.init(
-            color: label.textColor.flatMap { hexString(from: $0.cgColor) } ?? .fallbackColor,
-            family: .fallbackFontFamily,
-            size: fontSize,
-            truncationMode: .init(label.lineBreakMode)
-        )
-    }
-}
-
-extension SRShapeBorder {
-    @available(iOS 13.0, tvOS 13.0, *)
-    fileprivate init?(layerSnapshot: CALayerSnapshot) {
-        guard
-            let borderColor = layerSnapshot.borderColor,
-            layerSnapshot.borderWidth > 0
-        else {
-            return nil
-        }
-        self.init(
-            color: hexString(from: borderColor) ?? .fallbackColor,
-            width: Int64.ddWithNoOverflow(layerSnapshot.borderWidth.rounded(.up))
-        )
-    }
-}
-extension SRShapeStyle {
-    @available(iOS 13.0, tvOS 13.0, *)
-    fileprivate init?(layerSnapshot: CALayerSnapshot) {
-        guard let backgroundColor = layerSnapshot.backgroundColor else {
-            return nil
-        }
-        self.init(
-            backgroundColor: hexString(from: backgroundColor) ?? .fallbackColor,
-            cornerRadius: layerSnapshot.cornerRadii.uniformCornerRadius.map(Double.init),
-        )
-    }
-}
-
-extension String {
-    fileprivate static let fallbackColor = "#FF0000FF"
-    fileprivate static let fallbackFontFamily = "-apple-system, BlinkMacSystemFont, 'Roboto', sans-serif"
-}
-
-extension CGFloat {
-    fileprivate static let fallbackFontSize: Self = 10
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -118,49 +118,76 @@ internal class CompositionTreeBuilder {
 
     private func makeWireframeReference(
         for snapshot: CALayerSnapshot,
-        parentTextInput _: TextInputSemantics?
+        parentTextInput textInput: TextInputSemantics?
     ) -> SRCompositionLayerChild? {
-        switch snapshot.observation.semantics {
-        case .label(let label):
-            guard let wireframe = SRWireframe(layerSnapshot: snapshot, label: label) else {
-                return nil
-            }
-
-            wireframes.append(wireframe)
-
-            return SRCompositionLayerChild(id: snapshot.replayID, type: .wireframe)
-        case .image:
-            guard let wireframe = makeImageWireframe(for: snapshot) else {
-                return nil
-            }
-
-            wireframes.append(wireframe)
-
-            return SRCompositionLayerChild(id: snapshot.replayID, type: .wireframe)
-        case .webView(let webView):
-            let wireframe = SRWireframe(layerSnapshot: snapshot, webView: webView)
-
-            wireframes.append(wireframe)
-            pendingWebViewSlotIDs.remove(webView.slotID)
-
-            return SRCompositionLayerChild(id: Int64(webView.slotID), type: .wireframe)
-        // TBD
+        let wireframe: SRWireframe? = switch (
+            snapshot.observation.semantics,
+            imageSnapshotResults[snapshot.replayID]
+        ) {
+        case (.layer, .some(let result)),
+            (.activityIndicator, .some(let result)),
+            (.image, .some(let result)),
+            (.stepper, .some(let result)),
+            (.switchControl, .some(let result)):
+            makeImageSnapshotWireframe(for: snapshot, result: result, parentTextInput: textInput)
+        case (.layer, .none):
+            SRWireframe(layerSnapshot: snapshot)
+        case (.label(let label), _):
+            SRWireframe(layerSnapshot: snapshot, label: label)
+        case (.textInput, .none):
+            SRWireframe(layerSnapshot: snapshot)
+        case (.image, .none):
+            // Private image
+            SRWireframe(
+                placeholderFor: snapshot,
+                label: snapshot.imagePrivacyLevel == .maskNonBundledOnly
+                    ? .contentImagePlaceholder
+                    : .imagePlaceholder
+            )
+        case (.webView(let webView), _):
+            makeVisibleWebViewWireframe(for: snapshot, webView: webView)
         default:
+            nil
+        }
+
+        guard let wireframe else {
             return nil
         }
+
+        wireframes.append(wireframe)
+        return SRCompositionLayerChild(id: snapshot.wireframeID, type: .wireframe)
     }
 
-    private func makeImageWireframe(for layerSnapshot: CALayerSnapshot) -> SRWireframe? {
-        switch imageSnapshotResults[layerSnapshot.replayID] {
+    private func makeImageSnapshotWireframe(
+        for layerSnapshot: CALayerSnapshot,
+        result: ImageSnapshotResult,
+        parentTextInput textInput: TextInputSemantics?
+    ) -> SRWireframe? {
+        switch result {
         case .success(let imageSnapshot):
-            let resource = ImageSnapshotResource(image: imageSnapshot.image)
-            resources.append(resource)
+            do {
+                switch try imageSnapshot.redacted(parentTextInput: textInput) {
+                case .image(let image):
+                    let resource = ImageSnapshotResource(image: image)
+                    resources.append(resource)
 
-            return SRWireframe(
-                id: layerSnapshot.replayID,
-                imageSnapshot: imageSnapshot,
-                resource: resource
-            )
+                    return SRWireframe(
+                        id: layerSnapshot.replayID,
+                        imageSnapshot: imageSnapshot,
+                        resource: resource
+                    )
+                case .placeholder(let color):
+                    return SRWireframe(
+                        layerSnapshot: layerSnapshot,
+                        placeholderColor: color
+                    )
+                }
+            } catch {
+                return SRWireframe(
+                    placeholderFor: layerSnapshot,
+                    label: .redactedPlaceholder
+                )
+            }
         case .failure(.timedOut):
             return SRWireframe(
                 placeholderFor: layerSnapshot,
@@ -168,14 +195,16 @@ internal class CompositionTreeBuilder {
             )
         case .failure(.discarded):
             return nil
-        case .none:
-            return SRWireframe(
-                placeholderFor: layerSnapshot,
-                label: layerSnapshot.imagePrivacyLevel == .maskNonBundledOnly
-                    ? .contentImagePlaceholder
-                    : .imagePlaceholder
-            )
         }
+    }
+
+    private func makeVisibleWebViewWireframe(
+        for layerSnapshot: CALayerSnapshot,
+        webView: CALayerSnapshot.SemanticObservation.WebViewSemantics
+    ) -> SRWireframe {
+        let wireframe = SRWireframe(layerSnapshot: layerSnapshot, webView: webView)
+        pendingWebViewSlotIDs.remove(webView.slotID)
+        return wireframe
     }
 
     private func makeHiddenWebViewWireframes() -> [SRWireframe] {
@@ -189,6 +218,19 @@ extension String {
     fileprivate static let imagePlaceholder = "Image"
     fileprivate static let contentImagePlaceholder = "Content Image"
     fileprivate static let timedOutPlaceholder = "Timed out"
+    fileprivate static let redactedPlaceholder = "Redacted"
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+private extension CALayerSnapshot {
+    var wireframeID: Int64 {
+        switch observation.semantics {
+        case .webView(let webView):
+            return Int64(webView.slotID)
+        default:
+            return replayID
+        }
+    }
 }
 
 @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -136,7 +136,7 @@ internal class CompositionTreeBuilder {
             SRWireframe(layerSnapshot: snapshot, label: label)
         case (.textInput, .none):
             SRWireframe(layerSnapshot: snapshot)
-        case (.image, .none):
+        case (.image(let image), .none) where image.hasContent:
             // Private image
             SRWireframe(
                 placeholderFor: snapshot,
@@ -144,6 +144,9 @@ internal class CompositionTreeBuilder {
                     ? .contentImagePlaceholder
                     : .imagePlaceholder
             )
+        case (.image, .none):
+            // Empty image
+            SRWireframe(layerSnapshot: snapshot)
         case (.webView(let webView), _):
             makeVisibleWebViewWireframe(for: snapshot, webView: webView)
         default:

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -118,11 +118,21 @@ internal class CompositionTreeBuilder {
     }
 
     private func makeWireframeReference(
-        for _: CALayerSnapshot,
+        for snapshot: CALayerSnapshot,
         parentTextInput _: TextInputSemantics?
     ) -> SRCompositionLayerChild? {
+        switch snapshot.observation.semantics {
+        case .webView(let webView):
+            let wireframe = SRWireframe(layerSnapshot: snapshot, webViewSlotID: webView.slotID)
+
+            wireframes.append(wireframe)
+            pendingWebViewSlotIDs.remove(webView.slotID)
+
+            return SRCompositionLayerChild(id: Int64(webView.slotID), type: .wireframe)
         // TBD
-        nil
+        default:
+            return nil
+        }
     }
 
     private func makeHiddenWebViewWireframes() -> [SRWireframe] {
@@ -156,5 +166,54 @@ extension SRWireframe {
             )
         )
     }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init(layerSnapshot: CALayerSnapshot, webViewSlotID slotID: Int) {
+        self = .webviewWireframe(
+            value: .init(
+                border: .init(layerSnapshot: layerSnapshot),
+                height: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.height),
+                id: Int64(slotID),
+                isVisible: true,
+                shapeStyle: .init(layerSnapshot: layerSnapshot),
+                slotId: String(slotID),
+                width: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.width),
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+            )
+        )
+    }
+}
+
+extension SRShapeBorder {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init?(layerSnapshot: CALayerSnapshot) {
+        guard
+            let borderColor = layerSnapshot.borderColor,
+            layerSnapshot.borderWidth > 0
+        else {
+            return nil
+        }
+        self.init(
+            color: hexString(from: borderColor) ?? .fallbackColor,
+            width: Int64.ddWithNoOverflow(layerSnapshot.borderWidth.rounded(.up))
+        )
+    }
+}
+extension SRShapeStyle {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init?(layerSnapshot: CALayerSnapshot) {
+        guard let backgroundColor = layerSnapshot.backgroundColor else {
+            return nil
+        }
+        self.init(
+            backgroundColor: hexString(from: backgroundColor) ?? .fallbackColor,
+            cornerRadius: layerSnapshot.cornerRadii.uniformCornerRadius.map(Double.init),
+        )
+    }
+}
+
+extension String {
+    fileprivate static let fallbackColor = "#FF0000FF"
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -123,7 +123,7 @@ internal class CompositionTreeBuilder {
     ) -> SRCompositionLayerChild? {
         switch snapshot.observation.semantics {
         case .webView(let webView):
-            let wireframe = SRWireframe(layerSnapshot: snapshot, webViewSlotID: webView.slotID)
+            let wireframe = SRWireframe(layerSnapshot: snapshot, webView: webView)
 
             wireframes.append(wireframe)
             pendingWebViewSlotIDs.remove(webView.slotID)
@@ -168,18 +168,21 @@ extension SRWireframe {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    fileprivate init(layerSnapshot: CALayerSnapshot, webViewSlotID slotID: Int) {
+    fileprivate init(
+        layerSnapshot: CALayerSnapshot,
+        webView: CALayerSnapshot.SemanticObservation.WebViewSemantics
+    ) {
         self = .webviewWireframe(
             value: .init(
                 border: .init(layerSnapshot: layerSnapshot),
-                height: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.height),
-                id: Int64(slotID),
+                height: Int64.ddWithNoOverflow(webView.slotFrame.height),
+                id: Int64(webView.slotID),
                 isVisible: true,
                 shapeStyle: .init(layerSnapshot: layerSnapshot),
-                slotId: String(slotID),
-                width: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.width),
-                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
-                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+                slotId: String(webView.slotID),
+                width: Int64.ddWithNoOverflow(webView.slotFrame.width),
+                x: Int64.ddWithNoOverflow(webView.slotFrame.minX),
+                y: Int64.ddWithNoOverflow(webView.slotFrame.minY)
             )
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -1,0 +1,134 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import UIKit
+
+/// Builds the composition tree produced by the layer recording pipeline.
+@available(iOS 13.0, tvOS 13.0, *)
+internal class CompositionTreeBuilder {
+    struct Output {
+        let compositionTree: SRCompositionTree
+        let wireframes: [SRWireframe]
+        let resources: [Resource]
+    }
+
+    private let root: CALayerSnapshot
+    private let imageSnapshotResults: [Int64: ImageSnapshotResult]
+    private let webViewSlotIDs: Set<Int>
+
+    private var layers: [SRCompositionLayer] = []
+    private var wireframes: [SRWireframe] = []
+    private var resources: [Resource] = []
+    private var pendingWebViewSlotIDs: Set<Int> = []
+
+    init(
+        root: CALayerSnapshot,
+        webViewSlotIDs: Set<Int>,
+        imageSnapshotResults: [Int64: ImageSnapshotResult]
+    ) {
+        self.root = root
+        self.webViewSlotIDs = webViewSlotIDs
+        self.imageSnapshotResults = imageSnapshotResults
+    }
+
+    func build() -> Output {
+        layers.removeAll(keepingCapacity: true)
+        wireframes.removeAll(keepingCapacity: true)
+        resources.removeAll(keepingCapacity: true)
+        pendingWebViewSlotIDs = webViewSlotIDs
+
+        let rootLayer = makeCompositionLayer(from: root)
+
+        return Output(
+            compositionTree: SRCompositionTree(
+                layers: layers,
+                root: rootLayer
+            ),
+            wireframes: makeHiddenWebViewWireframes() + wireframes,
+            resources: resources
+        )
+    }
+
+    private func makeCompositionLayer(from snapshot: CALayerSnapshot) -> SRCompositionLayer {
+        SRCompositionLayer(
+            children: children(for: snapshot),
+            compositeOperation: snapshot.compositingFilter
+                .flatMap(SRCompositionLayer.CompositeOperation.init(compositingFilter:)),
+            height: Int64.ddWithNoOverflow(snapshot.absoluteFrame.height),
+            id: snapshot.replayID,
+            modifiers: snapshot.modifiers(),
+            width: Int64.ddWithNoOverflow(snapshot.absoluteFrame.width),
+            x: Int64.ddWithNoOverflow(snapshot.absoluteFrame.minX),
+            y: Int64.ddWithNoOverflow(snapshot.absoluteFrame.minY)
+        )
+    }
+
+    private func children(for snapshot: CALayerSnapshot) -> [SRCompositionLayerChild] {
+        guard !snapshot.sublayers.isEmpty else {
+            return makeWireframeReference(for: snapshot)
+                .map { [$0] } ?? []
+        }
+
+        var children: [SRCompositionLayerChild] = []
+
+        // Append a wireframe for the layer background color
+        // We don't support containers with image or custom content because `CALayer.render(in:)`
+        // renders both the layer and its sublayers
+        if snapshot.hasBackgroundColor || snapshot.hasBorder,
+           let backgroundWireframe = makeWireframeReference(for: snapshot) {
+            children.append(backgroundWireframe)
+        }
+
+        children.append(
+            contentsOf: snapshot.sublayers.compactMap { sublayer in
+                childReference(for: sublayer)
+            }
+        )
+
+        return children
+    }
+
+    private func childReference(for snapshot: CALayerSnapshot) -> SRCompositionLayerChild? {
+        guard !snapshot.sublayers.isEmpty || snapshot.requiresCompositionLayer else {
+            return makeWireframeReference(for: snapshot)
+        }
+
+        let layer = makeCompositionLayer(from: snapshot)
+        layers.append(layer)
+
+        return .init(id: layer.id, type: .layer)
+    }
+
+    private func makeWireframeReference(for snapshot: CALayerSnapshot) -> SRCompositionLayerChild? {
+        // TBD
+        nil
+    }
+
+    private func makeHiddenWebViewWireframes() -> [SRWireframe] {
+        let result = pendingWebViewSlotIDs.map(SRWireframe.init(hiddenWebViewSlotID:))
+        pendingWebViewSlotIDs.removeAll()
+        return result
+    }
+}
+
+extension SRWireframe {
+    fileprivate init(hiddenWebViewSlotID slotID: Int) {
+        self = .webviewWireframe(
+            value: .init(
+                height: 0,
+                id: Int64(slotID),
+                isVisible: false,
+                slotId: String(slotID),
+                width: 0,
+                x: 0,
+                y: 0
+            )
+        )
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotResource.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotResource.swift
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import DatadogInternal
+import UIKit
+
+@available(iOS 13.0, tvOS 13.0, *)
+internal struct ImageSnapshotResource: Resource {
+    let image: UIImage
+
+    var mimeType: String {
+        "image/png"
+    }
+
+    func calculateIdentifier() -> String {
+        image.dd.identifier
+    }
+
+    func calculateData() -> Data {
+        image.dd.pngData() ?? Data()
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecorder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecorder.swift
@@ -61,21 +61,23 @@ internal actor LayerRecorder: LayerRecording {
         let (layerTreeSnapshot, touchSnapshot) = await takeSnapshot(context: context)
 
         guard
-            let layerTreeSnapshot,
+            var layerTreeSnapshot,
             let root = layerTreeSnapshot.root.removingOccluded()
         else {
             return
         }
 
+        layerTreeSnapshot.root = root
+
         let remainingTime = max(0, timeoutInterval - (timeSource.now - startTime))
         let imageSnapshots = await imageSnapshotter.takeImageSnapshots(
-            for: root,
+            for: layerTreeSnapshot.root,
             changeset: changeset,
             timeout: remainingTime
         )
 
-        _ = (root, touchSnapshot, imageSnapshots)
-        // TODO: PANA-7592 Process optimized layer tree, image snapshots, and touch snapshots
+        _ = (layerTreeSnapshot, touchSnapshot, imageSnapshots)
+        // TODO: PANA-7784 Process optimized layer tree, image snapshots, and touch snapshots
     }
 
     private func takeSnapshot(context: LayerRecordingContext) async -> (LayerTreeSnapshot?, TouchSnapshot?) {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeSnapshotBuilder.swift
@@ -14,7 +14,7 @@ internal struct LayerTreeSnapshot: Sendable {
     let date: Date
     let context: LayerRecordingContext
     let viewportSize: CGSize
-    let root: CALayerSnapshot
+    var root: CALayerSnapshot
     let webViewSlotIDs: Set<Int>
 }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
@@ -203,7 +203,7 @@ extension SRShapeStyle {
         }
         self.init(
             backgroundColor: hexString(from: backgroundColor) ?? .fallbackColor,
-            cornerRadius: layerSnapshot.cornerRadii.uniformCornerRadius.map(Double.init),
+            cornerRadius: layerSnapshot.cornerRadii.uniformCornerRadius.map(Double.init)
         )
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
@@ -1,0 +1,186 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import DatadogInternal
+import Foundation
+import UIKit
+
+extension SRWireframe {
+    @available(iOS 13.0, tvOS 13.0, *)
+    init(hiddenWebViewSlotID slotID: Int) {
+        self = .webviewWireframe(
+            value: .init(
+                height: 0,
+                id: Int64(slotID),
+                isVisible: false,
+                slotId: String(slotID),
+                width: 0,
+                x: 0,
+                y: 0
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    init?(
+        layerSnapshot: CALayerSnapshot,
+        label: CALayerSnapshot.SemanticObservation.LabelSemantics
+    ) {
+        let text = layerSnapshot.textAndInputPrivacyLevel.staticTextObfuscator.mask(text: label.text ?? "")
+        let hasVisibleText = !text.isEmpty
+        let hasVisibleAppearance = layerSnapshot.hasBackgroundColor || layerSnapshot.hasBorder
+
+        guard hasVisibleText || hasVisibleAppearance else {
+            return nil
+        }
+
+        self = .textWireframe(
+            value: .init(
+                border: .init(layerSnapshot: layerSnapshot),
+                height: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.height),
+                id: layerSnapshot.replayID,
+                shapeStyle: .init(layerSnapshot: layerSnapshot),
+                text: text,
+                textPosition: .init(label: label),
+                textStyle: .init(label: label, frame: layerSnapshot.absoluteFrame),
+                width: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.width),
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    init(
+        id: Int64,
+        imageSnapshot: ImageSnapshot,
+        resource: Resource
+    ) {
+        self = .imageWireframe(
+            value: .init(
+                height: Int64.ddWithNoOverflow(imageSnapshot.frame.height),
+                id: id,
+                isEmpty: false,
+                mimeType: resource.mimeType,
+                resourceId: resource.calculateIdentifier(),
+                width: Int64.ddWithNoOverflow(imageSnapshot.frame.width),
+                x: Int64.ddWithNoOverflow(imageSnapshot.frame.minX),
+                y: Int64.ddWithNoOverflow(imageSnapshot.frame.minY)
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    init(
+        placeholderFor layerSnapshot: CALayerSnapshot,
+        label: String
+    ) {
+        self = .placeholderWireframe(
+            value: .init(
+                height: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.height),
+                id: layerSnapshot.replayID,
+                label: label,
+                width: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.width),
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    init(
+        layerSnapshot: CALayerSnapshot,
+        webView: CALayerSnapshot.SemanticObservation.WebViewSemantics
+    ) {
+        self = .webviewWireframe(
+            value: .init(
+                border: .init(layerSnapshot: layerSnapshot),
+                height: Int64.ddWithNoOverflow(webView.slotFrame.height),
+                id: Int64(webView.slotID),
+                isVisible: true,
+                shapeStyle: .init(layerSnapshot: layerSnapshot),
+                slotId: String(webView.slotID),
+                width: Int64.ddWithNoOverflow(webView.slotFrame.width),
+                x: Int64.ddWithNoOverflow(webView.slotFrame.minX),
+                y: Int64.ddWithNoOverflow(webView.slotFrame.minY)
+            )
+        )
+    }
+}
+
+extension SRTextPosition {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init(label: CALayerSnapshot.SemanticObservation.LabelSemantics) {
+        self.init(
+            alignment: .init(systemTextAlignment: label.textAlignment)
+        )
+    }
+}
+
+extension SRTextStyle {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init(
+        label: CALayerSnapshot.SemanticObservation.LabelSemantics,
+        frame: CGRect
+    ) {
+        var fontSize = Int64.ddWithNoOverflow(label.font?.pointSize ?? .fallbackFontSize)
+
+        if let text = label.text, !text.isEmpty, label.adjustsFontSizeToFitWidth {
+            let calculatedFontSize = Int64(sqrt(frame.width * frame.height / CGFloat(text.count)))
+
+            if calculatedFontSize < fontSize {
+                fontSize = calculatedFontSize
+            }
+        }
+
+        self.init(
+            color: label.textColor.flatMap { hexString(from: $0.cgColor) } ?? .fallbackColor,
+            family: .fallbackFontFamily,
+            size: fontSize,
+            truncationMode: .init(label.lineBreakMode)
+        )
+    }
+}
+
+extension SRShapeBorder {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init?(layerSnapshot: CALayerSnapshot) {
+        guard
+            let borderColor = layerSnapshot.borderColor,
+            layerSnapshot.borderWidth > 0
+        else {
+            return nil
+        }
+        self.init(
+            color: hexString(from: borderColor) ?? .fallbackColor,
+            width: Int64.ddWithNoOverflow(layerSnapshot.borderWidth.rounded(.up))
+        )
+    }
+}
+
+extension SRShapeStyle {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate init?(layerSnapshot: CALayerSnapshot) {
+        guard let backgroundColor = layerSnapshot.backgroundColor else {
+            return nil
+        }
+        self.init(
+            backgroundColor: hexString(from: backgroundColor) ?? .fallbackColor,
+            cornerRadius: layerSnapshot.cornerRadii.uniformCornerRadius.map(Double.init),
+        )
+    }
+}
+
+extension String {
+    fileprivate static let fallbackColor = "#FF0000FF"
+    fileprivate static let fallbackFontFamily = "-apple-system, BlinkMacSystemFont, 'Roboto', sans-serif"
+}
+
+extension CGFloat {
+    fileprivate static let fallbackFontSize: Self = 10
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
@@ -26,6 +26,39 @@ extension SRWireframe {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    init?(layerSnapshot: CALayerSnapshot) {
+        guard layerSnapshot.hasBackgroundColor || layerSnapshot.hasBorder else {
+            return nil
+        }
+
+        self = .shapeWireframe(
+            value: .init(
+                border: .init(layerSnapshot: layerSnapshot),
+                height: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.height),
+                id: layerSnapshot.replayID,
+                shapeStyle: .init(layerSnapshot: layerSnapshot),
+                width: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.width),
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    init(layerSnapshot: CALayerSnapshot, placeholderColor: UIColor) {
+        self = .shapeWireframe(
+            value: .init(
+                height: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.height),
+                id: layerSnapshot.replayID,
+                shapeStyle: .init(backgroundColor: hexString(from: placeholderColor.cgColor) ?? .fallbackColor),
+                width: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.width),
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     init?(
         layerSnapshot: CALayerSnapshot,
         label: CALayerSnapshot.SemanticObservation.LabelSemantics

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/Path+CornerRadii.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/Path+CornerRadii.swift
@@ -1,0 +1,158 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import SwiftUI
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension SwiftUI.Path {
+    init(roundedRect rect: CGRect, cornerRadii: CALayerSnapshot.CornerRadii, cornerCurve: CALayerCornerCurve) {
+        if cornerRadii == .zero {
+            self.init(rect)
+        } else if #available(iOS 16.0, tvOS 16.0, *), let rectangleCornerRadii = RectangleCornerRadii(cornerRadii: cornerRadii) {
+            self.init(
+                roundedRect: rect,
+                cornerRadii: rectangleCornerRadii,
+                style: .init(cornerCurve: cornerCurve)
+            )
+        } else {
+            // It's OK to ignore `cornerCurve` and use the `.circular` approximation in this case,
+            // since we don't know the exact curve Apple use for `.continuous`
+            let rect = rect.standardized
+            let cornerRadii = cornerRadii.clamped(to: rect)
+
+            self.init { path in
+                path.move(to: CGPoint(x: rect.minX + cornerRadii.topLeft.width, y: rect.minY))
+
+                path.addLine(to: CGPoint(x: rect.maxX - cornerRadii.topRight.width, y: rect.minY))
+                path.addCurve(
+                    to: CGPoint(x: rect.maxX, y: rect.minY + cornerRadii.topRight.height),
+                    control1: CGPoint(
+                        x: rect.maxX - cornerRadii.topRight.width + cornerRadii.topRight.width * .bezierKappa,
+                        y: rect.minY
+                    ),
+                    control2: CGPoint(
+                        x: rect.maxX,
+                        y: rect.minY + cornerRadii.topRight.height - cornerRadii.topRight.height * .bezierKappa
+                    )
+                )
+
+                path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - cornerRadii.bottomRight.height))
+                path.addCurve(
+                    to: CGPoint(x: rect.maxX - cornerRadii.bottomRight.width, y: rect.maxY),
+                    control1: CGPoint(
+                        x: rect.maxX,
+                        y: rect.maxY - cornerRadii.bottomRight.height + cornerRadii.bottomRight.height * .bezierKappa
+                    ),
+                    control2: CGPoint(
+                        x: rect.maxX - cornerRadii.bottomRight.width + cornerRadii.bottomRight.width * .bezierKappa,
+                        y: rect.maxY
+                    )
+                )
+
+                path.addLine(to: CGPoint(x: rect.minX + cornerRadii.bottomLeft.width, y: rect.maxY))
+                path.addCurve(
+                    to: CGPoint(x: rect.minX, y: rect.maxY - cornerRadii.bottomLeft.height),
+                    control1: CGPoint(
+                        x: rect.minX + cornerRadii.bottomLeft.width - cornerRadii.bottomLeft.width * .bezierKappa,
+                        y: rect.maxY
+                    ),
+                    control2: CGPoint(
+                        x: rect.minX,
+                        y: rect.maxY - cornerRadii.bottomLeft.height + cornerRadii.bottomLeft.height * .bezierKappa
+                    )
+                )
+
+                path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + cornerRadii.topLeft.height))
+                path.addCurve(
+                    to: CGPoint(x: rect.minX + cornerRadii.topLeft.width, y: rect.minY),
+                    control1: CGPoint(
+                        x: rect.minX,
+                        y: rect.minY + cornerRadii.topLeft.height - cornerRadii.topLeft.height * .bezierKappa
+                    ),
+                    control2: CGPoint(
+                        x: rect.minX + cornerRadii.topLeft.width - cornerRadii.topLeft.width * .bezierKappa,
+                        y: rect.minY
+                    )
+                )
+
+                path.closeSubpath()
+            }
+        }
+    }
+}
+
+extension CGFloat {
+    /// A constant used to approximate a 90 degree circular arc with a cubic Bézier curve
+    fileprivate static let bezierKappa: CGFloat = 0.5522847498307933
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot.CornerRadii {
+    fileprivate func clamped(to rect: CGRect) -> Self {
+        .init(
+            topLeft: .init(
+                width: min(max(topLeft.width, 0), rect.width / 2),
+                height: min(max(topLeft.height, 0), rect.height / 2)
+            ),
+            topRight: .init(
+                width: min(max(topRight.width, 0), rect.width / 2),
+                height: min(max(topRight.height, 0), rect.height / 2)
+            ),
+            bottomLeft: .init(
+                width: min(max(bottomLeft.width, 0), rect.width / 2),
+                height: min(max(bottomLeft.height, 0), rect.height / 2)
+            ),
+            bottomRight: .init(
+                width: min(max(bottomRight.width, 0), rect.width / 2),
+                height: min(max(bottomRight.height, 0), rect.height / 2)
+            )
+        )
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension RoundedCornerStyle {
+    fileprivate init(cornerCurve: CALayerCornerCurve) {
+        switch cornerCurve {
+        case .circular:
+            self = .circular
+        case .continuous:
+            self = .continuous
+        default:
+            self = .circular
+        }
+    }
+}
+
+@available(iOS 16.0, tvOS 16.0, *)
+extension RectangleCornerRadii {
+    fileprivate init?(cornerRadii: CALayerSnapshot.CornerRadii) {
+        guard
+            cornerRadii.topLeft.isSquare,
+            cornerRadii.topRight.isSquare,
+            cornerRadii.bottomLeft.isSquare,
+            cornerRadii.bottomRight.isSquare
+        else {
+            return nil
+        }
+
+        self.init(
+            topLeading: cornerRadii.topLeft.width,
+            bottomLeading: cornerRadii.bottomLeft.width,
+            bottomTrailing: cornerRadii.bottomRight.width,
+            topTrailing: cornerRadii.topRight.width
+        )
+    }
+}
+
+extension CGSize {
+    fileprivate var isSquare: Bool {
+        return width == height
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/WKWebView+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/WKWebView+SessionReplay.swift
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import UIKit
+import WebKit
+
+extension WKWebView {
+    func sessionReplayContentFrame(from frame: CGRect) -> CGRect {
+        guard let frameOffset = sessionReplayContentFrameOffset(for: frame) else {
+            return frame
+        }
+
+        return frame.offsetBy(dx: 0, dy: frameOffset)
+    }
+
+    private func sessionReplayContentFrameOffset(for frame: CGRect) -> CGFloat? {
+        // When `contentInsetAdjustmentBehavior` is set to `.automatic` or `.always`, WebKit
+        // internally adjusts the web content viewport to account for safe area insets. This
+        // creates a mismatch between the native frame position (which can start at y=0) and
+        // where the web content actually renders (which starts below the safe area).
+        //
+        // To compensate for this, we need to offset the webview frame ensuring that:
+        // - Native touch coordinates align with web content touch coordinates
+        // - Web content from the Browser SDK integration displays at the expected position
+        guard scrollView.contentInsetAdjustmentBehavior != .never else {
+            return nil
+        }
+
+        let safeAreaTop = safeAreaInsets.top
+
+        if frame.minY < safeAreaTop {
+            // This offset is based on empirical testing and investigation.
+            // WebKit appears to apply internal coordinate transformations that
+            // create a mismatch between the native frame position and where web
+            // content renders.
+            // We don't fully understand the exact WebKit internal behavior causing
+            // the issue, but applying this offset resolves the coordinate mismatch.
+            return safeAreaTop / (window?.screen.scale ?? 1)
+        }
+
+        return nil
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorder.swift
@@ -25,44 +25,11 @@ internal class WKWebViewRecorder: NodeRecorder {
 
         // Adjust the frame for webviews that extends beyond safe area (RUM-6227)
         var adjustedAttributes = attributes
-        if let frameAdjustment = calculateFrameOffset(for: webView, with: attributes) {
-            adjustedAttributes.frame = attributes.frame.offsetBy(dx: 0, dy: frameAdjustment)
-        }
+        adjustedAttributes.frame = webView.sessionReplayContentFrame(from: attributes.frame)
 
         let builder = WKWebViewWireframesBuilder(slotID: webView.hash, attributes: adjustedAttributes)
         let node = Node(viewAttributes: adjustedAttributes, wireframesBuilder: builder)
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
-    }
-
-    private func calculateFrameOffset(
-        for webView: WKWebView,
-        with attributes: ViewAttributes
-    ) -> CGFloat? {
-        // When `contentInsetAdjustmentBehavior` is set to `.automatic` or `.always`, WebKit
-        // internally adjusts the web content viewport to account for safe area insets. This
-        // creates a mismatch between the native frame position (which can start at y=0) and
-        // where the web content actually renders (which starts below the safe area).
-        //
-        // To compensate for this, we need to offset the webview frame ensuring that:
-        // - Native touch coordinates align with web content touch coordinates
-        // - Web content from the Browser SDK integration displays at the expected position
-        guard webView.scrollView.contentInsetAdjustmentBehavior != .never else {
-            return nil
-        }
-
-        let safeAreaTop = webView.safeAreaInsets.top
-
-        if attributes.frame.minY < safeAreaTop {
-            // This offset is based on empirical testing and investigation.
-            // WebKit appears to apply internal coordinate transformations that
-            // create a mismatch between the native frame position and where web
-            // content renders.
-            // We don't fully understand the exact WebKit internal behavior causing
-            // the issue, but applying this offset resolves the coordinate mismatch.
-            return safeAreaTop / (webView.window?.screen.scale ?? 1)
-        }
-
-        return nil
     }
 }
 

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -146,6 +146,23 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Skips empty semantic image layer")
+    func skipsEmptySemanticImageLayer() throws {
+        // Given
+        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
+        imageView.layer.contents = NSObject()
+
+        let snapshot = try #require(CALayerSnapshot(from: imageView.layer, in: .mockAny(imagePrivacyLevel: .maskNone)))
+        let cache = ImageSnapshotCache()
+
+        // When
+        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
+
+        // Then
+        #expect(requests.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips semantic image layer when image privacy masks all")
     func skipsSemanticImageLayerWhenImagePrivacyMasksAll() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSRCompositionLayerTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSRCompositionLayerTests.swift
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import QuartzCore
+import Testing
+import UIKit
+
+@_spi(Internal)
+@testable import DatadogSessionReplay
+
+@MainActor
+struct CALayerSnapshotSRCompositionLayerTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates modifiers in rendering order")
+    func createsModifiersInRenderingOrder() throws {
+        // Given
+        let filter = try NSObject.makeCAFilter(type: "colorBrightness")
+        filter.setValue(CGFloat(0.25), forKey: "inputAmount")
+
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 50)
+        layer.masksToBounds = true
+        layer.filters = [filter]
+        layer.opacity = 0.5
+
+        let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+
+        // When
+        let modifiers = snapshot.modifiers()
+
+        // Then
+        #expect(snapshot.requiresCompositionLayer)
+        #expect(modifierTypes(modifiers) == ["clip", "brightnessBias", "opacity"])
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Maps multiply color filters to color matrix modifiers")
+    func mapsMultiplyColorFiltersToColorMatrixModifiers() throws {
+        // Given
+        let filter = try NSObject.makeCAFilter(type: "multiplyColor")
+        filter.setValue(CGColor(red: 0.25, green: 0.5, blue: 0.75, alpha: 0.8), forKey: "inputColor")
+
+        let layer = CALayer()
+        layer.bounds = CGRect(x: 0, y: 0, width: 100, height: 50)
+        layer.filters = [filter]
+
+        let snapshot = try #require(CALayerSnapshot(from: layer, in: .mockAny()))
+
+        // When
+        let modifiers = snapshot.modifiers()
+
+        // Then
+        let modifier = try #require(modifiers.first)
+        guard case .compositionLayerColorMatrixModifier(let colorMatrix) = modifier else {
+            Issue.record("Expected a color matrix modifier")
+            return
+        }
+
+        #expect(snapshot.requiresCompositionLayer)
+        #expect(colorMatrix.matrix.count == 20)
+        #expect(colorMatrix.matrix[0] > 0)
+        #expect(colorMatrix.matrix[6] > 0)
+        #expect(colorMatrix.matrix[12] > 0)
+        #expect(colorMatrix.matrix[18] > 0)
+        #expect(colorMatrix.matrix.enumerated().allSatisfy { index, value in
+            [0, 6, 12, 18].contains(index) || value == 0
+        })
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    private func modifierTypes(_ modifiers: [SRCompositionLayerModifier]) -> [String] {
+        modifiers.map { modifier in
+            switch modifier {
+            case .compositionLayerClipModifier:
+                "clip"
+            case .compositionLayerOpacityModifier:
+                "opacity"
+            case .compositionLayerColorMatrixModifier:
+                "colorMatrix"
+            case .compositionLayerGaussianBlurModifier:
+                "gaussianBlur"
+            case .compositionLayerBrightnessBiasModifier:
+                "brightnessBias"
+            case .compositionLayerSaturateModifier:
+                "saturate"
+            case .compositionLayerBackgroundMaterialModifier:
+                "backgroundMaterial"
+            }
+        }
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -135,7 +135,7 @@ struct CALayerSnapshotSemanticObservationTests {
         // Then
         #expect(observation == .init(
             semantics: .image(
-                .init(isContextual: false)
+                .init(hasContent: true, isContextual: false)
             ),
             ignoreSublayers: true
         ))

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -126,11 +126,8 @@ struct CALayerSnapshotSemanticObservationTests {
     @Test("Records image semantics and ignores sublayers")
     func recordsImageSemanticsAndIgnoresSublayers() {
         // Given
-        let image = UIImage()
-        let highlightedImage = UIImage()
-        let imageView = UIImageView(image: image, highlightedImage: highlightedImage)
+        let imageView = UIImageView(image: UIImage())
         imageView.isHighlighted = true
-        imageView.tintColor = .green
 
         // When
         let observation = CALayerSnapshot.SemanticObservation(layer: imageView.layer, context: .mockAny())
@@ -138,12 +135,7 @@ struct CALayerSnapshotSemanticObservationTests {
         // Then
         #expect(observation == .init(
             semantics: .image(
-                .init(
-                    image: image,
-                    highlightedImage: highlightedImage,
-                    isHighlighted: true,
-                    tintColor: .green
-                )
+                .init(isContextual: false)
             ),
             ignoreSublayers: true
         ))

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSemanticObservationTests.swift
@@ -346,7 +346,12 @@ struct CALayerSnapshotSemanticObservationTests {
         let observation = CALayerSnapshot.SemanticObservation(layer: webView.layer, context: context)
 
         // Then
-        #expect(observation == .init(semantics: .webView(.init(slotID: webView.hash)), ignoreSublayers: true))
+        #expect(
+            observation == .init(
+                semantics: .webView(.init(slotID: webView.hash, slotFrame: webView.frame)),
+                ignoreSublayers: true
+            )
+        )
         #expect(webViewCache.allObjects.first === webView)
     }
 }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -15,6 +15,14 @@ import WebKit
 
 @MainActor
 struct CompositionTreeBuilderTests {
+    private final class SafeAreaWebView: WKWebView {
+        var stubbedSafeAreaInsets: UIEdgeInsets = .zero
+
+        override var safeAreaInsets: UIEdgeInsets {
+            stubbedSafeAreaInsets
+        }
+    }
+
     @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates visible webview wireframe")
     func buildCreatesVisibleWebViewWireframe() throws {
@@ -65,6 +73,40 @@ struct CompositionTreeBuilderTests {
         #expect(wireframe.shapeStyle?.opacity == nil)
         #expect(wireframe.clip == nil)
         #expect(output.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build offsets webview wireframe for safe-area adjusted content")
+    func buildOffsetsWebViewWireframeForSafeAreaAdjustedContent() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let webView = SafeAreaWebView(frame: CGRect(x: 10, y: 20, width: 60, height: 40))
+        webView.stubbedSafeAreaInsets = UIEdgeInsets(top: 30, left: 0, bottom: 0, right: 0)
+        webView.scrollView.contentInsetAdjustmentBehavior = .automatic
+        rootView.addSubview(webView)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny()))
+        let slotID = webView.hash
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [slotID],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        guard case .webviewWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a webview wireframe")
+            return
+        }
+
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 50)
+        #expect(wireframe.width == 60)
+        #expect(wireframe.height == 40)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -7,12 +7,66 @@
 #if os(iOS)
 import QuartzCore
 import Testing
+import UIKit
+import WebKit
 
 @_spi(Internal)
 @testable import DatadogSessionReplay
 
 @MainActor
 struct CompositionTreeBuilderTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates visible webview wireframe")
+    func buildCreatesVisibleWebViewWireframe() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let webView = WKWebView(frame: CGRect(x: 10, y: 20, width: 60, height: 40))
+        webView.layer.backgroundColor = UIColor.red.cgColor
+        webView.layer.borderColor = UIColor.green.cgColor
+        webView.layer.borderWidth = 2
+        webView.layer.cornerRadius = 6
+        rootView.addSubview(webView)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny()))
+        let slotID = webView.hash
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [slotID],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.count == 1)
+        #expect(output.compositionTree.root.children.first?.id == Int64(slotID))
+        #expect(output.compositionTree.root.children.first?.type == .wireframe)
+        #expect(hiddenWebViewSlotIDs(in: output.wireframes).isEmpty)
+
+        #expect(output.wireframes.count == 1)
+        guard case .webviewWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a webview wireframe")
+            return
+        }
+
+        #expect(wireframe.id == Int64(slotID))
+        #expect(wireframe.slotId == String(slotID))
+        #expect(wireframe.isVisible == true)
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 20)
+        #expect(wireframe.width == 60)
+        #expect(wireframe.height == 40)
+        #expect(wireframe.border?.color == "#00FF00FF")
+        #expect(wireframe.border?.width == 2)
+        #expect(wireframe.shapeStyle?.backgroundColor == "#FF0000FF")
+        #expect(wireframe.shapeStyle?.cornerRadius == 6)
+        #expect(wireframe.shapeStyle?.opacity == nil)
+        #expect(wireframe.clip == nil)
+        #expect(output.resources.isEmpty)
+    }
+
     @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build can be reused without accumulating output state")
     func buildCanBeReusedWithoutAccumulatingOutputState() throws {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import QuartzCore
+import Testing
+
+@_spi(Internal)
+@testable import DatadogSessionReplay
+
+@MainActor
+struct CompositionTreeBuilderTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build can be reused without accumulating output state")
+    func buildCanBeReusedWithoutAccumulatingOutputState() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 100)
+
+        let containerLayer = CALayer()
+        containerLayer.frame = CGRect(x: 40, y: 50, width: 60, height: 70)
+
+        let leafLayer = CALayer()
+        leafLayer.frame = CGRect(x: 1, y: 2, width: 30, height: 40)
+
+        containerLayer.addSublayer(leafLayer)
+        rootLayer.addSublayer(containerLayer)
+
+        let root = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let container = try #require(root.sublayers.first)
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [42],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let firstOutput = builder.build()
+        let secondOutput = builder.build()
+
+        // Then
+        #expect(firstOutput.compositionTree.layers?.map(\.id) == [container.replayID])
+        #expect(secondOutput.compositionTree.layers?.map(\.id) == [container.replayID])
+        #expect(hiddenWebViewSlotIDs(in: firstOutput.wireframes) == ["42"])
+        #expect(hiddenWebViewSlotIDs(in: secondOutput.wireframes) == ["42"])
+        #expect(firstOutput.resources.isEmpty)
+        #expect(secondOutput.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    private func hiddenWebViewSlotIDs(in wireframes: [SRWireframe]) -> [String] {
+        wireframes.compactMap { wireframe in
+            guard case .webviewWireframe(let value) = wireframe, value.isVisible == false else {
+                return nil
+            }
+            return value.slotId
+        }
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -281,6 +281,47 @@ struct CompositionTreeBuilderTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates hidden placeholder for private layer")
+    func buildCreatesHiddenPlaceholderForPrivateLayer() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let privateView = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+        privateView.dd.sessionReplayPrivacyOverrides.hide = true
+        rootView.addSubview(privateView)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny()))
+        let privateSnapshot = try #require(root.sublayers.first)
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.count == 1)
+        #expect(output.compositionTree.root.children.first?.id == privateSnapshot.replayID)
+        #expect(output.compositionTree.root.children.first?.type == .wireframe)
+
+        #expect(output.wireframes.count == 1)
+        guard case .placeholderWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a placeholder wireframe")
+            return
+        }
+
+        #expect(wireframe.id == privateSnapshot.replayID)
+        #expect(wireframe.label == "Hidden")
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 20)
+        #expect(wireframe.width == 100)
+        #expect(wireframe.height == 40)
+        #expect(output.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates shape wireframe for text input appearance")
     func buildCreatesShapeWireframeForTextInputAppearance() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -538,6 +538,31 @@ struct CompositionTreeBuilderTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build skips empty image view without appearance")
+    func buildSkipsEmptyImageViewWithoutAppearance() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let imageView = UIImageView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+        rootView.addSubview(imageView)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny(imagePrivacyLevel: .maskAll)))
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.isEmpty)
+        #expect(output.wireframes.isEmpty)
+        #expect(output.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates placeholder for timed out image snapshot")
     func buildCreatesPlaceholderForTimedOutImageSnapshot() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -231,6 +231,166 @@ struct CompositionTreeBuilderTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates image wireframe for image snapshot")
+    func buildCreatesImageWireframeForImageSnapshot() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let imageView = UIImageView(image: UIImage.mockWith(color: .red))
+        imageView.frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        imageView.layer.backgroundColor = UIColor.blue.cgColor
+        imageView.layer.borderColor = UIColor.green.cgColor
+        imageView.layer.borderWidth = 2
+        imageView.layer.cornerRadius = 4
+        rootView.addSubview(imageView)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny(imagePrivacyLevel: .maskNone)))
+        let imageSnapshot = try #require(root.sublayers.first)
+        let snapshotImage = UIImage.mockWith(color: .red)
+        let renderedImage = ImageSnapshot.mockAny(
+            image: snapshotImage,
+            frame: imageSnapshot.absoluteFrame,
+            layerClass: imageSnapshot.layerClass,
+            delegateClass: imageSnapshot.delegateClass,
+            hasLayerSemantics: false,
+            imagePrivacyLevel: .maskNone
+        )
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [imageSnapshot.replayID: .success(renderedImage)]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.count == 1)
+        #expect(output.compositionTree.root.children.first?.id == imageSnapshot.replayID)
+        #expect(output.compositionTree.root.children.first?.type == .wireframe)
+
+        #expect(output.wireframes.count == 1)
+        guard case .imageWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected an image wireframe")
+            return
+        }
+
+        let resource = try #require(output.resources.first)
+        #expect(output.resources.count == 1)
+        #expect(resource.mimeType == "image/png")
+        #expect(resource.calculateData().isEmpty == false)
+        #expect(wireframe.id == imageSnapshot.replayID)
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 20)
+        #expect(wireframe.width == 100)
+        #expect(wireframe.height == 40)
+        #expect(wireframe.isEmpty == false)
+        #expect(wireframe.mimeType == resource.mimeType)
+        #expect(wireframe.resourceId == resource.calculateIdentifier())
+        #expect(wireframe.border == nil)
+        #expect(wireframe.shapeStyle == nil)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates placeholder for image without snapshot result")
+    func buildCreatesPlaceholderForImageWithoutSnapshotResult() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        rootView.addSubview(imageView)
+
+        let root = try #require(
+            CALayerSnapshot(from: rootView.layer, in: .mockAny(imagePrivacyLevel: .maskNonBundledOnly))
+        )
+        let imageSnapshot = try #require(root.sublayers.first)
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.wireframes.count == 1)
+        guard case .placeholderWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a placeholder wireframe")
+            return
+        }
+
+        #expect(wireframe.id == imageSnapshot.replayID)
+        #expect(wireframe.label == "Content Image")
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 20)
+        #expect(wireframe.width == 100)
+        #expect(wireframe.height == 40)
+        #expect(output.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates placeholder for timed out image snapshot")
+    func buildCreatesPlaceholderForTimedOutImageSnapshot() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        rootView.addSubview(imageView)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny(imagePrivacyLevel: .maskNone)))
+        let imageSnapshot = try #require(root.sublayers.first)
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [imageSnapshot.replayID: .failure(.timedOut)]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.wireframes.count == 1)
+        guard case .placeholderWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a placeholder wireframe")
+            return
+        }
+
+        #expect(wireframe.id == imageSnapshot.replayID)
+        #expect(wireframe.label == "Timed out")
+        #expect(output.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build skips discarded image snapshot")
+    func buildSkipsDiscardedImageSnapshot() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let imageView = UIImageView(image: UIImage())
+        imageView.frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        rootView.addSubview(imageView)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny(imagePrivacyLevel: .maskNone)))
+        let imageSnapshot = try #require(root.sublayers.first)
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [imageSnapshot.replayID: .failure(.discarded)]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.isEmpty)
+        #expect(output.wireframes.isEmpty)
+        #expect(output.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build can be reused without accumulating output state")
     func buildCanBeReusedWithoutAccumulatingOutputState() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -9,6 +9,7 @@ import QuartzCore
 import Testing
 import UIKit
 import WebKit
+import DatadogInternal
 
 @_spi(Internal)
 @testable import DatadogSessionReplay
@@ -107,6 +108,126 @@ struct CompositionTreeBuilderTests {
         #expect(wireframe.y == 50)
         #expect(wireframe.width == 60)
         #expect(wireframe.height == 40)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates text wireframe for label")
+    func buildCreatesTextWireframeForLabel() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let label = UILabel(frame: CGRect(x: 10, y: 20, width: 100, height: 30))
+        label.text = "Hello, world!"
+        label.textColor = .blue
+        label.textAlignment = .right
+        label.font = .systemFont(ofSize: 17)
+        label.adjustsFontSizeToFitWidth = true
+        label.lineBreakMode = .byTruncatingMiddle
+        label.layer.backgroundColor = UIColor.red.cgColor
+        label.layer.borderColor = UIColor.green.cgColor
+        label.layer.borderWidth = 2
+        label.layer.cornerRadius = 4
+        rootView.addSubview(label)
+
+        let root = try #require(CALayerSnapshot(
+            from: rootView.layer,
+            in: .mockAny(textAndInputPrivacyLevel: .maskSensitiveInputs)
+        ))
+        let labelSnapshot = try #require(root.sublayers.first)
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.count == 1)
+        #expect(output.compositionTree.root.children.first?.id == labelSnapshot.replayID)
+        #expect(output.compositionTree.root.children.first?.type == .wireframe)
+
+        #expect(output.wireframes.count == 1)
+        guard case .textWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a text wireframe")
+            return
+        }
+
+        #expect(wireframe.id == labelSnapshot.replayID)
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 20)
+        #expect(wireframe.width == 100)
+        #expect(wireframe.height == 30)
+        #expect(wireframe.text == "Hello, world!")
+        #expect(wireframe.textPosition?.alignment?.horizontal == .right)
+        #expect(wireframe.textPosition?.alignment?.vertical == .center)
+        #expect(wireframe.textPosition?.padding == nil)
+        #expect(wireframe.textStyle.color == "#0000FFFF")
+        #expect(wireframe.textStyle.size == 15)
+        #expect(wireframe.textStyle.truncationMode == .middle)
+        #expect(wireframe.border?.color == "#00FF00FF")
+        #expect(wireframe.border?.width == 2)
+        #expect(wireframe.shapeStyle?.backgroundColor == "#FF0000FF")
+        #expect(wireframe.shapeStyle?.cornerRadius == 4)
+        #expect(output.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build masks label text for mask all privacy")
+    func buildMasksLabelTextForMaskAllPrivacy() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let label = UILabel(frame: CGRect(x: 10, y: 20, width: 100, height: 30))
+        label.text = "Hello world"
+        rootView.addSubview(label)
+
+        let root = try #require(CALayerSnapshot(
+            from: rootView.layer,
+            in: .mockAny(textAndInputPrivacyLevel: .maskAll)
+        ))
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        guard case .textWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a text wireframe")
+            return
+        }
+
+        #expect(wireframe.text == "xxxxx xxxxx")
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build skips empty label without appearance")
+    func buildSkipsEmptyLabelWithoutAppearance() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let label = UILabel(frame: CGRect(x: 10, y: 20, width: 100, height: 30))
+        rootView.addSubview(label)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny()))
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.isEmpty)
+        #expect(output.wireframes.isEmpty)
+        #expect(output.resources.isEmpty)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -231,6 +231,114 @@ struct CompositionTreeBuilderTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates shape wireframe for layer appearance")
+    func buildCreatesShapeWireframeForLayerAppearance() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 100)
+
+        let layer = CALayer()
+        layer.frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        layer.backgroundColor = UIColor.red.cgColor
+        layer.borderColor = UIColor.green.cgColor
+        layer.borderWidth = 2
+        layer.cornerRadius = 4
+        rootLayer.addSublayer(layer)
+
+        let root = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let layerSnapshot = try #require(root.sublayers.first)
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.count == 1)
+        #expect(output.compositionTree.root.children.first?.id == layerSnapshot.replayID)
+        #expect(output.compositionTree.root.children.first?.type == .wireframe)
+
+        #expect(output.wireframes.count == 1)
+        guard case .shapeWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a shape wireframe")
+            return
+        }
+
+        #expect(wireframe.id == layerSnapshot.replayID)
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 20)
+        #expect(wireframe.width == 100)
+        #expect(wireframe.height == 40)
+        #expect(wireframe.border?.color == "#00FF00FF")
+        #expect(wireframe.border?.width == 2)
+        #expect(wireframe.shapeStyle?.backgroundColor == "#FF0000FF")
+        #expect(wireframe.shapeStyle?.cornerRadius == 4)
+        #expect(output.resources.isEmpty)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates shape wireframe for text input appearance")
+    func buildCreatesShapeWireframeForTextInputAppearance() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let textView = UITextView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+        textView.backgroundColor = .red
+        textView.layer.borderColor = UIColor.green.cgColor
+        textView.layer.borderWidth = 2
+
+        let contentLayer = CALayer()
+        contentLayer.frame = CGRect(x: 5, y: 6, width: 20, height: 10)
+        contentLayer.backgroundColor = UIColor.blue.cgColor
+        textView.layer.addSublayer(contentLayer)
+
+        rootView.addSubview(textView)
+
+        let root = try #require(CALayerSnapshot(from: rootView.layer, in: .mockAny()))
+        let textInputSnapshot = try #require(root.sublayers.first)
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [:]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.count == 1)
+        #expect(output.compositionTree.root.children.first?.id == textInputSnapshot.replayID)
+        #expect(output.compositionTree.root.children.first?.type == .layer)
+
+        let textInputLayer = try #require(output.compositionTree.layers?.first { $0.id == textInputSnapshot.replayID })
+        #expect(textInputLayer.children.contains {
+            $0.id == textInputSnapshot.replayID && $0.type == .wireframe
+        })
+
+        let shapeWireframes = output.wireframes.compactMap { wireframe -> SRShapeWireframe? in
+            guard case .shapeWireframe(let shapeWireframe) = wireframe else {
+                return nil
+            }
+            return shapeWireframe
+        }
+        let wireframe = try #require(shapeWireframes.first {
+            $0.id == textInputSnapshot.replayID
+        })
+
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 20)
+        #expect(wireframe.width == 100)
+        #expect(wireframe.height == 40)
+        #expect(wireframe.border?.color == "#00FF00FF")
+        #expect(wireframe.border?.width == 2)
+        #expect(wireframe.shapeStyle?.backgroundColor == "#FF0000FF")
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates image wireframe for image snapshot")
     func buildCreatesImageWireframeForImageSnapshot() throws {
         // Given
@@ -289,6 +397,105 @@ struct CompositionTreeBuilderTests {
         #expect(wireframe.resourceId == resource.calculateIdentifier())
         #expect(wireframe.border == nil)
         #expect(wireframe.shapeStyle == nil)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates image wireframe for control snapshot")
+    func buildCreatesImageWireframeForControlSnapshot() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let activityIndicator = UIActivityIndicatorView(frame: CGRect(x: 10, y: 20, width: 40, height: 40))
+        activityIndicator.startAnimating()
+        rootView.addSubview(activityIndicator)
+
+        let root = try #require(CALayerSnapshot(
+            from: rootView.layer,
+            in: .mockAny(textAndInputPrivacyLevel: .maskAll, imagePrivacyLevel: .maskAll)
+        ))
+        let controlSnapshot = try #require(root.sublayers.first)
+        let renderedImage = ImageSnapshot.mockAny(
+            image: UIImage.mockWith(color: .red),
+            frame: controlSnapshot.absoluteFrame,
+            layerClass: controlSnapshot.layerClass,
+            delegateClass: controlSnapshot.delegateClass,
+            hasLayerSemantics: false,
+            textAndInputPrivacyLevel: .maskAll,
+            imagePrivacyLevel: .maskAll
+        )
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [controlSnapshot.replayID: .success(renderedImage)]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.count == 1)
+        #expect(output.compositionTree.root.children.first?.id == controlSnapshot.replayID)
+        #expect(output.compositionTree.root.children.first?.type == .wireframe)
+
+        #expect(output.wireframes.count == 1)
+        guard case .imageWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected an image wireframe")
+            return
+        }
+
+        #expect(output.resources.count == 1)
+        #expect(wireframe.id == controlSnapshot.replayID)
+        #expect(wireframe.x == 10)
+        #expect(wireframe.y == 20)
+        #expect(wireframe.width == 40)
+        #expect(wireframe.height == 40)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build creates shape wireframe when image snapshot redacts to placeholder")
+    func buildCreatesShapeWireframeWhenImageSnapshotRedactsToPlaceholder() throws {
+        // Given
+        let rootLayer = CALayer()
+        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 100)
+
+        let layer = CALayer()
+        layer.frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        rootLayer.addSublayer(layer)
+
+        let root = try #require(CALayerSnapshot(from: rootLayer, in: .mockAny()))
+        let layerSnapshot = try #require(root.sublayers.first)
+        let renderedImage = ImageSnapshot.mockAny(
+            image: UIImage.mockWith(color: .red),
+            frame: layerSnapshot.absoluteFrame,
+            layerClass: try imageLayerClass(),
+            delegateClass: layerSnapshot.delegateClass,
+            hasLayerSemantics: true,
+            imagePrivacyLevel: .maskAll
+        )
+
+        let builder = CompositionTreeBuilder(
+            root: root,
+            webViewSlotIDs: [],
+            imageSnapshotResults: [layerSnapshot.replayID: .success(renderedImage)]
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children.count == 1)
+        #expect(output.compositionTree.root.children.first?.id == layerSnapshot.replayID)
+        #expect(output.compositionTree.root.children.first?.type == .wireframe)
+
+        #expect(output.wireframes.count == 1)
+        guard case .shapeWireframe(let wireframe) = try #require(output.wireframes.first) else {
+            Issue.record("Expected a shape wireframe")
+            return
+        }
+
+        #expect(wireframe.id == layerSnapshot.replayID)
+        #expect(wireframe.shapeStyle?.backgroundColor == "#FF0000FF")
+        #expect(output.resources.isEmpty)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -437,5 +644,9 @@ struct CompositionTreeBuilderTests {
             return value.slotId
         }
     }
+}
+
+private func imageLayerClass() throws -> AnyClass {
+    try #require(NSClassFromString("SwiftUI.ImageLayer"))
 }
 #endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotMocks.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotMocks.swift
@@ -44,4 +44,14 @@ extension ImageSnapshotData {
         ImageSnapshotData(snapshot: snapshot, localRect: localRect, bounds: bounds, dependencies: dependencies)
     }
 }
+
+extension UIImage {
+    static func mockWith(color: UIColor) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10))
+        return renderer.image { context in
+            color.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }
+    }
+}
 #endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRedactionTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotRedactionTests.swift
@@ -461,17 +461,6 @@ private extension ImageRedactionResult {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
-private extension UIImage {
-    static func mockWith(color: UIColor) -> UIImage {
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10))
-        return renderer.image { context in
-            color.setFill()
-            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
-        }
-    }
-}
-
 private func textLayoutFragmentClass() throws -> AnyClass {
     try #require(NSClassFromString("_UITextLayoutFragmentView"))
 }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
@@ -118,10 +118,13 @@ struct LayerTreeSnapshotBuilderTests {
         // Then
         #expect(snapshot.webViewSlotIDs == Set([webView.hash]))
         #expect(snapshot.root.sublayers.count == 1)
-        #expect(snapshot.root.sublayers[0].observation == .init(
-            semantics: .webView(.init(slotID: webView.hash)),
-            ignoreSublayers: true
-        ))
+        let webViewSnapshot = snapshot.root.sublayers[0]
+        #expect(
+            webViewSnapshot.observation == .init(
+                semantics: .webView(.init(slotID: webView.hash, slotFrame: webViewSnapshot.absoluteFrame)),
+                ignoreSublayers: true
+            )
+        )
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/PathCornerRadiiTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/PathCornerRadiiTests.swift
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import QuartzCore
+import SwiftUI
+import Testing
+
+@testable import DatadogSessionReplay
+
+struct PathCornerRadiiTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Creates path for elliptical corner radii")
+    func createsPathForEllipticalCornerRadii() {
+        // Given
+        let cornerRadii = CALayerSnapshot.CornerRadii(
+            topLeft: CGSize(width: 10, height: 5),
+            topRight: CGSize(width: 20, height: 10),
+            bottomLeft: CGSize(width: 5, height: 20),
+            bottomRight: CGSize(width: 30, height: 15)
+        )
+
+        // When
+        let path = SwiftUI.Path(
+            roundedRect: CGRect(x: 0, y: 0, width: 100, height: 50),
+            cornerRadii: cornerRadii,
+            cornerCurve: .circular
+        )
+
+        // Then
+        #expect(
+            path.dd.svgString == """
+                M 10.000 0.000 L 80.000 0.000 \
+                C 91.046 0.000 100.000 4.477 100.000 10.000 \
+                L 100.000 35.000 \
+                C 100.000 43.284 86.569 50.000 70.000 50.000 \
+                L 5.000 50.000 \
+                C 2.239 50.000 0.000 41.046 0.000 30.000 \
+                L 0.000 5.000 \
+                C 0.000 2.239 4.477 0.000 10.000 0.000 Z
+                """
+        )
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/WKWebViewRecorderTests.swift
@@ -57,6 +57,27 @@ class WKWebViewRecorderTests: XCTestCase {
         XCTAssertFalse(wireframes.isEmpty)
     }
 
+    func testWhenWebViewExtendsBeyondSafeArea_itOffsetsNodeFrame() throws {
+        // Given
+        let webView = SafeAreaWebView()
+        webView.stubbedSafeAreaInsets = UIEdgeInsets(top: 30, left: 0, bottom: 0, right: 0)
+        webView.scrollView.contentInsetAdjustmentBehavior = .automatic
+
+        let frame = CGRect(x: 10, y: 20, width: 60, height: 40)
+        let viewAttributes: ViewAttributes = .mockWith(
+            frame: frame,
+            clip: frame,
+            alpha: 1,
+            isHidden: false
+        )
+
+        // When
+        let semantics = try XCTUnwrap(recorder.semantics(of: webView, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+
+        // Then
+        XCTAssertEqual(semantics.nodes.first?.viewAttributes.frame, frame.offsetBy(dx: 0, dy: 30))
+    }
+
     func testVisibleWebViewSlot() throws {
         // Given
         let attributes: ViewAttributes = .mock(fixture: .visible())
@@ -84,6 +105,14 @@ class WKWebViewRecorderTests: XCTestCase {
         XCTAssertEqual(wireframe.height, Int64.ddWithNoOverflow( attributes.frame.height))
         XCTAssertTrue(wireframe.isVisible ?? false)
         XCTAssertTrue(builder.hiddenWebViewWireframes().isEmpty, "webview slot should be removed from builder")
+    }
+}
+
+private final class SafeAreaWebView: WKWebView {
+    var stubbedSafeAreaInsets: UIEdgeInsets = .zero
+
+    override var safeAreaInsets: UIEdgeInsets {
+        stubbedSafeAreaInsets
     }
 }
 


### PR DESCRIPTION
### What and why?

This PR adds the `CompositionTreeBuilder` for the Core Animation based Session Replay recording pipeline.

It maps optimized `CALayerSnapshot` trees and image snapshot results into the new composition tree schema, plus the wireframes and resources needed by the payload.

This is still behind the internal layer-tree recording feature flag.

Out of scope:
- Heatmaps. Path based `permanentId` computation will be added in the future
- Wiring the builder to `LayerRecorder`
- Layer masks
- Full parity with the existing recording pipeline. The Core Animation recording pipeline is a major shift for SR

### How?

The builder preserves the captured layer hierarchy as `SRCompositionTree`.

It maps layer-level clipping, corner radii, opacity, filters, and compositing filters to composition layer modifiers.

It creates wireframes for web views, labels, image snapshots, redaction placeholders, timed-out snapshots, private image placeholders, and visible layer backgrounds or borders.

It also shares the existing WKWebView safe-area frame adjustment with the current view-tree recorder, so web view slot frames stay aligned.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
