### PR TITLE
Remove macos:sonoma from CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -344,25 +344,6 @@ SPM Build (Swift 6.2):
     - make spm-build-macos
     - make spm-build-watchos
 
-SPM Build (Swift 6.0):
-  stage: smoke-test
-  rules: 
-    - !reference [.test-pipeline-job, rules]
-    - !reference [.release-pipeline-job, rules]
-  tags:
-    - macos:sonoma
-    - specific:true
-  variables:
-    XCODE: "16.2.0"
-  script:
-    - ./tools/runner-setup.sh --xcode "$XCODE" --iOS --tvOS --visionOS --watchOS
-    - make clean repo-setup ENV=ci
-    - make spm-build-ios
-    - make spm-build-tvos
-    - make spm-build-visionos
-    - make spm-build-macos
-    - make spm-build-watchos
-
 SPI Docs Build:
   stage: lint
   rules: 
@@ -451,13 +432,8 @@ Dogfood (Datadog app):
 
 Build Artifacts:
   stage: release-build
-  tags:
-    - macos:sonoma
-    - specific:true
   rules:
     - !reference [.release-pipeline-job, rules]
-  variables:
-    XCODE: "16.2.0"
   id_tokens:
     <<: *dd-octo-sts-id-token
   artifacts:
@@ -467,7 +443,7 @@ Build Artifacts:
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --datadog-ci --xcode "$XCODE" --ssh
+    - ./tools/runner-setup.sh --datadog-ci --xcode "$DEFAULT_XCODE" --ssh
     - make env-check
     - make clean
     - make release-build release-validate

--- a/ZEN.md
+++ b/ZEN.md
@@ -32,7 +32,7 @@ This SDK lives in our customer’s applications, and is run on end users devices
 ## Compatibility
 
 - Support all iOS versions supported by current Xcode version that can publish to AppStoreConnect:
-    - Minimum accepted Xcode version: 16
+    - Minimum accepted Xcode version: 26
     - Minimum iOS accepted version: 12.0 
 - Support all main languages; especially the behavior should be the same for any language, but can be enhanced for modern languages.
     - iOS: ObjC/Swift


### PR DESCRIPTION
### What and why?

Remove `macos:sonoma` from CI: Xcode 16 (included in sonoma) can no longer submit apps to the store; we don't need to continue building on this version.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
