### PR TITLE
[FFL-2601] Add flag assignment snapshot API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Unreleased
 
-# 3.13.0 / 30-06-2026
 - [FEATURE] Add a preview snapshot API to `DatadogFlags` for reading cached precomputed feature flag assignments without recording evaluations. See [#2937][]
-- [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
-- [FIX] Fix watchOS uploads blocked by NWPathMonitor always reporting no reachability. See [#2975][]
 
+# 3.13.0 / 30-06-2026
 - [FEATURE] Expose `allocationKey` as a top-level property on `FlagDetails` for callers using `getDetails(key:defaultValue:)`. See [#2989][]
 - [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
 - [FIX] Fix `DatadogFlags` exposure deduplication so assignment changes for the same subject and flag emit new exposure events. See [#2987][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 # 3.13.0 / 30-06-2026
+- [FEATURE] Add a preview snapshot API to `DatadogFlags` for reading cached precomputed feature flag assignments without recording evaluations. See [#2937][]
+- [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]
+- [FIX] Fix watchOS uploads blocked by NWPathMonitor always reporting no reachability. See [#2975][]
 
 - [FEATURE] Expose `allocationKey` as a top-level property on `FlagDetails` for callers using `getDetails(key:defaultValue:)`. See [#2989][]
 - [FEATURE] Add wildcard host pattern support to WebView tracking via `WebViewTracking.enable(webView:hostPatterns:)`. See [#2963][]

--- a/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
@@ -144,6 +144,26 @@ extension FlagsClientProtocol {
 // MARK: - Convenience flag evaluation methods
 
 extension FlagsClientProtocol {
+    /// Returns a side-effect-free snapshot of cached precomputed feature flag assignments.
+    ///
+    /// Use this method for diagnostics and export use cases, such as attaching the cached
+    /// assignment set to support logs. The snapshot may include assignments that have not
+    /// been evaluated through ``getValue(key:defaultValue:)`` or ``getDetails(key:defaultValue:)``.
+    /// Calling this method does not record evaluations,
+    /// exposures, or RUM feature flag evaluations. Use ``getValue(key:defaultValue:)`` or
+    /// ``getDetails(key:defaultValue:)`` for application logic that should be tracked.
+    ///
+    /// - Returns: A ``FlagsSnapshot`` if precomputed assignments are cached for the client,
+    ///   or `nil` if the client does not have cached assignments.
+    @available(*, message: "This API is in preview and may change in future releases")
+    public func snapshot() -> FlagsSnapshot? {
+        guard let assignments = (self as? FlagsClientInternal)?.getFlagAssignments() else {
+            return nil
+        }
+
+        return FlagsSnapshot(assignments: assignments.compactMapValues(FlagSnapshot.init))
+    }
+
     /// Evaluates a feature flag and returns only its value.
     ///
     /// This is a convenience method that evaluates a flag and returns only the value,

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -102,3 +102,85 @@ public struct FlagDetails<T>: Equatable where T: Equatable {
         self.allocationKey = allocationKey
     }
 }
+
+/// A side-effect-free snapshot of cached precomputed feature flag assignments.
+///
+/// `FlagsSnapshot` is intended for diagnostics and export use cases. Reading a snapshot does not record
+/// evaluations, exposures, or RUM feature flag evaluations. A snapshot may include assignments that have not
+/// been evaluated through ``FlagsClientProtocol/getValue(key:defaultValue:)`` or
+/// ``FlagsClientProtocol/getDetails(key:defaultValue:)``.
+@available(*, message: "This API is in preview and may change in future releases")
+public struct FlagsSnapshot: Equatable, Codable {
+    /// The cached precomputed assignments, keyed by feature flag key.
+    public let assignments: [String: FlagSnapshot]
+
+    /// Creates a feature flag snapshot.
+    ///
+    /// - Parameter assignments: The cached precomputed assignments, keyed by feature flag key.
+    public init(assignments: [String: FlagSnapshot]) {
+        self.assignments = assignments
+    }
+}
+
+/// A side-effect-free snapshot of a cached precomputed feature flag assignment.
+///
+/// `FlagSnapshot` contains the value and metadata cached for a single feature flag. Reading a snapshot does not
+/// record evaluations, exposures, or RUM feature flag evaluations.
+@available(*, message: "This API is in preview and may change in future releases")
+public struct FlagSnapshot: Equatable, Codable {
+    /// The assigned flag value.
+    public let value: AnyValue
+
+    /// The variant key for the assigned flag.
+    public let variant: String
+
+    /// The reason why this assignment was returned.
+    public let reason: String
+
+    /// Creates a feature flag assignment snapshot.
+    ///
+    /// - Parameters:
+    ///   - value: The assigned flag value.
+    ///   - variant: The variant key for the assigned flag.
+    ///   - reason: The reason why this assignment was returned.
+    public init(
+        value: AnyValue,
+        variant: String,
+        reason: String
+    ) {
+        self.value = value
+        self.variant = variant
+        self.reason = reason
+    }
+
+    internal init?(_ assignment: FlagAssignment) {
+        guard let value = assignment.variation.snapshotValue else {
+            return nil
+        }
+
+        self.init(
+            value: value,
+            variant: assignment.variationKey,
+            reason: assignment.reason
+        )
+    }
+}
+
+private extension FlagAssignment.Variation {
+    var snapshotValue: AnyValue? {
+        switch self {
+        case .boolean(let value):
+            return .bool(value)
+        case .string(let value):
+            return .string(value)
+        case .integer(let value):
+            return .int(value)
+        case .double(let value):
+            return .double(value)
+        case .object(let value):
+            return value
+        case .unknown:
+            return nil
+        }
+    }
+}

--- a/DatadogFlags/Sources/Models/FlagDetails.swift
+++ b/DatadogFlags/Sources/Models/FlagDetails.swift
@@ -110,7 +110,7 @@ public struct FlagDetails<T>: Equatable where T: Equatable {
 /// been evaluated through ``FlagsClientProtocol/getValue(key:defaultValue:)`` or
 /// ``FlagsClientProtocol/getDetails(key:defaultValue:)``.
 @available(*, message: "This API is in preview and may change in future releases")
-public struct FlagsSnapshot: Equatable, Codable {
+public struct FlagsSnapshot: Equatable, Encodable {
     /// The cached precomputed assignments, keyed by feature flag key.
     public let assignments: [String: FlagSnapshot]
 
@@ -127,7 +127,7 @@ public struct FlagsSnapshot: Equatable, Codable {
 /// `FlagSnapshot` contains the value and metadata cached for a single feature flag. Reading a snapshot does not
 /// record evaluations, exposures, or RUM feature flag evaluations.
 @available(*, message: "This API is in preview and may change in future releases")
-public struct FlagSnapshot: Equatable, Codable {
+public struct FlagSnapshot: Equatable, Encodable {
     /// The assigned flag value.
     public let value: AnyValue
 

--- a/DatadogFlags/Tests/Client/FlagsClientTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsClientTests.swift
@@ -359,6 +359,122 @@ final class FlagsClientTests: XCTestCase {
         XCTAssertEqual(messageReceiver.messages.filter(\.isRUMMessage).count, 0, "No RUM messages should be sent")
     }
 
+    func testSnapshot() {
+        // Given
+        let exposureLogger = ExposureLoggerMock()
+        let evaluationLogger = EvaluationLoggerMock()
+        let rumFlagEvaluationReporter = RUMFlagEvaluationReporterMock()
+        let client: FlagsClientProtocol = FlagsClient(
+            repository: FlagsRepositoryMock(
+                flagsData: .init(
+                    flags: [
+                        "string-flag": .init(
+                            allocationKey: "allocation-123",
+                            variationKey: "variation-123",
+                            variation: .string("red"),
+                            reason: "TARGETING_MATCH",
+                            doLog: true
+                        ),
+                        "boolean-flag": .init(
+                            allocationKey: "allocation-124",
+                            variationKey: "variation-124",
+                            variation: .boolean(true),
+                            reason: "TARGETING_MATCH",
+                            doLog: true
+                        ),
+                        "integer-flag": .init(
+                            allocationKey: "allocation-125",
+                            variationKey: "variation-125",
+                            variation: .integer(42),
+                            reason: "TARGETING_MATCH",
+                            doLog: true
+                        ),
+                        "numeric-flag": .init(
+                            allocationKey: "allocation-126",
+                            variationKey: "variation-126",
+                            variation: .double(3.14),
+                            reason: "TARGETING_MATCH",
+                            doLog: true
+                        ),
+                        "json-flag": .init(
+                            allocationKey: "allocation-127",
+                            variationKey: "variation-127",
+                            variation: .object(
+                                .dictionary(["key": .string("value"), "prop": .int(123)])
+                            ),
+                            reason: "TARGETING_MATCH",
+                            doLog: true
+                        ),
+                    ],
+                    context: .mockAny(),
+                    date: .mockAny()
+                )
+            ),
+            exposureLogger: exposureLogger,
+            evaluationLogger: evaluationLogger,
+            rumFlagEvaluationReporter: rumFlagEvaluationReporter
+        )
+
+        // When
+        guard let snapshot = client.snapshot() else {
+            XCTFail("Failed to get snapshot")
+            return
+        }
+
+        // Then
+        XCTAssertEqual(
+            snapshot,
+            FlagsSnapshot(
+                assignments: [
+                    "string-flag": FlagSnapshot(
+                        value: .string("red"),
+                        variant: "variation-123",
+                        reason: "TARGETING_MATCH"
+                    ),
+                    "boolean-flag": FlagSnapshot(
+                        value: .bool(true),
+                        variant: "variation-124",
+                        reason: "TARGETING_MATCH"
+                    ),
+                    "integer-flag": FlagSnapshot(
+                        value: .int(42),
+                        variant: "variation-125",
+                        reason: "TARGETING_MATCH"
+                    ),
+                    "numeric-flag": FlagSnapshot(
+                        value: .double(3.14),
+                        variant: "variation-126",
+                        reason: "TARGETING_MATCH"
+                    ),
+                    "json-flag": FlagSnapshot(
+                        value: .dictionary(["key": .string("value"), "prop": .int(123)]),
+                        variant: "variation-127",
+                        reason: "TARGETING_MATCH"
+                    ),
+                ]
+            )
+        )
+        XCTAssertEqual(exposureLogger.logExposureCalls.count, 0)
+        XCTAssertEqual(evaluationLogger.logEvaluationCalls.count, 0)
+        XCTAssertEqual(rumFlagEvaluationReporter.sendFlagEvaluationCalls.count, 0)
+    }
+
+    func testSnapshotWhenNoCachedAssignments() {
+        // Given
+        let client: FlagsClientProtocol = FlagsClient(
+            repository: FlagsRepositoryMock(),
+            exposureLogger: ExposureLoggerMock(),
+            evaluationLogger: EvaluationLoggerMock(),
+            rumFlagEvaluationReporter: RUMFlagEvaluationReporterMock()
+        )
+
+        // When
+        let snapshot = client.snapshot()
+
+        // Then
+        XCTAssertNil(snapshot)
+    }
+
     // MARK: - Internal methods consumed by the React Native SDK
 
     func testGetFlagAssignments() {

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1483,6 +1483,7 @@ public protocol FlagsClientProtocol: AnyObject
     public func setEvaluationContext(_ context: FlagsEvaluationContext)
     public func setEvaluationContext(_ context: FlagsEvaluationContext) async throws
 [?] extension FlagsClientProtocol
+    public func snapshot() -> FlagsSnapshot?
     public func getValue<T>(key: String, defaultValue: T) -> T where T: Equatable, T: FlagValue
     public func getBooleanValue(key: String, defaultValue: Bool) -> Bool
     public func getStringValue(key: String, defaultValue: String) -> String
@@ -1561,6 +1562,14 @@ public struct FlagDetails<T>: Equatable where T: Equatable
     public var error: FlagEvaluationError?
     public var allocationKey: String?
     public init(key: String,value: T,variant: String? = nil,reason: String? = nil,error: FlagEvaluationError? = nil,allocationKey: String? = nil)
+public struct FlagsSnapshot: Equatable, Codable
+    public let assignments: [String: FlagSnapshot]
+    public init(assignments: [String: FlagSnapshot])
+public struct FlagSnapshot: Equatable, Codable
+    public let value: AnyValue
+    public let variant: String
+    public let reason: String
+    public init(value: AnyValue,variant: String,reason: String)
 public protocol FlagValue: Encodable
 public enum FlagsError: Error
     case networkError(Error)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1562,10 +1562,10 @@ public struct FlagDetails<T>: Equatable where T: Equatable
     public var error: FlagEvaluationError?
     public var allocationKey: String?
     public init(key: String,value: T,variant: String? = nil,reason: String? = nil,error: FlagEvaluationError? = nil,allocationKey: String? = nil)
-public struct FlagsSnapshot: Equatable, Codable
+public struct FlagsSnapshot: Equatable, Encodable
     public let assignments: [String: FlagSnapshot]
     public init(assignments: [String: FlagSnapshot])
-public struct FlagSnapshot: Equatable, Codable
+public struct FlagSnapshot: Equatable, Encodable
     public let value: AnyValue
     public let variant: String
     public let reason: String


### PR DESCRIPTION
### What and why?

Adds a preview snapshot API for `DatadogFlags` clients to read cached precomputed feature flag assignments without recording exposure, evaluation, or RUM feature flag evaluation events.

This addresses #2937 / [FFL-2601](https://datadoghq.atlassian.net/browse/FFL-2601) / [RUM-16415](https://datadoghq.atlassian.net/browse/RUM-16415) and supports diagnostics and export use cases where customers need the cached assignment set without using tracked evaluation APIs. The snapshot may include assignments that have not been evaluated through `getValue` or `getDetails`.

### How?

- Adds `FlagsClientProtocol.snapshot() -> FlagsSnapshot?` as a side-effect-free protocol extension backed by the existing internal cached assignment access.
- Adds public `FlagsSnapshot` and `FlagSnapshot` models using `AnyValue` for assigned values.
- Covers scalar and object assignment values in unit tests, including assertions that no tracking calls are emitted.
- Updates the Swift API surface and changelog.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

[FFL-2601]: https://datadoghq.atlassian.net/browse/FFL-2601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUM-16415]: https://datadoghq.atlassian.net/browse/RUM-16415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ