### PR TITLE
[RUM-17019] Do not aggregate client-side stats without consent

### DIFF
--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -39,14 +39,19 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
             runtimeID: UUID().uuidString,
             sequenceNumberProvider: StatsSequenceNumberProvider()
         )
-        self.messageReceiver = NOPFeatureMessageReceiver()
         self.performanceOverride = nil
         self.dateProvider = dateProvider
         self.flushInterval = flushInterval
         self.featureScope = core.scope(for: ClientStatsFeature.self)
 
         let now = dateProvider.now.timeIntervalSince1970.dd.toNanoseconds
-        self.concentrator = StatsConcentrator(now: now)
+        let concentrator = StatsConcentrator(now: now)
+        self.concentrator = concentrator
+
+        // Observe consent changes through the message bus. The core delivers the current context
+        // right after registration, so the concentrator learns the real consent before the first
+        // flush even though it starts in the `.pending` default.
+        self.messageReceiver = TraceClientStatsConsentReceiver(concentrator: concentrator)
 
         startFlushTimer()
     }
@@ -88,5 +93,21 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
 extension ClientStatsFeature: Flushable {
     func flush() {
         flushStats(force: true)
+    }
+}
+
+/// Forwards tracking-consent changes from the message bus to the `StatsConcentrator`.
+///
+/// Holds the concentrator weakly: it is owned by `ClientStatsFeature`, while the bus owns this
+/// receiver, so a weak reference avoids keeping the concentrator alive past the feature.
+internal struct TraceClientStatsConsentReceiver: FeatureMessageReceiver {
+    weak var concentrator: StatsConcentrator?
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard case let .context(context) = message else {
+            return false
+        }
+        concentrator?.updateConsent(context.trackingConsent)
+        return false
     }
 }

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -108,6 +108,6 @@ internal struct TraceClientStatsConsentReceiver: FeatureMessageReceiver {
             return false
         }
         concentrator?.updateConsent(context.trackingConsent)
-        return false
+        return true
     }
 }

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -205,8 +205,15 @@ internal final class StatsConcentrator: @unchecked Sendable {
     private var buckets: [UInt64: StatsBucket] = [:]
     private var oldestTs: UInt64
 
+    /// The user's current tracking consent. `.granted` and `.pending` are both recording states;
+    /// `.notGranted` stops aggregation and drops any data buffered in memory. Guarded by its own
+    /// lock so `add()` can cheaply check it off the serial queue without blocking the span hot path.
+    @ReadWriteLock
+    private var currentConsent: TrackingConsent
+
     init(
         now: Nanoseconds,
+        initialConsent: TrackingConsent = .pending,
         bucketDuration: Nanoseconds = StatsConcentrator.defaultBucketDuration,
         bufferLen: Int = StatsConcentrator.defaultBufferLen,
         peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys
@@ -215,6 +222,7 @@ internal final class StatsConcentrator: @unchecked Sendable {
         self.bufferLen = bufferLen
         self.peerTagKeys = peerTagKeys
         self.oldestTs = StatsConcentrator.alignTimestamp(now, bucketDuration: bucketDuration)
+        self.currentConsent = initialConsent
     }
 
     // MARK: - Add
@@ -223,6 +231,11 @@ internal final class StatsConcentrator: @unchecked Sendable {
     /// Ineligible spans are silently discarded. This method dispatches
     /// asynchronously and returns immediately without blocking the caller.
     func add(_ snapshot: SpanSnapshot) {
+        // Skip aggregation entirely when consent is not granted, so we neither spend work
+        // building the aggregation key nor retain any data we are not allowed to collect.
+        guard currentConsent != .notGranted else {
+            return
+        }
         guard Self.isEligible(snapshot) else {
             return
         }
@@ -233,6 +246,13 @@ internal final class StatsConcentrator: @unchecked Sendable {
         let peerTagStrings = matchingPeerTags.map { "\($0.key):\($0.value)" }
 
         queue.async { [self] in
+            // Re-check on the serial queue: consent may have been revoked between the check
+            // above and this block running, in which case `updateConsent` has (or will have)
+            // cleared the buffer and this span must not be re-added.
+            guard currentConsent != .notGranted else {
+                return
+            }
+
             let bucketKey = max(
                 Self.alignTimestamp(endTime, bucketDuration: bucketDuration),
                 oldestTs
@@ -257,6 +277,12 @@ internal final class StatsConcentrator: @unchecked Sendable {
     /// - Returns: Array of exported buckets ready for serialization.
     func flush(now: Nanoseconds, force: Bool) -> [ExportedBucket] {
         return queue.sync {
+            // Never export while consent is not granted. The storage writer already drops these
+            // writes, but returning early avoids needlessly serializing the sketches.
+            guard currentConsent != .notGranted else {
+                return []
+            }
+
             let cutoff = force ? Int64.max : Int64(now) - Int64(bufferLen) * Int64(bucketDuration)
             var flushed: [ExportedBucket] = []
             var keysToRemove: [UInt64] = []
@@ -309,6 +335,25 @@ internal final class StatsConcentrator: @unchecked Sendable {
             }
 
             return flushed
+        }
+    }
+
+    // MARK: - Consent
+
+    /// Updates the tracking consent that gates aggregation.
+    ///
+    /// `.granted` and `.pending` are both recording states, so transitions between them need no
+    /// action: data already written to storage is migrated by the core, and in-memory data keeps
+    /// accumulating. Revoking consent (`→ .notGranted`) discards the in-memory buffer so spans
+    /// aggregated before the revocation are never uploaded, even if consent is later re-granted.
+    func updateConsent(_ consent: TrackingConsent) {
+        currentConsent = consent
+
+        guard consent == .notGranted else {
+            return
+        }
+        queue.async { [self] in
+            buckets.removeAll()
         }
     }
 

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -206,14 +206,18 @@ internal final class StatsConcentrator: @unchecked Sendable {
     private var oldestTs: UInt64
 
     /// The user's current tracking consent. `.granted` and `.pending` are both recording states;
-    /// `.notGranted` stops aggregation and drops any data buffered in memory. Guarded by its own
-    /// lock so `add()` can cheaply check it off the serial queue without blocking the span hot path.
-    @ReadWriteLock
+    /// `.notGranted` stops aggregation and drops any data buffered in memory. Confined to `queue`,
+    /// so consent transitions stay ordered with `add`, `flush`, and the revoke clear and cannot be
+    /// observed out of order across threads.
+    ///
+    /// Starts gated (`.notGranted`) so nothing is aggregated until the first context message
+    /// confirms the real consent. The core delivers that context right after registration, before
+    /// spans realistically start finishing.
     private var currentConsent: TrackingConsent
 
     init(
         now: Nanoseconds,
-        initialConsent: TrackingConsent = .pending,
+        initialConsent: TrackingConsent = .notGranted,
         bucketDuration: Nanoseconds = StatsConcentrator.defaultBucketDuration,
         bufferLen: Int = StatsConcentrator.defaultBufferLen,
         peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys
@@ -231,11 +235,6 @@ internal final class StatsConcentrator: @unchecked Sendable {
     /// Ineligible spans are silently discarded. This method dispatches
     /// asynchronously and returns immediately without blocking the caller.
     func add(_ snapshot: SpanSnapshot) {
-        // Skip aggregation entirely when consent is not granted, so we neither spend work
-        // building the aggregation key nor retain any data we are not allowed to collect.
-        guard currentConsent != .notGranted else {
-            return
-        }
         guard Self.isEligible(snapshot) else {
             return
         }
@@ -246,9 +245,10 @@ internal final class StatsConcentrator: @unchecked Sendable {
         let peerTagStrings = matchingPeerTags.map { "\($0.key):\($0.value)" }
 
         queue.async { [self] in
-            // Re-check on the serial queue: consent may have been revoked between the check
-            // above and this block running, in which case `updateConsent` has (or will have)
-            // cleared the buffer and this span must not be re-added.
+            // Drop the span when consent is not granted. Checking on the serial queue (rather than
+            // off-queue) keeps the decision ordered with consent changes and the revoke clear, so a
+            // span recorded around a revocation cannot slip past or be re-added after the buffer is
+            // cleared.
             guard currentConsent != .notGranted else {
                 return
             }
@@ -347,13 +347,14 @@ internal final class StatsConcentrator: @unchecked Sendable {
     /// accumulating. Revoking consent (`→ .notGranted`) discards the in-memory buffer so spans
     /// aggregated before the revocation are never uploaded, even if consent is later re-granted.
     func updateConsent(_ consent: TrackingConsent) {
-        currentConsent = consent
-
-        guard consent == .notGranted else {
-            return
-        }
         queue.async { [self] in
-            buckets.removeAll()
+            currentConsent = consent
+            // Revoking consent discards everything buffered in memory so spans aggregated before
+            // the revocation are never uploaded, even if consent is later granted again. Running on
+            // the queue orders this clear with any in-flight `add` and `flush` work.
+            if consent == .notGranted {
+                buckets.removeAll()
+            }
         }
     }
 

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -210,14 +210,17 @@ internal final class StatsConcentrator: @unchecked Sendable {
     /// so consent transitions stay ordered with `add`, `flush`, and the revoke clear and cannot be
     /// observed out of order across threads.
     ///
-    /// Starts gated (`.notGranted`) so nothing is aggregated until the first context message
-    /// confirms the real consent. The core delivers that context right after registration, before
-    /// spans realistically start finishing.
+    /// Starts at `.pending`, the SDK's default until consent is known. This is a record-but-hold
+    /// state: spans in the startup window are aggregated, yet nothing is uploaded until the first
+    /// context message confirms consent, because the flush writer is consent-gated and the buffer
+    /// is cleared if consent turns out to be `.notGranted`. Defaulting to a recording state (rather
+    /// than `.notGranted`) avoids dropping spans that are stamped `_dd.compute_stats=0`, which would
+    /// otherwise leave the backend with no stats and no client bucket for that window.
     private var currentConsent: TrackingConsent
 
     init(
         now: Nanoseconds,
-        initialConsent: TrackingConsent = .notGranted,
+        initialConsent: TrackingConsent = .pending,
         bucketDuration: Nanoseconds = StatsConcentrator.defaultBucketDuration,
         bufferLen: Int = StatsConcentrator.defaultBufferLen,
         peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -68,6 +68,32 @@ class ClientStatsFeatureTests: XCTestCase {
         XCTAssertFalse(defaultConfig.statsComputationEnabled)
     }
 
+    // MARK: - Consent
+
+    func testWhenContextMessageRevokesConsent_itStopsConcentratorFromExporting() {
+        // Given: a concentrator with buffered data and the feature's consent receiver
+        let concentrator = StatsConcentrator(now: 0, initialConsent: .granted)
+        let receiver = TraceClientStatsConsentReceiver(concentrator: concentrator)
+        concentrator.add(SpanSnapshot.mockWith(startTime: 0, duration: 2_000_000_000, isTopLevel: true))
+
+        // When: the bus delivers a context carrying revoked consent
+        let handled = receiver.receive(
+            message: .context(.mockWith(trackingConsent: .notGranted)),
+            from: core
+        )
+
+        // Then: the message is observed (not consumed) and the buffered data is dropped
+        XCTAssertFalse(handled)
+        XCTAssertTrue(concentrator.flush(now: 100_000_000_000, force: true).isEmpty)
+    }
+
+    func testWhenMessageIsNotContext_theConsentReceiverIgnoresIt() {
+        let concentrator = StatsConcentrator(now: 0, initialConsent: .granted)
+        let receiver = TraceClientStatsConsentReceiver(concentrator: concentrator)
+
+        XCTAssertFalse(receiver.receive(message: .payload("irrelevant"), from: core))
+    }
+
     // MARK: - Request Builder
 
     func testWhenStatsComputationEnabled_thenRequestBuilderUsesStatsEndpoint() throws {

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -82,8 +82,8 @@ class ClientStatsFeatureTests: XCTestCase {
             from: core
         )
 
-        // Then: the message is observed (not consumed) and the buffered data is dropped
-        XCTAssertFalse(handled)
+        // Then: the message is processed and the buffered data is dropped
+        XCTAssertTrue(handled)
         XCTAssertTrue(concentrator.flush(now: 100_000_000_000, force: true).isEmpty)
     }
 

--- a/DatadogTrace/Tests/StatsConcentratorTests.swift
+++ b/DatadogTrace/Tests/StatsConcentratorTests.swift
@@ -15,14 +15,27 @@ class StatsConcentratorTests: XCTestCase {
 
     private func makeConcentrator(
         now: Nanoseconds = 100_000_000_000,
+        initialConsent: TrackingConsent = .granted,
         bufferLen: Int = StatsConcentrator.defaultBufferLen,
         peerTagKeys: [String] = StatsConcentrator.defaultPeerTagKeys
     ) -> StatsConcentrator {
         return StatsConcentrator(
             now: now,
+            initialConsent: initialConsent,
             bucketDuration: bucketDuration,
             bufferLen: bufferLen,
             peerTagKeys: peerTagKeys
+        )
+    }
+
+    private func makeEligibleSnapshot(now: Nanoseconds = 0) -> SpanSnapshot {
+        return SpanSnapshot.mockWith(
+            service: "web",
+            operationName: "http.request",
+            resource: "GET /api",
+            startTime: now,
+            duration: 2_000_000_000,
+            isTopLevel: true
         )
     }
 
@@ -771,5 +784,71 @@ class StatsConcentratorTests: XCTestCase {
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
         XCTAssertEqual(buckets[0].stats[0].type, "http")
+    }
+
+    // MARK: - Consent
+
+    func testWhenInitialConsentIsNotGranted_itDropsAllSpans() {
+        let concentrator = makeConcentrator(now: 0, initialConsent: .notGranted)
+
+        concentrator.add(makeEligibleSnapshot())
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertTrue(buckets.isEmpty)
+    }
+
+    func testWhenInitialConsentIsPending_itAggregatesSpans() {
+        let concentrator = makeConcentrator(now: 0, initialConsent: .pending)
+
+        concentrator.add(makeEligibleSnapshot())
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 1)
+    }
+
+    func testWhenConsentIsRevoked_itDiscardsBufferedData() {
+        let concentrator = makeConcentrator(now: 0, initialConsent: .granted)
+        concentrator.add(makeEligibleSnapshot())
+
+        // Revoke, then re-grant: the buffered span must stay dropped, proving the buffer was
+        // discarded on revocation rather than merely gated while not granted.
+        concentrator.updateConsent(.notGranted)
+        concentrator.updateConsent(.granted)
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertTrue(buckets.isEmpty)
+    }
+
+    func testWhenConsentRevoked_itDropsSpansRecordedAfterRevocation() {
+        let concentrator = makeConcentrator(now: 0, initialConsent: .granted)
+
+        concentrator.updateConsent(.notGranted)
+        concentrator.add(makeEligibleSnapshot())
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertTrue(buckets.isEmpty)
+    }
+
+    func testWhenConsentMovesBetweenGrantedAndPending_itKeepsAggregating() {
+        let concentrator = makeConcentrator(now: 0, initialConsent: .granted)
+        concentrator.add(makeEligibleSnapshot())
+
+        // Both are recording states, so neither transition should drop the buffered span.
+        concentrator.updateConsent(.pending)
+        concentrator.updateConsent(.granted)
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 1)
+        XCTAssertEqual(buckets[0].stats[0].hits, 1)
+    }
+
+    func testWhenConsentIsGrantedAfterNotGranted_itResumesAggregating() {
+        let concentrator = makeConcentrator(now: 0, initialConsent: .notGranted)
+
+        concentrator.updateConsent(.granted)
+        concentrator.add(makeEligibleSnapshot())
+
+        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
+        XCTAssertEqual(buckets.count, 1)
     }
 }


### PR DESCRIPTION
### What and why?

Client-side stats were aggregated and uploaded regardless of tracking consent. This makes the stats pipeline respect `TrackingConsent`, matching the Android change in DataDog/dd-sdk-android#3581.

`.granted` and `.pending` are both recording states. `.notGranted` stops aggregation, and revoking consent drops any data still buffered in memory so it is never uploaded, even if consent is later re-granted.

### How?

- `StatsConcentrator` now tracks the current consent (guarded by `@ReadWriteLock` so the span hot path stays lock-light): `add()` skips when not granted, `flush()` returns nothing when not granted, and a new `updateConsent()` clears the in-memory buffer on revocation.
- `ClientStatsFeature` observes consent through the message bus via a new `TraceClientStatsConsentReceiver`, replacing the no-op receiver. The core delivers the current context right after registration, so consent is known before the first flush.
- Data already written to storage is unchanged: the consent-aware writer and the core's batch migration already handle it.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs