### PR TITLE
[PANA-7890] Add layer snapshot processor

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -355,12 +355,14 @@
 		5BB294C02E83E02900CAA44B /* ExposureLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */; };
 		5BB771A62FE5917900C95960 /* CompositionTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771A52FE5916E00C95960 /* CompositionTreeBuilder.swift */; };
 		5BB771BA2FEF3A3E00C95960 /* LayerRecordBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B92FEF3A3E00C95960 /* LayerRecordBuilder.swift */; };
+		759302012FF0000100000001 /* LayerSnapshotProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759302002FF0000100000001 /* LayerSnapshotProcessor.swift */; };
 		5BB771A82FE59F9000C95960 /* Path+CornerRadii.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771A72FE59F8500C95960 /* Path+CornerRadii.swift */; };
 		5BB771AA2FE7E85100C95960 /* CALayerSnapshot+SRCompositionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771A92FE7E84500C95960 /* CALayerSnapshot+SRCompositionLayer.swift */; };
 		5BB771AC2FE8769B00C95960 /* CompositionTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AB2FE8769B00C95960 /* CompositionTreeBuilderTests.swift */; };
 		5BB771AE2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */; };
 		5BB771B02FE876D600C95960 /* PathCornerRadiiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */; };
 		5BB771BC2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771BB2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift */; };
+		759302032FF0000100000001 /* LayerSnapshotProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759302022FF0000100000001 /* LayerSnapshotProcessorTests.swift */; };
 		5BB771B42FE9848900C95960 /* WKWebView+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */; };
 		5BB771B62FEA7A0E00C95960 /* ImageSnapshotResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B52FEA7A0E00C95960 /* ImageSnapshotResource.swift */; };
 		5BB771B82FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */; };
@@ -2131,12 +2133,14 @@
 		5BB294BF2E83E02100CAA44B /* ExposureLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLogger.swift; sourceTree = "<group>"; };
 		5BB771A52FE5916E00C95960 /* CompositionTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionTreeBuilder.swift; sourceTree = "<group>"; };
 		5BB771B92FEF3A3E00C95960 /* LayerRecordBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerRecordBuilder.swift; sourceTree = "<group>"; };
+		759302002FF0000100000001 /* LayerSnapshotProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerSnapshotProcessor.swift; sourceTree = "<group>"; };
 		5BB771A72FE59F8500C95960 /* Path+CornerRadii.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+CornerRadii.swift"; sourceTree = "<group>"; };
 		5BB771A92FE7E84500C95960 /* CALayerSnapshot+SRCompositionLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayerSnapshot+SRCompositionLayer.swift"; sourceTree = "<group>"; };
 		5BB771AB2FE8769B00C95960 /* CompositionTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositionTreeBuilderTests.swift; sourceTree = "<group>"; };
 		5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerSnapshotSRCompositionLayerTests.swift; sourceTree = "<group>"; };
 		5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathCornerRadiiTests.swift; sourceTree = "<group>"; };
 		5BB771BB2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerRecordBuilderTests.swift; sourceTree = "<group>"; };
+		759302022FF0000100000001 /* LayerSnapshotProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerSnapshotProcessorTests.swift; sourceTree = "<group>"; };
 		5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+SessionReplay.swift"; sourceTree = "<group>"; };
 		5BB771B52FEA7A0E00C95960 /* ImageSnapshotResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotResource.swift; sourceTree = "<group>"; };
 		5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRWireframe+CALayerSnapshot.swift"; sourceTree = "<group>"; };
@@ -3981,6 +3985,7 @@
 				5BB771AD2FE876B000C95960 /* CALayerSnapshotSRCompositionLayerTests.swift */,
 				5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */,
 				5BB771BB2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift */,
+				759302022FF0000100000001 /* LayerSnapshotProcessorTests.swift */,
 			);
 			path = LayerTreeRecorder;
 			sourceTree = "<group>";
@@ -6053,6 +6058,7 @@
 				5BB771A92FE7E84500C95960 /* CALayerSnapshot+SRCompositionLayer.swift */,
 				5BB771A52FE5916E00C95960 /* CompositionTreeBuilder.swift */,
 				5BB771B92FEF3A3E00C95960 /* LayerRecordBuilder.swift */,
+				759302002FF0000100000001 /* LayerSnapshotProcessor.swift */,
 				759200052FD2000100000001 /* ImageSnapshot.swift */,
 				5B1877C02FDC0607005AC2CE /* ImageSnapshot+Redaction.swift */,
 				759200072FD2000100000001 /* ImageSnapshotCache.swift */,
@@ -8320,6 +8326,7 @@
 				969B3B212C33F80500D62400 /* UIActivityIndicatorRecorder.swift in Sources */,
 				5BB771A62FE5917900C95960 /* CompositionTreeBuilder.swift in Sources */,
 				5BB771BA2FEF3A3E00C95960 /* LayerRecordBuilder.swift in Sources */,
+				759302012FF0000100000001 /* LayerSnapshotProcessor.swift in Sources */,
 				61054EA22A6EE10B00AAA894 /* Scheduler.swift in Sources */,
 				A7EA88562B17639A00FE2580 /* ResourcesWriter.swift in Sources */,
 				5BF2BA9F2FBF1393000E999C /* CALayer+ReplayID.swift in Sources */,
@@ -8515,6 +8522,7 @@
 				17EFC9D8185942399E05BDB4 /* OcclusionMapTests.swift in Sources */,
 				5BB771AC2FE8769B00C95960 /* CompositionTreeBuilderTests.swift in Sources */,
 				5BB771BC2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift in Sources */,
+				759302032FF0000100000001 /* LayerSnapshotProcessorTests.swift in Sources */,
 				EF5678AB9012CD345678EFAB /* CALayerSnapshotOcclusionTests.swift in Sources */,
 				BC9876FA1234CDEF56789ABC /* NSObject+CAFilter.swift in Sources */,
 				7592000E2FD2000100000001 /* ImageSnapshotCacheTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -363,6 +363,7 @@
 		5BB771B02FE876D600C95960 /* PathCornerRadiiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */; };
 		5BB771BC2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771BB2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift */; };
 		759302032FF0000100000001 /* LayerSnapshotProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759302022FF0000100000001 /* LayerSnapshotProcessorTests.swift */; };
+		759302052FF0000100000001 /* LayerTreeSnapshotMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759302042FF0000100000001 /* LayerTreeSnapshotMocks.swift */; };
 		5BB771B42FE9848900C95960 /* WKWebView+SessionReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */; };
 		5BB771B62FEA7A0E00C95960 /* ImageSnapshotResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B52FEA7A0E00C95960 /* ImageSnapshotResource.swift */; };
 		5BB771B82FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */; };
@@ -2141,6 +2142,7 @@
 		5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathCornerRadiiTests.swift; sourceTree = "<group>"; };
 		5BB771BB2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerRecordBuilderTests.swift; sourceTree = "<group>"; };
 		759302022FF0000100000001 /* LayerSnapshotProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerSnapshotProcessorTests.swift; sourceTree = "<group>"; };
+		759302042FF0000100000001 /* LayerTreeSnapshotMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerTreeSnapshotMocks.swift; sourceTree = "<group>"; };
 		5BB771B32FE9847F00C95960 /* WKWebView+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+SessionReplay.swift"; sourceTree = "<group>"; };
 		5BB771B52FEA7A0E00C95960 /* ImageSnapshotResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshotResource.swift; sourceTree = "<group>"; };
 		5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRWireframe+CALayerSnapshot.swift"; sourceTree = "<group>"; };
@@ -3986,6 +3988,7 @@
 				5BB771AF2FE876D600C95960 /* PathCornerRadiiTests.swift */,
 				5BB771BB2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift */,
 				759302022FF0000100000001 /* LayerSnapshotProcessorTests.swift */,
+				759302042FF0000100000001 /* LayerTreeSnapshotMocks.swift */,
 			);
 			path = LayerTreeRecorder;
 			sourceTree = "<group>";
@@ -8523,6 +8526,7 @@
 				5BB771AC2FE8769B00C95960 /* CompositionTreeBuilderTests.swift in Sources */,
 				5BB771BC2FEF3A6F00C95960 /* LayerRecordBuilderTests.swift in Sources */,
 				759302032FF0000100000001 /* LayerSnapshotProcessorTests.swift in Sources */,
+				759302052FF0000100000001 /* LayerTreeSnapshotMocks.swift in Sources */,
 				EF5678AB9012CD345678EFAB /* CALayerSnapshotOcclusionTests.swift in Sources */,
 				BC9876FA1234CDEF56789ABC /* NSObject+CAFilter.swift in Sources */,
 				7592000E2FD2000100000001 /* ImageSnapshotCacheTests.swift in Sources */,

--- a/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
+++ b/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
@@ -19,9 +19,7 @@ internal struct RecordingComponents {
         if #available(iOS 13.0, tvOS 13.0, *), configuration.featureFlags[.layerTreeRecording] {
             // This is purely defensive, as `SessionReplay.enable()` initializes on the main thread
             self = try runOnMainThreadSync {
-                try MainActor.assumeIsolated {
-                    try .layerTreeRecordingComponents(core: core, configuration: configuration)
-                }
+                try .layerTreeRecordingComponents(core: core, configuration: configuration)
             }
         } else {
             self = try .viewTreeRecordingComponents(core: core, configuration: configuration)
@@ -100,10 +98,27 @@ internal struct RecordingComponents {
         core: DatadogCoreProtocol,
         configuration: SessionReplay.Configuration
     ) throws -> Self {
-        let telemetryQueue = BackgroundAsyncQueue(label: "com.datadoghq.session-replay.telemetry", qos: .background)
+        let processorsQueue = BackgroundAsyncQueue(label: "com.datadoghq.session-replay.processors", qos: .utility)
+        // The telemetry queue targets the processors queue with a lower qos.
+        let telemetryQueue = BackgroundAsyncQueue(
+            label: "com.datadoghq.session-replay.telemetry",
+            qos: .background,
+            target: processorsQueue
+        )
         let telemetry = SessionReplayTelemetry(
             telemetry: core.telemetry,
             queue: telemetryQueue
+        )
+        let resourceProcessor = ResourceProcessor(
+            queue: processorsQueue,
+            resourcesWriter: ResourcesWriter(scope: core.scope(for: ResourcesFeature.self))
+        )
+        let snapshotProcessor = LayerSnapshotProcessor(
+            queue: processorsQueue,
+            recordWriter: RecordWriter(core: core),
+            resourceProcessor: resourceProcessor,
+            replayContextPublisher: SRContextPublisher(core: core),
+            telemetry: telemetry
         )
 
         let keyWindowObserver = KeyWindowObserver()
@@ -116,7 +131,8 @@ internal struct RecordingComponents {
             imageSnapshotter: ImageSnapshotter(
                 screenChangeFilter: screenChangeFilter,
                 telemetry: telemetry
-            )
+            ),
+            snapshotProcessor: snapshotProcessor
         )
         let screenChangeMonitor = try ScreenChangeMonitor(
             minimumDeliveryInterval: 0.1,

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecorder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecorder.swift
@@ -18,6 +18,7 @@ internal actor LayerRecorder: LayerRecording {
     private let uiApplicationSwizzler: UIApplicationSwizzler
     private let touchSnapshotProducer: any TouchSnapshotProducer
     private let imageSnapshotter: any ImageSnapshotting
+    private let snapshotProcessor: any LayerSnapshotProcessing
     private let timeoutInterval: TimeInterval
     private let timeSource: any TimeSource
 
@@ -28,6 +29,7 @@ internal actor LayerRecorder: LayerRecording {
         uiApplicationSwizzler: UIApplicationSwizzler,
         touchSnapshotProducer: any TouchSnapshotProducer,
         imageSnapshotter: any ImageSnapshotting,
+        snapshotProcessor: any LayerSnapshotProcessing,
         timeoutInterval: TimeInterval = 0.09,
         timeSource: any TimeSource = MediaTimeSource()
     ) {
@@ -35,6 +37,7 @@ internal actor LayerRecorder: LayerRecording {
         self.uiApplicationSwizzler = uiApplicationSwizzler
         self.touchSnapshotProducer = touchSnapshotProducer
         self.imageSnapshotter = imageSnapshotter
+        self.snapshotProcessor = snapshotProcessor
         self.timeoutInterval = timeoutInterval
         self.timeSource = timeSource
 
@@ -58,7 +61,11 @@ internal actor LayerRecorder: LayerRecording {
 
     private func record(_ changeset: CALayerChangeset, context: LayerRecordingContext) async {
         let startTime = timeSource.now
-        let (layerTreeSnapshot, touchSnapshot) = await takeSnapshot(context: context)
+        let (layerTreeSnapshot, touchSnapshot) = await takeSnapshot(
+            context: context,
+            snapshotBuilder: snapshotBuilder,
+            touchSnapshotProducer: touchSnapshotProducer
+        )
 
         guard
             var layerTreeSnapshot,
@@ -76,35 +83,41 @@ internal actor LayerRecorder: LayerRecording {
             timeout: remainingTime
         )
 
-        _ = (layerTreeSnapshot, touchSnapshot, imageSnapshots)
-        // TODO: PANA-7784 Process optimized layer tree, image snapshots, and touch snapshots
+        snapshotProcessor.process(
+            layerTreeSnapshot: layerTreeSnapshot,
+            imageSnapshotResults: imageSnapshots,
+            touchSnapshot: touchSnapshot
+        )
     }
 
-    private func takeSnapshot(context: LayerRecordingContext) async -> (LayerTreeSnapshot?, TouchSnapshot?) {
-        return await MainActor.run { [snapshotBuilder, touchSnapshotProducer] in
-            do {
-                return try objc_rethrow { () -> (LayerTreeSnapshot?, TouchSnapshot?) in
-                    guard let layerTreeSnapshot = snapshotBuilder.takeSnapshot(context: context) else {
-                        return (nil, nil)
-                    }
-                    let touchSnapshot = touchSnapshotProducer.takeSnapshot(
-                        context: .init(
-                            touchPrivacy: context.touchPrivacy,
-                            viewServerTimeOffset: context.viewServerTimeOffset
-                        )
-                    )
-                    return (layerTreeSnapshot, touchSnapshot)
+    @MainActor
+    private func takeSnapshot(
+        context: LayerRecordingContext,
+        snapshotBuilder: any LayerTreeSnapshotBuilding,
+        touchSnapshotProducer: any TouchSnapshotProducer
+    ) -> (LayerTreeSnapshot?, TouchSnapshot?) {
+        do {
+            return try objc_rethrow { () -> (LayerTreeSnapshot?, TouchSnapshot?) in
+                guard let layerTreeSnapshot = snapshotBuilder.takeSnapshot(context: context) else {
+                    return (nil, nil)
                 }
-            } catch let objc as ObjcException {
-                context.telemetry.error(
-                    "[SR] Failed to take snapshot due to Objective-C runtime exception",
-                    error: objc.error
+                let touchSnapshot = touchSnapshotProducer.takeSnapshot(
+                    context: .init(
+                        touchPrivacy: context.touchPrivacy,
+                        viewServerTimeOffset: context.viewServerTimeOffset
+                    )
                 )
-                return (nil, nil)
-            } catch {
-                context.telemetry.error("[SR] Failed to take snapshot", error: error)
-                return (nil, nil)
+                return (layerTreeSnapshot, touchSnapshot)
             }
+        } catch let objc as ObjcException {
+            context.telemetry.error(
+                "[SR] Failed to take snapshot due to Objective-C runtime exception",
+                error: objc.error
+            )
+            return (nil, nil)
+        } catch {
+            context.telemetry.error("[SR] Failed to take snapshot", error: error)
+            return (nil, nil)
         }
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerSnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerSnapshotProcessor.swift
@@ -1,0 +1,196 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import DatadogInternal
+import Foundation
+
+/// Turns layer tree, image, and touch snapshots into Session Replay records.
+@available(iOS 13.0, tvOS 13.0, *)
+internal protocol LayerSnapshotProcessing {
+    func process(
+        layerTreeSnapshot: LayerTreeSnapshot,
+        imageSnapshotResults: [Int64: ImageSnapshotResult],
+        touchSnapshot: TouchSnapshot?
+    )
+}
+
+/// Builds and writes Session Replay records for the Core Animation recording pipeline.
+@available(iOS 13.0, tvOS 13.0, *)
+internal final class LayerSnapshotProcessor: LayerSnapshotProcessing {
+    private let queue: Queue
+    private let recordWriter: RecordWriting
+    private let resourceProcessor: ResourceProcessing
+    private let replayContextPublisher: SRContextPublisher
+    private let telemetry: Telemetry
+    private let recordBuilder = LayerRecordBuilder()
+
+    private var lastSnapshot: LayerTreeSnapshot?
+    private var lastCompositionTree: SRCompositionTree?
+    private var lastWireframes: [SRWireframe]?
+    private var recordsCountByViewID: [String: Int64] = [:]
+
+    init(
+        queue: Queue,
+        recordWriter: RecordWriting,
+        resourceProcessor: ResourceProcessing,
+        replayContextPublisher: SRContextPublisher,
+        telemetry: Telemetry
+    ) {
+        self.queue = queue
+        self.recordWriter = recordWriter
+        self.resourceProcessor = resourceProcessor
+        self.replayContextPublisher = replayContextPublisher
+        self.telemetry = telemetry
+    }
+
+    func process(
+        layerTreeSnapshot: LayerTreeSnapshot,
+        imageSnapshotResults: [Int64: ImageSnapshotResult],
+        touchSnapshot: TouchSnapshot?
+    ) {
+        queue.run { [weak self] in
+            self?.processSync(
+                layerTreeSnapshot: layerTreeSnapshot,
+                imageSnapshotResults: imageSnapshotResults,
+                touchSnapshot: touchSnapshot
+            )
+        }
+    }
+
+    private func processSync(
+        layerTreeSnapshot: LayerTreeSnapshot,
+        imageSnapshotResults: [Int64: ImageSnapshotResult],
+        touchSnapshot: TouchSnapshot?
+    ) {
+        let output = CompositionTreeBuilder(
+            root: layerTreeSnapshot.root,
+            webViewSlotIDs: layerTreeSnapshot.webViewSlotIDs,
+            imageSnapshotResults: imageSnapshotResults
+        ).build()
+
+        var records = records(
+            from: layerTreeSnapshot,
+            compositionTree: output.compositionTree,
+            wireframes: output.wireframes
+        )
+
+        if let touchSnapshot {
+            records.append(contentsOf: recordBuilder.touchRecords(from: touchSnapshot))
+        }
+
+        if !records.isEmpty {
+            let enrichedRecord = EnrichedRecord(context: layerTreeSnapshot.context, records: records)
+            trackRecord(key: enrichedRecord.viewID, value: Int64(records.count))
+            recordWriter.write(nextRecord: enrichedRecord)
+        }
+
+        lastSnapshot = layerTreeSnapshot
+        lastCompositionTree = output.compositionTree
+        lastWireframes = output.wireframes
+
+        resourceProcessor.process(
+            resources: output.resources,
+            context: .init(layerTreeSnapshot.context.applicationID)
+        )
+    }
+
+    private func records(
+        from snapshot: LayerTreeSnapshot,
+        compositionTree: SRCompositionTree,
+        wireframes: [SRWireframe]
+    ) -> [SRRecord] {
+        guard !snapshot.shouldStartNewSegment(after: lastSnapshot) else {
+            return [
+                recordBuilder.metaRecord(from: snapshot),
+                recordBuilder.focusRecord(from: snapshot),
+                recordBuilder.fullSnapshotRecord(
+                    from: snapshot,
+                    compositionTree: compositionTree,
+                    wireframes: wireframes
+                )
+            ]
+        }
+
+        guard
+            let lastSnapshot,
+            let lastCompositionTree,
+            let lastWireframes
+        else {
+            telemetry.error("[SR] Unexpected flow in `LayerSnapshotProcessor`: missing previous layer recording state")
+            return [
+                recordBuilder.fullSnapshotRecord(
+                    from: snapshot,
+                    compositionTree: compositionTree,
+                    wireframes: wireframes
+                )
+            ]
+        }
+
+        do {
+            var records: [SRRecord] = []
+
+            if let record = try recordBuilder.wireframeMutationRecord(
+                from: snapshot,
+                wireframes: wireframes,
+                previousWireframes: lastWireframes
+            ) {
+                records.append(record)
+            }
+
+            if let record = try recordBuilder.compositionTreeMutationRecord(
+                from: snapshot,
+                compositionTree: compositionTree,
+                previousCompositionTree: lastCompositionTree
+            ) {
+                records.append(record)
+            }
+
+            if let record = recordBuilder.viewportRecord(
+                from: snapshot,
+                previousSnapshot: lastSnapshot
+            ) {
+                records.append(record)
+            }
+
+            return records
+        } catch {
+            telemetry.error("[SR] Failed to build layer recording mutation records", error: error)
+            return [
+                recordBuilder.fullSnapshotRecord(
+                    from: snapshot,
+                    compositionTree: compositionTree,
+                    wireframes: wireframes
+                )
+            ]
+        }
+    }
+
+    private func trackRecord(key: String, value: Int64) {
+        recordsCountByViewID[key, default: 0] += value
+        replayContextPublisher.setRecordsCountByViewID(recordsCountByViewID)
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+private extension LayerTreeSnapshot {
+    func shouldStartNewSegment(after previousSnapshot: LayerTreeSnapshot?) -> Bool {
+        return context.applicationID != previousSnapshot?.context.applicationID ||
+            context.sessionID != previousSnapshot?.context.sessionID ||
+            context.viewID != previousSnapshot?.context.viewID
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+private extension EnrichedRecord {
+    init(context: LayerRecordingContext, records: [SRRecord]) {
+        self.applicationID = context.applicationID
+        self.sessionID = context.sessionID
+        self.viewID = context.viewID
+        self.records = records
+    }
+}
+#endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerSnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerSnapshotProcessor.swift
@@ -130,9 +130,9 @@ internal final class LayerSnapshotProcessor: LayerSnapshotProcessing {
             ]
         }
 
-        do {
-            var records: [SRRecord] = []
+        var records: [SRRecord] = []
 
+        do {
             if let record = try recordBuilder.wireframeMutationRecord(
                 from: snapshot,
                 wireframes: wireframes,
@@ -148,25 +148,25 @@ internal final class LayerSnapshotProcessor: LayerSnapshotProcessing {
             ) {
                 records.append(record)
             }
-
-            if let record = recordBuilder.viewportRecord(
-                from: snapshot,
-                previousSnapshot: lastSnapshot
-            ) {
-                records.append(record)
-            }
-
-            return records
         } catch {
             telemetry.error("[SR] Failed to build layer recording mutation records", error: error)
-            return [
+            records.append(
                 recordBuilder.fullSnapshotRecord(
                     from: snapshot,
                     compositionTree: compositionTree,
                     wireframes: wireframes
                 )
-            ]
+            )
         }
+
+        if let record = recordBuilder.viewportRecord(
+            from: snapshot,
+            previousSnapshot: lastSnapshot
+        ) {
+            records.append(record)
+        }
+
+        return records
     }
 
     private func trackRecord(key: String, value: Int64) {

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -181,6 +181,7 @@ extension SRImageWireframe: MutableWireframe {
                 id: id,
                 isEmpty: use(isEmpty, ifDifferentThan: other.isEmpty),
                 mimeType: use(mimeType, ifDifferentThan: other.mimeType),
+                resourceId: use(resourceId, ifDifferentThan: other.resourceId),
                 shapeStyle: use(shapeStyle, ifDifferentThan: other.shapeStyle),
                 width: use(width, ifDifferentThan: other.width),
                 x: use(x, ifDifferentThan: other.x),

--- a/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/Processor/SnapshotProcessor.swift
@@ -27,7 +27,7 @@ internal protocol SnapshotProcessing {
 ///
 /// VTSs processing is following:
 /// - the VTS is broke apart into individual view snapshots, mapped into array of SR wireframes (see `WireframesBuilder`);
-/// - the array of wireframes is attached to SR record (see `RecordsBuidler`);
+/// - the array of wireframes is attached to SR record (see `RecordsBuilder`);
 /// - succeeding records are enriched with their RUM context and written to `DatadogCore`;
 /// - when `DatadogCore` triggers an upload, batched records are deserialized, grouped into SR segments and then uploaded.
 internal class SnapshotProcessor: SnapshotProcessing {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerRecordBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerRecordBuilderTests.swift
@@ -8,7 +8,7 @@
 import CoreGraphics
 @_spi(Internal)
 import DatadogInternal
-import QuartzCore
+import Foundation
 import Testing
 @_spi(Internal)
 import TestUtilities
@@ -283,76 +283,6 @@ struct LayerRecordBuilderTests {
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
-private extension LayerTreeSnapshot {
-    static func mockWith(
-        date: Date = Date(timeIntervalSince1970: 42),
-        viewportSize: CGSize = CGSize(width: 320, height: 640)
-    ) -> LayerTreeSnapshot {
-        return LayerTreeSnapshot(
-            date: date,
-            context: LayerRecordingContext(
-                textAndInputPrivacy: .maskSensitiveInputs,
-                imagePrivacy: .maskNone,
-                touchPrivacy: .show,
-                applicationID: "app-id",
-                sessionID: "session-id",
-                viewID: "view-id",
-                viewServerTimeOffset: 2,
-                viewPath: "/view",
-                date: date,
-                telemetry: NOPTelemetry()
-            ),
-            viewportSize: viewportSize,
-            root: .mockWith(),
-            webViewSlotIDs: []
-        )
-    }
-}
-
-@available(iOS 13.0, tvOS 13.0, *)
-private extension CALayerSnapshot {
-    static func mockWith(replayID: Int64 = 1) -> CALayerSnapshot {
-        let layer = CALayer()
-        return CALayerSnapshot(
-            layer: CALayerReference(layer),
-            replayID: replayID,
-            observation: .init(semantics: .layer),
-            layerClass: CALayer.self,
-            delegateClass: nil,
-            contentsClass: nil,
-            textAndInputPrivacyLevel: .maskSensitiveInputs,
-            imagePrivacyLevel: .maskNone,
-            isPrivate: false,
-            bounds: .zero,
-            position: .zero,
-            zPosition: 0,
-            transform: CATransform3DIdentity,
-            absoluteFrame: .zero,
-            sublayers: [],
-            dependencies: [],
-            sublayerTransform: CATransform3DIdentity,
-            mask: nil,
-            masksToBounds: false,
-            isOpaque: false,
-            backgroundColor: nil,
-            cornerRadii: .zero,
-            cornerCurve: .circular,
-            borderWidth: 0,
-            borderColor: nil,
-            opacity: 1,
-            allowsGroupOpacity: true,
-            compositingFilter: nil,
-            filters: [],
-            shadowColor: nil,
-            shadowOpacity: 0,
-            shadowOffset: .zero,
-            shadowRadius: 0,
-            shadowPath: nil
-        )
-    }
-}
-
-@available(iOS 13.0, tvOS 13.0, *)
 private extension SRCompositionLayer {
     static func mockWith(
         id: Int64,
@@ -401,7 +331,4 @@ private extension SRIncrementalSnapshotRecord {
     }
 }
 
-private struct NOPTelemetry: Telemetry {
-    func send(telemetry: TelemetryMessage) {}
-}
 #endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerSnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerSnapshotProcessorTests.swift
@@ -8,7 +8,6 @@
 import CoreGraphics
 @_spi(Internal)
 import DatadogInternal
-import QuartzCore
 import Testing
 @_spi(Internal)
 import TestUtilities
@@ -198,99 +197,6 @@ private final class RecordWriterMock: RecordWriting {
 
     func write(nextRecord: EnrichedRecord) {
         records.append(nextRecord)
-    }
-}
-
-@available(iOS 13.0, tvOS 13.0, *)
-private extension LayerTreeSnapshot {
-    static func mockWith(
-        date: Date = Date(timeIntervalSince1970: 1),
-        applicationID: String = "app-id",
-        sessionID: String = "session-id",
-        viewID: String = "view-id",
-        viewportSize: CGSize = CGSize(width: 100, height: 200),
-        root: CALayerSnapshot = .mockRoot(),
-        webViewSlotIDs: Set<Int> = []
-    ) -> LayerTreeSnapshot {
-        return LayerTreeSnapshot(
-            date: date,
-            context: LayerRecordingContext(
-                textAndInputPrivacy: .maskSensitiveInputs,
-                imagePrivacy: .maskNone,
-                touchPrivacy: .show,
-                applicationID: applicationID,
-                sessionID: sessionID,
-                viewID: viewID,
-                viewServerTimeOffset: 0,
-                viewPath: "/view",
-                date: date,
-                telemetry: TelemetryMock()
-            ),
-            viewportSize: viewportSize,
-            root: root,
-            webViewSlotIDs: webViewSlotIDs
-        )
-    }
-}
-
-@available(iOS 13.0, tvOS 13.0, *)
-private extension CALayerSnapshot {
-    static func mockRoot(
-        absoluteFrame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 200),
-        sublayers: [CALayerSnapshot] = []
-    ) -> CALayerSnapshot {
-        return mockWith(
-            replayID: 1,
-            absoluteFrame: absoluteFrame,
-            backgroundColor: nil,
-            sublayers: sublayers
-        )
-    }
-
-    static func mockWith(
-        replayID: Int64,
-        absoluteFrame: CGRect,
-        backgroundColor: CGColor? = nil,
-        isPrivate: Bool = false,
-        sublayers: [CALayerSnapshot] = []
-    ) -> CALayerSnapshot {
-        let layer = CALayer()
-        return CALayerSnapshot(
-            layer: CALayerReference(layer),
-            replayID: replayID,
-            observation: .init(semantics: .layer),
-            layerClass: CALayer.self,
-            delegateClass: nil,
-            contentsClass: nil,
-            textAndInputPrivacyLevel: .maskSensitiveInputs,
-            imagePrivacyLevel: .maskNone,
-            isPrivate: isPrivate,
-            bounds: CGRect(origin: .zero, size: absoluteFrame.size),
-            position: absoluteFrame.origin,
-            zPosition: 0,
-            transform: CATransform3DIdentity,
-            absoluteFrame: absoluteFrame,
-            sublayers: sublayers,
-            dependencies: [],
-            sublayerTransform: CATransform3DIdentity,
-            mask: nil,
-            masksToBounds: false,
-            isOpaque: false,
-            backgroundColor: backgroundColor,
-            cornerRadii: .zero,
-            cornerCurve: .circular,
-            borderWidth: 0,
-            borderColor: nil,
-            opacity: 1,
-            allowsGroupOpacity: true,
-            compositingFilter: nil,
-            filters: [],
-            shadowColor: nil,
-            shadowOpacity: 0,
-            shadowOffset: .zero,
-            shadowRadius: 0,
-            shadowPath: nil
-        )
     }
 }
 

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerSnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerSnapshotProcessorTests.swift
@@ -1,0 +1,373 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import CoreGraphics
+@_spi(Internal)
+import DatadogInternal
+import QuartzCore
+import Testing
+@_spi(Internal)
+import TestUtilities
+import UIKit
+@_spi(Internal)
+@testable import DatadogSessionReplay
+
+struct LayerSnapshotProcessorTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("First layer tree snapshot starts a segment and processes resources")
+    func firstLayerTreeSnapshotStartsSegmentAndProcessesResources() throws {
+        // Given
+        let fixture = Fixture()
+        let leaf = CALayerSnapshot.mockWith(
+            replayID: 2,
+            absoluteFrame: CGRect(x: 10, y: 20, width: 30, height: 40)
+        )
+        let snapshot = LayerTreeSnapshot.mockWith(root: .mockRoot(sublayers: [leaf]))
+        let imageSnapshot = ImageSnapshot.mockAny(
+            image: .mockWith(color: .red),
+            frame: leaf.absoluteFrame,
+            hasLayerSemantics: false,
+            imagePrivacyLevel: .maskNone
+        )
+
+        // When
+        fixture.processor.process(
+            layerTreeSnapshot: snapshot,
+            imageSnapshotResults: [2: .success(imageSnapshot)],
+            touchSnapshot: nil
+        )
+
+        // Then
+        let enrichedRecord = try #require(fixture.recordWriter.records.first)
+        #expect(fixture.recordWriter.records.count == 1)
+        #expect(enrichedRecord.records.map(\.type) == [.meta, .focus, .fullSnapshot])
+        #expect(enrichedRecord.records[2].fullSnapshot?.data.wireframes.count == 1)
+
+        #expect(fixture.resourceProcessor.processedResources.count == 1)
+        #expect(fixture.resourceProcessor.resources.count == 1)
+        #expect(fixture.resourceProcessor.processedResources.first?.context.application.id == "app-id")
+        #expect(fixture.core.recordsCountByViewID == ["view-id": 3])
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Same context writes wireframe, composition tree, viewport, and touch records in order")
+    func sameContextWritesMutationViewportAndTouchRecordsInOrder() throws {
+        // Given
+        let fixture = Fixture()
+        let firstSnapshot = LayerTreeSnapshot.mockWith(
+            date: Date(timeIntervalSince1970: 1),
+            viewportSize: CGSize(width: 100, height: 200),
+            root: .mockRoot(sublayers: [
+                .mockWith(
+                    replayID: 2,
+                    absoluteFrame: CGRect(x: 0, y: 0, width: 10, height: 10),
+                    backgroundColor: UIColor.red.cgColor
+                )
+            ])
+        )
+        let secondSnapshot = LayerTreeSnapshot.mockWith(
+            date: Date(timeIntervalSince1970: 2),
+            viewportSize: CGSize(width: 200, height: 100),
+            root: .mockRoot(
+                absoluteFrame: CGRect(x: 0, y: 0, width: 200, height: 100),
+                sublayers: [
+                    .mockWith(
+                        replayID: 2,
+                        absoluteFrame: CGRect(x: 0, y: 0, width: 20, height: 10),
+                        backgroundColor: UIColor.red.cgColor
+                    ),
+                    .mockWith(
+                        replayID: 3,
+                        absoluteFrame: CGRect(x: 20, y: 0, width: 10, height: 10),
+                        backgroundColor: UIColor.blue.cgColor
+                    )
+                ]
+            )
+        )
+        let touchSnapshot = TouchSnapshot(
+            date: Date(timeIntervalSince1970: 2),
+            touches: [
+                .init(id: 42, phase: .down, date: Date(), position: CGPoint(x: 12, y: 34), touchOverride: nil)
+            ]
+        )
+
+        // When
+        fixture.processor.process(layerTreeSnapshot: firstSnapshot, imageSnapshotResults: [:], touchSnapshot: nil)
+        fixture.processor.process(layerTreeSnapshot: secondSnapshot, imageSnapshotResults: [:], touchSnapshot: touchSnapshot)
+
+        // Then
+        let enrichedRecord = try #require(fixture.recordWriter.records.last)
+        #expect(enrichedRecord.records.map(\.type) == [
+            .incrementalSnapshot,
+            .incrementalSnapshot,
+            .incrementalSnapshot,
+            .incrementalSnapshot
+        ])
+
+        #expect(enrichedRecord.records[0].incrementalSnapshot?.mutationData != nil)
+        #expect(enrichedRecord.records[1].incrementalSnapshot?.compositionTreeMutationData != nil)
+        #expect(enrichedRecord.records[2].incrementalSnapshot?.viewportResizeData != nil)
+        #expect(enrichedRecord.records[3].incrementalSnapshot?.pointerInteractionData != nil)
+        #expect(fixture.core.recordsCountByViewID == ["view-id": 7])
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("RUM context change starts a new segment")
+    func rumContextChangeStartsNewSegment() throws {
+        // Given
+        let fixture = Fixture()
+        let firstSnapshot = LayerTreeSnapshot.mockWith(viewID: "view-1")
+        let secondSnapshot = LayerTreeSnapshot.mockWith(viewID: "view-2")
+
+        // When
+        fixture.processor.process(layerTreeSnapshot: firstSnapshot, imageSnapshotResults: [:], touchSnapshot: nil)
+        fixture.processor.process(layerTreeSnapshot: secondSnapshot, imageSnapshotResults: [:], touchSnapshot: nil)
+
+        // Then
+        let enrichedRecord = try #require(fixture.recordWriter.records.last)
+        #expect(fixture.recordWriter.records.count == 2)
+        #expect(enrichedRecord.viewID == "view-2")
+        #expect(enrichedRecord.records.map(\.type) == [.meta, .focus, .fullSnapshot])
+        #expect(fixture.core.recordsCountByViewID == ["view-1": 3, "view-2": 3])
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Diffing errors fall back to a full snapshot and update state")
+    func diffingErrorsFallBackToFullSnapshotAndUpdateState() throws {
+        // Given
+        let fixture = Fixture()
+        let shapeSnapshot = LayerTreeSnapshot.mockWith(root: .mockRoot(sublayers: [
+            .mockWith(
+                replayID: 2,
+                absoluteFrame: CGRect(x: 0, y: 0, width: 10, height: 10),
+                backgroundColor: UIColor.red.cgColor
+            )
+        ]))
+        let privateSnapshot = LayerTreeSnapshot.mockWith(root: .mockRoot(sublayers: [
+            .mockWith(
+                replayID: 2,
+                absoluteFrame: CGRect(x: 0, y: 0, width: 10, height: 10),
+                isPrivate: true
+            )
+        ]))
+
+        // When
+        fixture.processor.process(layerTreeSnapshot: shapeSnapshot, imageSnapshotResults: [:], touchSnapshot: nil)
+        fixture.processor.process(layerTreeSnapshot: privateSnapshot, imageSnapshotResults: [:], touchSnapshot: nil)
+        fixture.processor.process(layerTreeSnapshot: privateSnapshot, imageSnapshotResults: [:], touchSnapshot: nil)
+
+        // Then
+        #expect(fixture.recordWriter.records.count == 2)
+        #expect(fixture.recordWriter.records[1].records.map(\.type) == [.fullSnapshot])
+        #expect(
+            fixture.telemetry.messages.firstError()?.message.hasPrefix(
+                "[SR] Failed to build layer recording mutation records"
+            ) == true
+        )
+        #expect(fixture.core.recordsCountByViewID == ["view-id": 4])
+    }
+}
+
+private extension LayerSnapshotProcessorTests {
+    @available(iOS 13.0, tvOS 13.0, *)
+    final class Fixture {
+        let core = PassthroughCoreMock()
+        let recordWriter = RecordWriterMock()
+        let resourceProcessor = ResourceProcessorSpy()
+        let telemetry = TelemetryMock()
+        let processor: LayerSnapshotProcessor
+
+        init() {
+            processor = LayerSnapshotProcessor(
+                queue: NoQueue(),
+                recordWriter: recordWriter,
+                resourceProcessor: resourceProcessor,
+                replayContextPublisher: SRContextPublisher(core: core),
+                telemetry: telemetry
+            )
+        }
+    }
+}
+
+private final class RecordWriterMock: RecordWriting {
+    var records: [EnrichedRecord] = []
+
+    func write(nextRecord: EnrichedRecord) {
+        records.append(nextRecord)
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+private extension LayerTreeSnapshot {
+    static func mockWith(
+        date: Date = Date(timeIntervalSince1970: 1),
+        applicationID: String = "app-id",
+        sessionID: String = "session-id",
+        viewID: String = "view-id",
+        viewportSize: CGSize = CGSize(width: 100, height: 200),
+        root: CALayerSnapshot = .mockRoot(),
+        webViewSlotIDs: Set<Int> = []
+    ) -> LayerTreeSnapshot {
+        return LayerTreeSnapshot(
+            date: date,
+            context: LayerRecordingContext(
+                textAndInputPrivacy: .maskSensitiveInputs,
+                imagePrivacy: .maskNone,
+                touchPrivacy: .show,
+                applicationID: applicationID,
+                sessionID: sessionID,
+                viewID: viewID,
+                viewServerTimeOffset: 0,
+                viewPath: "/view",
+                date: date,
+                telemetry: TelemetryMock()
+            ),
+            viewportSize: viewportSize,
+            root: root,
+            webViewSlotIDs: webViewSlotIDs
+        )
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+private extension CALayerSnapshot {
+    static func mockRoot(
+        absoluteFrame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 200),
+        sublayers: [CALayerSnapshot] = []
+    ) -> CALayerSnapshot {
+        return mockWith(
+            replayID: 1,
+            absoluteFrame: absoluteFrame,
+            backgroundColor: nil,
+            sublayers: sublayers
+        )
+    }
+
+    static func mockWith(
+        replayID: Int64,
+        absoluteFrame: CGRect,
+        backgroundColor: CGColor? = nil,
+        isPrivate: Bool = false,
+        sublayers: [CALayerSnapshot] = []
+    ) -> CALayerSnapshot {
+        let layer = CALayer()
+        return CALayerSnapshot(
+            layer: CALayerReference(layer),
+            replayID: replayID,
+            observation: .init(semantics: .layer),
+            layerClass: CALayer.self,
+            delegateClass: nil,
+            contentsClass: nil,
+            textAndInputPrivacyLevel: .maskSensitiveInputs,
+            imagePrivacyLevel: .maskNone,
+            isPrivate: isPrivate,
+            bounds: CGRect(origin: .zero, size: absoluteFrame.size),
+            position: absoluteFrame.origin,
+            zPosition: 0,
+            transform: CATransform3DIdentity,
+            absoluteFrame: absoluteFrame,
+            sublayers: sublayers,
+            dependencies: [],
+            sublayerTransform: CATransform3DIdentity,
+            mask: nil,
+            masksToBounds: false,
+            isOpaque: false,
+            backgroundColor: backgroundColor,
+            cornerRadii: .zero,
+            cornerCurve: .circular,
+            borderWidth: 0,
+            borderColor: nil,
+            opacity: 1,
+            allowsGroupOpacity: true,
+            compositingFilter: nil,
+            filters: [],
+            shadowColor: nil,
+            shadowOpacity: 0,
+            shadowOffset: .zero,
+            shadowRadius: 0,
+            shadowPath: nil
+        )
+    }
+}
+
+private extension PassthroughCoreMock {
+    var recordsCountByViewID: [String: Int64]? {
+        context.additionalContext(
+            ofType: SessionReplayCoreContext.RecordsCount.self
+        )?.value
+    }
+}
+
+private extension SRRecord {
+    enum RecordType: Equatable {
+        case meta
+        case focus
+        case fullSnapshot
+        case incrementalSnapshot
+        case other
+    }
+
+    var type: RecordType {
+        switch self {
+        case .metaRecord:
+            return .meta
+        case .focusRecord:
+            return .focus
+        case .fullSnapshotRecord:
+            return .fullSnapshot
+        case .incrementalSnapshotRecord:
+            return .incrementalSnapshot
+        case .viewEndRecord, .visualViewportRecord:
+            return .other
+        }
+    }
+
+    var fullSnapshot: SRFullSnapshotRecord? {
+        guard case let .fullSnapshotRecord(record) = self else {
+            return nil
+        }
+        return record
+    }
+
+    var incrementalSnapshot: SRIncrementalSnapshotRecord? {
+        guard case let .incrementalSnapshotRecord(record) = self else {
+            return nil
+        }
+        return record
+    }
+}
+
+private extension SRIncrementalSnapshotRecord {
+    var mutationData: SRIncrementalSnapshotRecord.Data.MutationData? {
+        guard case let .mutationData(data) = self.data else {
+            return nil
+        }
+        return data
+    }
+
+    var compositionTreeMutationData: SRCompositionTreeMutationData? {
+        guard case let .compositionTreeMutationData(data) = self.data else {
+            return nil
+        }
+        return data
+    }
+
+    var viewportResizeData: SRIncrementalSnapshotRecord.Data.ViewportResizeData? {
+        guard case let .viewportResizeData(data) = self.data else {
+            return nil
+        }
+        return data
+    }
+
+    var pointerInteractionData: SRIncrementalSnapshotRecord.Data.PointerInteractionData? {
+        guard case let .pointerInteractionData(data) = self.data else {
+            return nil
+        }
+        return data
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotMocks.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotMocks.swift
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import CoreGraphics
+@_spi(Internal)
+import DatadogInternal
+import Foundation
+import QuartzCore
+
+@testable import DatadogSessionReplay
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension LayerTreeSnapshot {
+    static func mockWith(
+        date: Date = Date(timeIntervalSince1970: 42),
+        applicationID: String = "app-id",
+        sessionID: String = "session-id",
+        viewID: String = "view-id",
+        viewportSize: CGSize = CGSize(width: 320, height: 640),
+        root: CALayerSnapshot = .mockRoot(),
+        webViewSlotIDs: Set<Int> = []
+    ) -> LayerTreeSnapshot {
+        return LayerTreeSnapshot(
+            date: date,
+            context: LayerRecordingContext(
+                textAndInputPrivacy: .maskSensitiveInputs,
+                imagePrivacy: .maskNone,
+                touchPrivacy: .show,
+                applicationID: applicationID,
+                sessionID: sessionID,
+                viewID: viewID,
+                viewServerTimeOffset: 0,
+                viewPath: "/view",
+                date: date,
+                telemetry: NOPTelemetry()
+            ),
+            viewportSize: viewportSize,
+            root: root,
+            webViewSlotIDs: webViewSlotIDs
+        )
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot {
+    static func mockRoot(
+        absoluteFrame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 200),
+        sublayers: [CALayerSnapshot] = []
+    ) -> CALayerSnapshot {
+        return mockWith(
+            replayID: 1,
+            absoluteFrame: absoluteFrame,
+            backgroundColor: nil,
+            sublayers: sublayers
+        )
+    }
+
+    static func mockWith(
+        replayID: Int64 = 1,
+        absoluteFrame: CGRect = .zero,
+        backgroundColor: CGColor? = nil,
+        isPrivate: Bool = false,
+        sublayers: [CALayerSnapshot] = []
+    ) -> CALayerSnapshot {
+        let layer = CALayer()
+        return CALayerSnapshot(
+            layer: CALayerReference(layer),
+            replayID: replayID,
+            observation: .init(semantics: .layer),
+            layerClass: CALayer.self,
+            delegateClass: nil,
+            contentsClass: nil,
+            textAndInputPrivacyLevel: .maskSensitiveInputs,
+            imagePrivacyLevel: .maskNone,
+            isPrivate: isPrivate,
+            bounds: CGRect(origin: .zero, size: absoluteFrame.size),
+            position: absoluteFrame.origin,
+            zPosition: 0,
+            transform: CATransform3DIdentity,
+            absoluteFrame: absoluteFrame,
+            sublayers: sublayers,
+            dependencies: [],
+            sublayerTransform: CATransform3DIdentity,
+            mask: nil,
+            masksToBounds: false,
+            isOpaque: false,
+            backgroundColor: backgroundColor,
+            cornerRadii: .zero,
+            cornerCurve: .circular,
+            borderWidth: 0,
+            borderColor: nil,
+            opacity: 1,
+            allowsGroupOpacity: true,
+            compositingFilter: nil,
+            filters: [],
+            shadowColor: nil,
+            shadowOpacity: 0,
+            shadowOffset: .zero,
+            shadowRadius: 0,
+            shadowPath: nil
+        )
+    }
+}
+
+private struct NOPTelemetry: Telemetry {
+    func send(telemetry: TelemetryMessage) {}
+}
+#endif

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -149,6 +149,38 @@ class DiffSRWireframes: XCTestCase {
         }
     }
 
+    func testWhenComputingMutationsForImageWireframe_itUpdatesResourceID() throws {
+        // Given
+        let randomID: WireframeID = .mockRandom()
+        let resourceID: String = .mockRandom()
+        let wireframeA: SRWireframe = .imageWireframe(value: SRImageWireframe(
+            height: 100,
+            id: randomID,
+            resourceId: .mockRandom(),
+            width: 200,
+            x: 10,
+            y: 20
+        ))
+        let wireframeB: SRWireframe = .imageWireframe(value: SRImageWireframe(
+            height: 100,
+            id: randomID,
+            resourceId: resourceID,
+            width: 200,
+            x: 10,
+            y: 20
+        ))
+
+        // When
+        let mutations = try wireframeB.mutations(from: wireframeA)
+
+        // Then
+        guard case let .imageWireframeUpdate(update) = mutations else {
+            XCTFail("mutations are expected to be `.imageWireframeUpdate`")
+            return
+        }
+        XCTAssertEqual(update.resourceId, resourceID)
+    }
+
     func testUpdatingContentClip() throws {
         let id: WireframeID = .mockRandom()
 
@@ -244,6 +276,7 @@ extension SRWireframe {
             id: update.id,
             isEmpty: update.isEmpty ?? wireframe.isEmpty,
             mimeType: update.mimeType ?? wireframe.mimeType,
+            resourceId: update.resourceId ?? wireframe.resourceId,
             shapeStyle: update.shapeStyle ?? wireframe.shapeStyle,
             width: update.width ?? wireframe.width,
             x: update.x ?? wireframe.x,


### PR DESCRIPTION
### What and why?

This PR adds the layer snapshot processor for the Core Animation Session Replay pipeline.

The processor ties the existing pipeline pieces together: it builds composition trees and wireframes, creates Session Replay records, writes enriched records, processes image resources, and keeps the previous snapshot state needed for incremental updates.

This is internal pipeline work behind the Core Animation recording feature flag.

### How?

`LayerSnapshotProcessor` runs on the injected processing queue.

For a new segment, it writes meta, focus, and full snapshot records.

For the same RUM context, it writes wireframe mutations, composition tree mutations, viewport resize records, and touch records when needed.

If diffing fails, it logs telemetry and falls back to a full snapshot instead of dropping the frame.

Resources are still sent through `ResourceProcessor`, and record counts are published through `SRContextPublisher`.

Tests cover new segments, same-context incremental records, RUM context changes, resource processing, record count tracking, and diffing fallback behavior.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
