### PR TITLE
Unify WebViewTracking.enable to accept both hosts and wildcard patterns

### DIFF
--- a/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
+++ b/DatadogWebViewTracking/Sources/ObjC/WebViewTracking+objc.swift
@@ -20,9 +20,12 @@ public final class objc_WebViewTracking: NSObject {
     /// If the content loaded in WebView uses Datadog Browser SDK (`v4.2.0+`) and matches specified
     /// `hosts`, web events will be correlated with the RUM session from native SDK.
     ///
+    /// Each entry in `hosts` can be a plain hostname (`"example.com"`) or a wildcard pattern with a
+    /// single `*` (`"*.example.com"`, `"preview-*.shopist.io"`). Invalid entries are dropped with a warning.
+    ///
     /// - Parameters:
     ///   - webView: The web-view to track.
-    ///   - hosts: A set of hosts instrumented with Browser SDK to capture Datadog events from.
+    ///   - hosts: A set of hosts or wildcard patterns instrumented with Browser SDK to capture Datadog events from.
     ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
     ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
     @objc
@@ -35,51 +38,6 @@ public final class objc_WebViewTracking: NSObject {
             webView: webView,
             hosts: hosts,
             logsSampleRate: logsSampleRate
-        )
-    }
-
-    /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session,
-    /// using wildcard host patterns for matching.
-    ///
-    /// - Parameters:
-    ///   - webView: The web-view to track.
-    ///   - hostPatterns: Wildcard patterns to match against the WebView page hostname.
-    ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
-    ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
-    @objc
-    public static func enable(
-        webView: WKWebView,
-        hostPatterns: [String],
-        logsSampleRate: SampleRate = .maxSampleRate
-    ) {
-        WebViewTracking.enable(
-            webView: webView,
-            hostPatterns: hostPatterns,
-            logsSampleRate: logsSampleRate
-        )
-    }
-
-    /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session
-    /// using wildcard host patterns, on a named SDK instance.
-    ///
-    /// - Parameters:
-    ///   - webView: The web-view to track.
-    ///   - hostPatterns: Wildcard patterns to match against the WebView page hostname.
-    ///   - instanceName: The name of the SDK instance to use for tracking.
-    ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
-    ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
-    @objc
-    public static func enable(
-        webView: WKWebView,
-        hostPatterns: [String],
-        instanceName: String?,
-        logsSampleRate: SampleRate = .maxSampleRate
-    ) {
-        WebViewTracking.enable(
-            webView: webView,
-            hostPatterns: hostPatterns,
-            logsSampleRate: logsSampleRate,
-            in: CoreRegistry.instance(named: instanceName ?? CoreRegistry.defaultInstanceName)
         )
     }
 

--- a/DatadogWebViewTracking/Sources/WebViewTracking.swift
+++ b/DatadogWebViewTracking/Sources/WebViewTracking.swift
@@ -24,13 +24,16 @@ import WebKit
 public enum WebViewTracking {
 #if canImport(WebKit)
     /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session.
-    /// 
+    ///
     /// If the content loaded in WebView uses Datadog Browser SDK (`v4.2.0+`) and matches specified
     /// `hosts`, web events will be correlated with the RUM session from native SDK.
     ///
+    /// Each entry in `hosts` can be a plain hostname (`"example.com"`) or a wildcard pattern with a
+    /// single `*` (`"*.example.com"`, `"preview-*.shopist.io"`). Invalid entries are dropped with a warning.
+    ///
     /// - Parameters:
     ///   - webView: The web-view to track.
-    ///   - hosts: A set of hosts instrumented with Browser SDK to capture Datadog events from.
+    ///   - hosts: A set of hosts or wildcard patterns instrumented with Browser SDK to capture Datadog events from.
     ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
     ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
     ///   - core: Datadog SDK core to use for tracking.
@@ -48,41 +51,6 @@ public enum WebViewTracking {
                     tracking: webView,
                     hosts: hosts,
                     hostsSanitizer: HostsSanitizer(),
-                    logsSampleRate: logsSampleRate,
-                    in: core
-                )
-            }
-        } catch let error {
-            consolePrint("\(error)", .error)
-        }
-    }
-
-    /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session,
-    /// using wildcard host patterns for matching.
-    ///
-    /// If the content loaded in WebView uses Datadog Browser SDK and its hostname matches one of the
-    /// specified patterns, web events will be correlated with the RUM session from native SDK.
-    ///
-    /// Patterns support a single `*` wildcard: `"*.example.com"`, `"preview-*.shopist.io"`, `"shopist.io"`.
-    /// Patterns with more than one `*` are dropped with a warning.
-    ///
-    /// - Parameters:
-    ///   - webView: The web-view to track.
-    ///   - hostPatterns: Wildcard patterns to match against the WebView page hostname.
-    ///   - logsSampleRate: The sampling rate for logs coming from the WebView. Must be a value between `0` and `100`,
-    ///   where 0 means no logs will be sent and 100 means all will be uploaded. Default: `100`.
-    ///   - core: Datadog SDK core to use for tracking.
-    public static func enable(
-        webView: WKWebView,
-        hostPatterns: [String],
-        logsSampleRate: SampleRate = .maxSampleRate,
-        in core: DatadogCoreProtocol = CoreRegistry.default
-    ) {
-        do {
-            try runOnMainThreadSync {
-                try enableOrThrow(
-                    tracking: webView,
-                    hostPatterns: hostPatterns,
                     logsSampleRate: logsSampleRate,
                     in: core
                 )
@@ -133,37 +101,8 @@ public enum WebViewTracking {
             warningMessage: "The allowed WebView host configured for Datadog SDK is not valid"
         )
         let allowedWebViewHostsString = sanitizedHosts
+            .sorted()
             .map { return "\"\($0)\"" }
-            .joined(separator: ",")
-
-        let elements = WebViewTrackingElements(allowedWebViewHostsString: allowedWebViewHostsString)
-        let isTraceSampled = WebViewTracking.isTraceSampledStringValue(for: core)
-
-        try WebViewSessionRolloverHandler.register(webView: webView, in: core, using: elements)
-
-        injectUserScript(on: webView, in: core, using: elements, isTraceSampled: isTraceSampled)
-
-        core.telemetry.usage(event: .trackWebView)
-    }
-
-    @MainActor
-    static func enableOrThrow(
-        tracking webView: WKWebView,
-        hostPatterns: [String],
-        logsSampleRate: Float,
-        in core: DatadogCoreProtocol
-    ) throws {
-        guard try prepareWebView(webView, logsSampleRate: logsSampleRate, callerName: "WebViewTracking.enable(webView:hostPatterns:)", in: core) else {
-            return
-        }
-
-        let sanitizedPatterns = HostsSanitizer().sanitized(
-            hosts: Set(hostPatterns),
-            warningMessage: "The WebView host pattern configured for Datadog SDK is not valid"
-        )
-        let validPatterns = sanitizedPatterns.sorted()
-        let allowedWebViewHostsString = validPatterns
-            .map { "\"\($0)\"" }
             .joined(separator: ",")
 
         let elements = WebViewTrackingElements(allowedWebViewHostsString: allowedWebViewHostsString)

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -970,7 +970,7 @@ class WebViewTrackingTests: XCTestCase {
 
     // MARK: - Wildcard host patterns
 
-    func testItAddsUserScriptWithHostPatterns() throws {
+    func testItAddsUserScriptWithWildcardHosts() throws {
         let config = WKWebViewConfiguration()
         let controller = DDUserContentController()
         config.userContentController = controller
@@ -978,7 +978,8 @@ class WebViewTrackingTests: XCTestCase {
 
         try WebViewTracking.enableOrThrow(
             tracking: webView,
-            hostPatterns: ["*.shopist.io", "preview-*.example.com"],
+            hosts: ["*.shopist.io", "preview-*.example.com"],
+            hostsSanitizer: HostsSanitizer(),
             logsSampleRate: 100,
             in: PassthroughCoreMock()
         )
@@ -1006,7 +1007,7 @@ class WebViewTrackingTests: XCTestCase {
         """)
     }
 
-    func testItDropsPatternWithMoreThanOneWildcard() throws {
+    func testItDropsWildcardWithMoreThanOneAsterisk() throws {
         let config = WKWebViewConfiguration()
         let controller = DDUserContentController()
         config.userContentController = controller
@@ -1014,17 +1015,18 @@ class WebViewTrackingTests: XCTestCase {
 
         try WebViewTracking.enableOrThrow(
             tracking: webView,
-            hostPatterns: ["*.foo.*.bar", "shopist.io"],
+            hosts: ["*.foo.*.bar.com", "shopist.io"],
+            hostsSanitizer: HostsSanitizer(),
             logsSampleRate: 100,
             in: PassthroughCoreMock()
         )
 
         let script = try XCTUnwrap(controller.userScripts.last)
         XCTAssertTrue(script.source.contains("\"shopist.io\""))
-        XCTAssertFalse(script.source.contains("*.foo.*.bar"))
+        XCTAssertFalse(script.source.contains("*.foo.*.bar.com"))
     }
 
-    func testItLowercasesHostPatterns() throws {
+    func testItLowercasesWildcardHosts() throws {
         let config = WKWebViewConfiguration()
         let controller = DDUserContentController()
         config.userContentController = controller
@@ -1032,7 +1034,8 @@ class WebViewTrackingTests: XCTestCase {
 
         try WebViewTracking.enableOrThrow(
             tracking: webView,
-            hostPatterns: ["*.SHOPIST.IO", "Preview-*.Example.COM"],
+            hosts: ["*.SHOPIST.IO", "Preview-*.Example.COM"],
+            hostsSanitizer: HostsSanitizer(),
             logsSampleRate: 100,
             in: PassthroughCoreMock()
         )
@@ -1042,7 +1045,7 @@ class WebViewTrackingTests: XCTestCase {
         XCTAssertTrue(script.source.contains("\"preview-*.example.com\""))
     }
 
-    func testItDropsPatternsWithInvalidCharacters() throws {
+    func testItDropsHostsWithInvalidCharacters() throws {
         let config = WKWebViewConfiguration()
         let controller = DDUserContentController()
         config.userContentController = controller
@@ -1050,7 +1053,8 @@ class WebViewTrackingTests: XCTestCase {
 
         try WebViewTracking.enableOrThrow(
             tracking: webView,
-            hostPatterns: ["foo'bar.com", "back\\slash.com", "shopist.io"],
+            hosts: ["foo'bar.com", "back\\slash.com", "shopist.io"],
+            hostsSanitizer: HostsSanitizer(),
             logsSampleRate: 100,
             in: PassthroughCoreMock()
         )
@@ -1061,7 +1065,7 @@ class WebViewTrackingTests: XCTestCase {
         XCTAssertFalse(script.source.contains("back\\\\slash.com"))
     }
 
-    func testSerializationEdgeCases() throws {
+    func testItSanitizesHostEdgeCases() throws {
         let printFunction = PrintFunctionSpy()
         consolePrint = printFunction.print
         defer { consolePrint = { message, _ in print(message) } }
@@ -1073,12 +1077,13 @@ class WebViewTrackingTests: XCTestCase {
 
         try WebViewTracking.enableOrThrow(
             tracking: webView,
-            hostPatterns: [
-                "*",
-                "",
-                "https://foo.com",
+            hosts: [
+                "*",              // dropped: no label boundary
+                "",               // dropped: empty
+                "https://foo.com", // sanitized to "foo.com"
                 "shopist.io",
             ],
+            hostsSanitizer: HostsSanitizer(),
             logsSampleRate: 100,
             in: PassthroughCoreMock()
         )

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3523,8 +3523,6 @@ public class objc_RUMMonitor: NSObject
 
 public final class objc_WebViewTracking: NSObject
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate)
-    public static func enable(webView: WKWebView,hostPatterns: [String],logsSampleRate: SampleRate = .maxSampleRate)
-    public static func enable(webView: WKWebView,hostPatterns: [String],instanceName: String?,logsSampleRate: SampleRate = .maxSampleRate)
     public static func enable(webView: WKWebView,instanceName: String?,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate)
     public static func disable(webView: WKWebView)
 

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -589,7 +589,6 @@ public protocol CrashReportingPlugin: AnyObject
 
 public enum WebViewTracking
     public static func enable(webView: WKWebView,hosts: Set<String> = [],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
-    public static func enable(webView: WKWebView,hostPatterns: [String],logsSampleRate: SampleRate = .maxSampleRate,in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func disable(webView: WKWebView)
 [?] extension InternalExtension where ExtendedType == WebViewTracking
     public class AbstractMessageEmitter


### PR DESCRIPTION
### What and why?

The wildcard host matching PR (#2981) introduced a separate `enable(webView:hostPatterns:)` overload alongside the existing `enable(webView:hosts:)`. Now that `HostsSanitizer` handles both plain hostnames and wildcard patterns transparently, there is no reason to expose two separate entry points. This PR collapses both into a single `hosts` parameter that accepts any mix of plain hostnames and wildcard patterns.

To be merged after #2981.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs