### PR TITLE
[RUM-16961] Fix URLSession network tracking when usesClassicLoadingMode is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
+- [FIX] Fix automatic URLSession network tracking not recording requests when `URLSessionConfiguration.usesClassicLoadingMode = false` on iOS/tvOS 18.4+. See [#3017][]
 - [FIX] Fix watchOS uploads blocked by NWPathMonitor always reporting no reachability. See [#2975][]
 
 # 3.12.0 / 04-06-2026
@@ -1177,6 +1178,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#2963]: https://github.com/DataDog/dd-sdk-ios/pull/2963
 [#2955]: https://github.com/DataDog/dd-sdk-ios/pull/2955
 [#2975]: https://github.com/DataDog/dd-sdk-ios/pull/2975
+[#3017]: https://github.com/DataDog/dd-sdk-ios/pull/3017
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
@@ -18,6 +18,7 @@ import Foundation
 internal final class URLSessionTaskStateSwizzler {
     private let lock: NSLocking
     private var taskSetState: TaskSetState?
+    private var nwTaskComplete: NWTaskComplete?
 
     init(lock: NSLocking = NSLock()) {
         self.lock = lock
@@ -31,6 +32,12 @@ internal final class URLSessionTaskStateSwizzler {
         defer { lock.unlock() }
         taskSetState = try TaskSetState.build()
         taskSetState?.swizzle(intercept: interceptSetState)
+        // NWURLSessionTask (usesClassicLoadingMode = false, iOS/tvOS 18.4+) bypasses setState:;
+        // completeTaskWithError: is its completion signal.
+        nwTaskComplete = NWTaskComplete.build()
+        nwTaskComplete?.swizzle { task, _ in
+            interceptSetState(task, URLSessionTask.State.completed.rawValue)
+        }
     }
 
     /// Unswizzles all.
@@ -39,6 +46,7 @@ internal final class URLSessionTaskStateSwizzler {
     func unswizzle() {
         lock.lock()
         taskSetState?.unswizzle()
+        nwTaskComplete?.unswizzle()
         lock.unlock()
     }
 
@@ -74,6 +82,38 @@ internal final class URLSessionTaskStateSwizzler {
                 return { task, state in
                     intercept(task, state)
                     previousImplementation(task, Self.selector, state)
+                }
+            }
+        }
+    }
+
+    /// Swizzles `NWURLSessionTask.completeTaskWithError:` — completion hook for the NW stack
+    /// (`usesClassicLoadingMode = false`, iOS/tvOS 18.4+). `TaskSetState` targets `__NSCFLocalSessionTask`
+    /// and never fires for NW tasks regardless of whether they have `setState:`.
+    class NWTaskComplete: MethodSwizzler<@convention(c) (URLSessionTask, Selector, Error?) -> Void, @convention(block) (URLSessionTask, Error?) -> Void> {
+        private static let selector = NSSelectorFromString("completeTaskWithError:")
+
+        private let method: Method
+
+        /// Returns `nil` if `NWURLSessionTask` is unavailable (iOS/tvOS < 18.4).
+        static func build() -> NWTaskComplete? {
+            guard let klass = NSClassFromString("NWURLSessionTask") else {
+                return nil
+            }
+            return try? NWTaskComplete(selector: self.selector, klass: klass)
+        }
+
+        private init(selector: Selector, klass: AnyClass) throws {
+            self.method = try dd_class_getInstanceMethod(klass, selector)
+            super.init()
+        }
+
+        func swizzle(intercept: @escaping (URLSessionTask, Error?) -> Void) {
+            typealias Signature = @convention(block) (URLSessionTask, Error?) -> Void
+            swizzle(method) { previousImplementation -> Signature in
+                return { task, error in
+                    intercept(task, error)
+                    previousImplementation(task, Self.selector, error)
                 }
             }
         }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
@@ -104,7 +104,9 @@ internal final class URLSessionTaskStateSwizzler {
 
         /// Returns `nil` if `NWURLSessionTask` is unavailable or if the selector is absent.
         static func build() -> NWTaskComplete? {
-            guard let klass = NSClassFromString("NWURLSessionTask") else { return nil }
+            guard let klass = NSClassFromString("NWURLSessionTask") else {
+                return nil
+            }
             return try? NWTaskComplete(selector: self.selector, klass: klass)
         }
 
@@ -133,7 +135,9 @@ internal final class URLSessionTaskStateSwizzler {
 
         /// Returns `nil` if `NWURLSessionTask` is unavailable or if the selector is absent.
         static func build() -> NWTaskCompleteRetryable? {
-            guard let klass = NSClassFromString("NWURLSessionTask") else { return nil }
+            guard let klass = NSClassFromString("NWURLSessionTask") else {
+                return nil
+            }
             return try? NWTaskCompleteRetryable(selector: self.selector, klass: klass)
         }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskStateSwizzler.swift
@@ -19,6 +19,7 @@ internal final class URLSessionTaskStateSwizzler {
     private let lock: NSLocking
     private var taskSetState: TaskSetState?
     private var nwTaskComplete: NWTaskComplete?
+    private var nwTaskCompleteRetryable: NWTaskCompleteRetryable?
 
     init(lock: NSLocking = NSLock()) {
         self.lock = lock
@@ -32,11 +33,18 @@ internal final class URLSessionTaskStateSwizzler {
         defer { lock.unlock() }
         taskSetState = try TaskSetState.build()
         taskSetState?.swizzle(intercept: interceptSetState)
-        // NWURLSessionTask (usesClassicLoadingMode = false, iOS/tvOS 18.4+) bypasses setState:;
-        // completeTaskWithError: is its completion signal.
-        nwTaskComplete = NWTaskComplete.build()
-        nwTaskComplete?.swizzle { task, _ in
-            interceptSetState(task, URLSessionTask.State.completed.rawValue)
+        // NWURLSessionTask bypasses setState:; hook into its completion method instead.
+        // iOS 26+ uses completeTaskWithError:retryable:; earlier versions use completeTaskWithError:.
+        nwTaskCompleteRetryable = NWTaskCompleteRetryable.build()
+        if nwTaskCompleteRetryable != nil {
+            nwTaskCompleteRetryable?.swizzle { task, _ in
+                interceptSetState(task, URLSessionTask.State.completed.rawValue)
+            }
+        } else {
+            nwTaskComplete = NWTaskComplete.build()
+            nwTaskComplete?.swizzle { task, _ in
+                interceptSetState(task, URLSessionTask.State.completed.rawValue)
+            }
         }
     }
 
@@ -47,6 +55,7 @@ internal final class URLSessionTaskStateSwizzler {
         lock.lock()
         taskSetState?.unswizzle()
         nwTaskComplete?.unswizzle()
+        nwTaskCompleteRetryable?.unswizzle()
         lock.unlock()
     }
 
@@ -87,19 +96,15 @@ internal final class URLSessionTaskStateSwizzler {
         }
     }
 
-    /// Swizzles `NWURLSessionTask.completeTaskWithError:` — completion hook for the NW stack
-    /// (`usesClassicLoadingMode = false`, iOS/tvOS 18.4+). `TaskSetState` targets `__NSCFLocalSessionTask`
-    /// and never fires for NW tasks regardless of whether they have `setState:`.
+    /// Swizzles `NWURLSessionTask.completeTaskWithError:` — NW stack completion hook (replaced by `NWTaskCompleteRetryable` on iOS 26+).
     class NWTaskComplete: MethodSwizzler<@convention(c) (URLSessionTask, Selector, Error?) -> Void, @convention(block) (URLSessionTask, Error?) -> Void> {
         private static let selector = NSSelectorFromString("completeTaskWithError:")
 
         private let method: Method
 
-        /// Returns `nil` if `NWURLSessionTask` is unavailable (iOS/tvOS < 18.4).
+        /// Returns `nil` if `NWURLSessionTask` is unavailable or if the selector is absent.
         static func build() -> NWTaskComplete? {
-            guard let klass = NSClassFromString("NWURLSessionTask") else {
-                return nil
-            }
+            guard let klass = NSClassFromString("NWURLSessionTask") else { return nil }
             return try? NWTaskComplete(selector: self.selector, klass: klass)
         }
 
@@ -114,6 +119,35 @@ internal final class URLSessionTaskStateSwizzler {
                 return { task, error in
                     intercept(task, error)
                     previousImplementation(task, Self.selector, error)
+                }
+            }
+        }
+    }
+
+    /// Swizzles `NWURLSessionTask.completeTaskWithError:retryable:` — iOS 26+ NW stack completion hook.
+    /// iOS 26 added a `retryable: Bool` parameter to the completion signal.
+    class NWTaskCompleteRetryable: MethodSwizzler<@convention(c) (URLSessionTask, Selector, Error?, Bool) -> Void, @convention(block) (URLSessionTask, Error?, Bool) -> Void> {
+        private static let selector = NSSelectorFromString("completeTaskWithError:retryable:")
+
+        private let method: Method
+
+        /// Returns `nil` if `NWURLSessionTask` is unavailable or if the selector is absent.
+        static func build() -> NWTaskCompleteRetryable? {
+            guard let klass = NSClassFromString("NWURLSessionTask") else { return nil }
+            return try? NWTaskCompleteRetryable(selector: self.selector, klass: klass)
+        }
+
+        private init(selector: Selector, klass: AnyClass) throws {
+            self.method = try dd_class_getInstanceMethod(klass, selector)
+            super.init()
+        }
+
+        func swizzle(intercept: @escaping (URLSessionTask, Error?) -> Void) {
+            typealias Signature = @convention(block) (URLSessionTask, Error?, Bool) -> Void
+            swizzle(method) { previousImplementation -> Signature in
+                return { task, error, retryable in
+                    intercept(task, error)
+                    previousImplementation(task, Self.selector, error, retryable)
                 }
             }
         }

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskSwizzler.swift
@@ -23,8 +23,7 @@ internal final class URLSessionTaskSwizzler {
         defer { lock.unlock() }
         taskResume = try TaskResume.build()
         taskResume?.swizzle(intercept: interceptResume)
-        // NWURLSessionTask is used when usesClassicLoadingMode = false (iOS/tvOS 18.4+)
-        // and bypasses the __NSCFLocalSessionTask swizzle above.
+        // NWURLSessionTask bypasses __NSCFLocalSessionTask, so it needs a separate swizzle.
         nwTaskResume = NWTaskResume.build()
         nwTaskResume?.swizzle(intercept: interceptResume)
     }
@@ -76,17 +75,19 @@ internal final class URLSessionTaskSwizzler {
         }
     }
 
-    /// Swizzles `NWURLSessionTask.resume()` — used when `usesClassicLoadingMode = false` (iOS/tvOS 18.4+).
+    /// Swizzles `NWURLSessionTask.resume()`.
     class NWTaskResume: MethodSwizzler<@convention(c) (URLSessionTask, Selector) -> Void, @convention(block) (URLSessionTask) -> Void> {
         private static let selector = #selector(URLSessionTask.resume)
 
         private let method: Method
 
-        /// Returns `nil` if `NWURLSessionTask` is unavailable or if `completeTaskWithError:` is absent.
-        /// Both guards are required: tracking resume without completion would leave interceptions open permanently.
+        /// Returns `nil` if `NWURLSessionTask` is unavailable or if no completion hook is present.
+        /// Both conditions are required: tracking resume without completion would leave interceptions open permanently.
+        /// Accepts either `completeTaskWithError:` or `completeTaskWithError:retryable:` (iOS 26+).
         static func build() -> NWTaskResume? {
             guard let klass = NSClassFromString("NWURLSessionTask"),
-                  class_getInstanceMethod(klass, NSSelectorFromString("completeTaskWithError:")) != nil else {
+                  (class_getInstanceMethod(klass, NSSelectorFromString("completeTaskWithError:")) != nil ||
+                   class_getInstanceMethod(klass, NSSelectorFromString("completeTaskWithError:retryable:")) != nil) else {
                 return nil
             }
             return try? NWTaskResume(selector: self.selector, klass: klass)

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskSwizzler.swift
@@ -86,8 +86,8 @@ internal final class URLSessionTaskSwizzler {
         /// Accepts either `completeTaskWithError:` or `completeTaskWithError:retryable:` (iOS 26+).
         static func build() -> NWTaskResume? {
             guard let klass = NSClassFromString("NWURLSessionTask"),
-                  (class_getInstanceMethod(klass, NSSelectorFromString("completeTaskWithError:")) != nil ||
-                   class_getInstanceMethod(klass, NSSelectorFromString("completeTaskWithError:retryable:")) != nil) else {
+                  class_getInstanceMethod(klass, NSSelectorFromString("completeTaskWithError:")) != nil ||
+                  class_getInstanceMethod(klass, NSSelectorFromString("completeTaskWithError:retryable:")) != nil else {
                 return nil
             }
             return try? NWTaskResume(selector: self.selector, klass: klass)

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskSwizzler.swift
@@ -9,6 +9,7 @@ import Foundation
 internal final class URLSessionTaskSwizzler {
     private let lock: NSLocking
     private var taskResume: TaskResume?
+    private var nwTaskResume: NWTaskResume?
 
     init(lock: NSLocking = NSLock()) {
         self.lock = lock
@@ -22,6 +23,10 @@ internal final class URLSessionTaskSwizzler {
         defer { lock.unlock() }
         taskResume = try TaskResume.build()
         taskResume?.swizzle(intercept: interceptResume)
+        // NWURLSessionTask is used when usesClassicLoadingMode = false (iOS/tvOS 18.4+)
+        // and bypasses the __NSCFLocalSessionTask swizzle above.
+        nwTaskResume = NWTaskResume.build()
+        nwTaskResume?.swizzle(intercept: interceptResume)
     }
 
     /// Unswizzles all.
@@ -30,6 +35,7 @@ internal final class URLSessionTaskSwizzler {
     func unswizzle() {
         lock.lock()
         taskResume?.unswizzle()
+        nwTaskResume?.unswizzle()
         lock.unlock()
     }
 
@@ -52,6 +58,38 @@ internal final class URLSessionTaskSwizzler {
                 throw InternalError(description: "Failed to swizzle `URLSessionTask`: `\(className)` class not found.")
             }
             return try TaskResume(selector: self.selector, klass: klass)
+        }
+
+        private init(selector: Selector, klass: AnyClass) throws {
+            self.method = try dd_class_getInstanceMethod(klass, selector)
+            super.init()
+        }
+
+        func swizzle(intercept: @escaping (URLSessionTask) -> Void) {
+            typealias Signature = @convention(block) (URLSessionTask) -> Void
+            swizzle(method) { previousImplementation -> Signature in
+                return { task in
+                    intercept(task)
+                    previousImplementation(task, Self.selector)
+                }
+            }
+        }
+    }
+
+    /// Swizzles `NWURLSessionTask.resume()` — used when `usesClassicLoadingMode = false` (iOS/tvOS 18.4+).
+    class NWTaskResume: MethodSwizzler<@convention(c) (URLSessionTask, Selector) -> Void, @convention(block) (URLSessionTask) -> Void> {
+        private static let selector = #selector(URLSessionTask.resume)
+
+        private let method: Method
+
+        /// Returns `nil` if `NWURLSessionTask` is unavailable or if `completeTaskWithError:` is absent.
+        /// Both guards are required: tracking resume without completion would leave interceptions open permanently.
+        static func build() -> NWTaskResume? {
+            guard let klass = NSClassFromString("NWURLSessionTask"),
+                  class_getInstanceMethod(klass, NSSelectorFromString("completeTaskWithError:")) != nil else {
+                return nil
+            }
+            return try? NWTaskResume(selector: self.selector, klass: klass)
         }
 
         private init(selector: Selector, klass: AnyClass) throws {

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -110,7 +110,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let notifyRequestMutation = expectation(description: "Notify request mutation")
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
         let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
+            skipIsMainThreadCheck: true
+        )
 
         handler.onRequestMutation = { _, _, _ in notifyRequestMutation.fulfill() }
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
@@ -1582,7 +1585,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
 
         let randomData: Data = .mockRandom()
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: randomData))
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: randomData),
+            skipIsMainThreadCheck: true
+        )
 
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
@@ -1993,7 +1999,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     func testAutomaticMode_detectsFirstPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
+            skipIsMainThreadCheck: true
+        )
         scopeHandler(to: server)
 
         // Given - Configure first-party hosts
@@ -2024,7 +2033,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     func testAutomaticMode_injectsTraceHeadersForFirstPartyHosts() throws {
         let notifyRequestMutation = expectation(description: "Notify request mutation")
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
+            skipIsMainThreadCheck: true
+        )
         scopeHandler(to: server)
 
         // Given - Configure first-party hosts
@@ -2059,7 +2071,10 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     func testAutomaticMode_doesNotInjectHeadersForThirdPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
+            skipIsMainThreadCheck: true
+        )
         scopeHandler(to: server)
 
         // Given - Configure first-party hosts that don't match the request URL
@@ -2090,9 +2105,129 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         _ = server.waitAndReturnRequests(count: 1)
     }
 
+    func testAutomaticMode_tracksDataTaskWhenClassicLoadingModeIsDisabled() throws {
+        guard #available(iOS 18.4, tvOS 18.4, macOS 15.4, watchOS 11.4, visionOS 2.4, *) else {
+            throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
+        }
+        guard URLSessionTaskSwizzler.NWTaskResume.build() != nil else {
+            throw XCTSkip("NW task tracking not fully supported on this platform/version")
+        }
+        let taskCompleted = expectation(description: "Task completed")
+        let url = URL(string: "https://localhost:1")!
+        handler.shouldInterceptRequest = { $0.url == url }
+
+        // Given - Enable automatic mode and use the Network.framework-backed URLSession stack.
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.usesClassicLoadingMode = false
+
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        // When
+        let task = session.dataTask(with: url) { _, _, _ in taskCompleted.fulfill() }
+        let taskClassName = String(describing: type(of: task))
+        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        task.resume()
+
+        // Then
+        wait(for: [taskCompleted], timeout: 5)
+        feature.flush()
+
+        let interception = try XCTUnwrap(
+            handler.interception(for: url),
+            "Automatic instrumentation should track URLSession tasks when usesClassicLoadingMode is false."
+        )
+        XCTAssertEqual(interception.trackingMode, .automatic)
+        XCTAssertNotNil(interception.completion, "Should capture completion for the Network.framework-backed task.")
+        XCTAssertNotNil(interception.startDate, "Should capture approximate start date.")
+        XCTAssertNotNil(interception.endDate, "Should capture approximate end date.")
+    }
+
+    func testAutomaticMode_tracksCompletionForDelegatelessNWTask() throws {
+        guard #available(iOS 18.4, tvOS 18.4, macOS 15.4, watchOS 11.4, visionOS 2.4, *) else {
+            throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
+        }
+        guard URLSessionTaskSwizzler.NWTaskResume.build() != nil else {
+            throw XCTSkip("NW task tracking not fully supported on this platform/version")
+        }
+        let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
+        let url = URL(string: "https://localhost:1")!
+        handler.shouldInterceptRequest = { $0.url == url }
+        handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
+
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.usesClassicLoadingMode = false
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        // When - no completion handler: relies entirely on NWTaskComplete swizzle for end tracking
+        let task = session.dataTask(with: url)
+        let taskClassName = String(describing: type(of: task))
+        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        task.resume()
+
+        // Then
+        wait(for: [notifyInterceptionDidComplete], timeout: 5)
+
+        let interception = try XCTUnwrap(handler.interception(for: url))
+        XCTAssertEqual(interception.trackingMode, .automatic)
+        XCTAssertNotNil(interception.completion, "Should capture completion via NWTaskComplete swizzle.")
+        XCTAssertNotNil(interception.startDate)
+        XCTAssertNotNil(interception.endDate)
+    }
+
+    func testAutomaticMode_injectsTraceHeadersForFirstPartyHostsWithNWTask() throws {
+        guard #available(iOS 18.4, tvOS 18.4, macOS 15.4, watchOS 11.4, visionOS 2.4, *) else {
+            throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
+        }
+        guard URLSessionTaskSwizzler.NWTaskResume.build() != nil else {
+            throw XCTSkip("NW task tracking not fully supported on this platform/version")
+        }
+        let notifyRequestMutation = expectation(description: "Notify request mutation")
+        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
+
+        // Given
+        let url = URL(string: "https://localhost:1")!
+        handler.firstPartyHosts = .init(hostsWithTracingHeaderTypes: [url.host!: [.datadog, .tracecontext]])
+
+        var capturedHeaderTypes: Set<TracingHeaderType>?
+        handler.onRequestMutation = { _, headerTypes, _ in
+            capturedHeaderTypes = headerTypes
+            notifyRequestMutation.fulfill()
+        }
+        handler.onInterceptionDidStart = { interception in
+            XCTAssertTrue(interception.isFirstPartyRequest)
+            notifyInterceptionDidStart.fulfill()
+        }
+
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        // When - usesClassicLoadingMode = false forces NWURLSessionTask instances
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.usesClassicLoadingMode = false
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+        let task = session.dataTask(with: url) { _, _, _ in }
+        let taskClassName = String(describing: type(of: task))
+        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        task.resume()
+
+        // Then
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertEqual(capturedHeaderTypes, [.datadog, .tracecontext])
+    }
+
     func testRegisteredDelegate_detectsFirstPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let server = ServerMock(
+            delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)),
+            skipIsMainThreadCheck: true
+        )
         scopeHandler(to: server)
 
         // Given

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -2129,7 +2129,9 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // When
         let task = session.dataTask(with: url) { _, _, _ in taskCompleted.fulfill() }
         let taskClassName = String(describing: type(of: task))
-        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        guard taskClassName.hasPrefix("NWURLSession") else {
+            throw XCTSkip("usesClassicLoadingMode = false does not create NWURLSessionTask on this platform")
+        }
         task.resume()
 
         // Then
@@ -2168,7 +2170,9 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // When - no completion handler: relies entirely on NWTaskComplete swizzle for end tracking
         let task = session.dataTask(with: url)
         let taskClassName = String(describing: type(of: task))
-        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        guard taskClassName.hasPrefix("NWURLSession") else {
+            throw XCTSkip("usesClassicLoadingMode = false does not create NWURLSessionTask on this platform")
+        }
         task.resume()
 
         // Then
@@ -2214,7 +2218,9 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         defer { session.invalidateAndCancel() }
         let task = session.dataTask(with: url) { _, _, _ in }
         let taskClassName = String(describing: type(of: task))
-        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        guard taskClassName.hasPrefix("NWURLSession") else {
+            throw XCTSkip("usesClassicLoadingMode = false does not create NWURLSessionTask on this platform")
+        }
         task.resume()
 
         // Then

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -2110,7 +2110,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
         }
         guard URLSessionTaskSwizzler.NWTaskResume.build() != nil else {
-            throw XCTSkip("NW task tracking not fully supported on this platform/version")
+            throw XCTSkip("NW task tracking not supported on this platform/version")
         }
         let taskCompleted = expectation(description: "Task completed")
         let url = URL(string: "https://localhost:1")!
@@ -2142,8 +2142,8 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         )
         XCTAssertEqual(interception.trackingMode, .automatic)
         XCTAssertNotNil(interception.completion, "Should capture completion for the Network.framework-backed task.")
-        XCTAssertNotNil(interception.startDate, "Should capture approximate start date.")
-        XCTAssertNotNil(interception.endDate, "Should capture approximate end date.")
+        XCTAssertNotNil(interception.startDate, "Should capture start date.")
+        XCTAssertNotNil(interception.endDate, "Should capture end date.")
     }
 
     func testAutomaticMode_tracksCompletionForDelegatelessNWTask() throws {
@@ -2151,7 +2151,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
         }
         guard URLSessionTaskSwizzler.NWTaskResume.build() != nil else {
-            throw XCTSkip("NW task tracking not fully supported on this platform/version")
+            throw XCTSkip("NW task tracking not supported on this platform/version")
         }
         let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
         let url = URL(string: "https://localhost:1")!
@@ -2186,7 +2186,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
         }
         guard URLSessionTaskSwizzler.NWTaskResume.build() != nil else {
-            throw XCTSkip("NW task tracking not fully supported on this platform/version")
+            throw XCTSkip("NW task tracking not supported on this platform/version")
         }
         let notifyRequestMutation = expectation(description: "Notify request mutation")
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
@@ -232,7 +232,9 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         defer { session.invalidateAndCancel() }
         let task = session.dataTask(with: URL(string: "https://localhost:1")!) { _, _, _ in }
         let taskClassName = String(describing: type(of: task))
-        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        guard taskClassName.hasPrefix("NWURLSession") else {
+            throw XCTSkip("usesClassicLoadingMode = false does not create NWURLSessionTask on this platform")
+        }
         task.resume()
 
         // Then

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
@@ -211,7 +211,8 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         guard #available(iOS 18.4, tvOS 18.4, macOS 15.4, watchOS 11.4, visionOS 2.4, *) else {
             throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
         }
-        guard URLSessionTaskStateSwizzler.NWTaskComplete.build() != nil else {
+        guard URLSessionTaskStateSwizzler.NWTaskComplete.build() != nil ||
+              URLSessionTaskStateSwizzler.NWTaskCompleteRetryable.build() != nil else {
             throw XCTSkip("NW task completion not supported on this platform/version")
         }
         let completionExpectation = expectation(description: "NWURLSessionTask completion intercepted")

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
@@ -206,4 +206,36 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
 
         swizzler.unswizzle()
     }
+
+    func testSwizzling_nwTaskComplete_interceptsCompletion() throws {
+        guard #available(iOS 18.4, tvOS 18.4, macOS 15.4, watchOS 11.4, visionOS 2.4, *) else {
+            throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
+        }
+        guard URLSessionTaskStateSwizzler.NWTaskComplete.build() != nil else {
+            throw XCTSkip("NW task completion not supported on this platform/version")
+        }
+        let completionExpectation = expectation(description: "NWURLSessionTask completion intercepted")
+
+        // Given
+        let swizzler = URLSessionTaskStateSwizzler()
+        try swizzler.swizzle(interceptSetState: { _, state in
+            if state == URLSessionTask.State.completed.rawValue {
+                completionExpectation.fulfill()
+            }
+        })
+
+        // When - usesClassicLoadingMode = false forces NWURLSessionTask instances
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.usesClassicLoadingMode = false
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+        let task = session.dataTask(with: URL(string: "https://localhost:1")!) { _, _, _ in }
+        let taskClassName = String(describing: type(of: task))
+        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        task.resume()
+
+        // Then
+        wait(for: [completionExpectation], timeout: 5)
+        swizzler.unswizzle()
+    }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskSwizzlerTests.swift
@@ -37,4 +37,32 @@ class URLSessionTaskSwizzlerTests: XCTestCase {
         // Then
         wait(for: [expectation], timeout: 5)
     }
+
+    func testSwizzling_nwTaskResume() throws {
+        guard #available(iOS 18.4, tvOS 18.4, macOS 15.4, watchOS 11.4, visionOS 2.4, *) else {
+            throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
+        }
+        guard URLSessionTaskSwizzler.NWTaskResume.build() != nil else {
+            throw XCTSkip("NW task tracking not fully supported on this platform/version")
+        }
+        let intercepted = expectation(description: "NWURLSessionTask.resume intercepted")
+
+        // Given
+        let swizzler = URLSessionTaskSwizzler()
+        try swizzler.swizzle(interceptResume: { _ in intercepted.fulfill() })
+
+        // When - usesClassicLoadingMode = false forces NWURLSessionTask instances
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.usesClassicLoadingMode = false
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+        let task = session.dataTask(with: URL(string: "https://localhost:1")!)
+        let taskClassName = String(describing: type(of: task))
+        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        task.resume()
+
+        // Then
+        wait(for: [intercepted], timeout: 5)
+        swizzler.unswizzle()
+    }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskSwizzlerTests.swift
@@ -58,7 +58,9 @@ class URLSessionTaskSwizzlerTests: XCTestCase {
         defer { session.invalidateAndCancel() }
         let task = session.dataTask(with: URL(string: "https://localhost:1")!)
         let taskClassName = String(describing: type(of: task))
-        XCTAssert(taskClassName.hasPrefix("NWURLSession"), "Expected NWURLSessionTask, got \(taskClassName)")
+        guard taskClassName.hasPrefix("NWURLSession") else {
+            throw XCTSkip("usesClassicLoadingMode = false does not create NWURLSessionTask on this platform")
+        }
         task.resume()
 
         // Then

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskSwizzlerTests.swift
@@ -43,7 +43,7 @@ class URLSessionTaskSwizzlerTests: XCTestCase {
             throw XCTSkip("usesClassicLoadingMode requires iOS 18.4+")
         }
         guard URLSessionTaskSwizzler.NWTaskResume.build() != nil else {
-            throw XCTSkip("NW task tracking not fully supported on this platform/version")
+            throw XCTSkip("NW task tracking not supported on this platform/version")
         }
         let intercepted = expectation(description: "NWURLSessionTask.resume intercepted")
 


### PR DESCRIPTION
### What and why?

On iOS/tvOS 18.4+, setting `URLSessionConfiguration.usesClassicLoadingMode = false` switches URLSession to a Network.framework-backed task stack that returns `NWURLSessionTask` instances instead of `__NSCFLocalSessionTask`. Our existing swizzles only targeted `__NSCFLocalSessionTask`, so all network tracking silently stopped for sessions using this configuration.

Fixes https://github.com/DataDog/dd-sdk-ios/issues/3012.

### How?

Added two inner classes to the existing swizzlers — no changes to public API or the `NetworkInstrumentationFeature` interface:

- **`NWTaskResume`** (in `URLSessionTaskSwizzler`): swizzles `NWURLSessionTask.resume` alongside the classic task, using the same `interceptResume` callback.
- **`NWTaskComplete`** (in `URLSessionTaskStateSwizzler`): swizzles `NWURLSessionTask.completeTaskWithError:` (the equivalent of `setState:` on the new stack) and maps it to a completed-state transition.

Both return `nil` on iOS/tvOS < 18.4 if `NWURLSessionTask` is not present, so there is no impact on existing behavior.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs — N/A, no public API changes
- [ ] Run `make api-surface` when adding new APIs — N/A, no new APIs