### PR TITLE
Add workflow to publish releases to Swift Package Registry

### DIFF
--- a/.github/workflows/publish-swift-package-registry.yml
+++ b/.github/workflows/publish-swift-package-registry.yml
@@ -1,0 +1,28 @@
+name: Publish to Swift Package Registry
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Publish to Swift Package Registry
+        env:
+          SWIFT_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          swift package-registry login https://swift.pkg.github.com/DataDog \
+            --token "$SWIFT_REGISTRY_TOKEN"
+
+          swift package-registry publish datadog.dd-sdk-ios@"${VERSION}" \
+            --registry-url https://swift.pkg.github.com/DataDog


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that automatically publishes new releases to [GitHub's Swift Package Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-swift-registry) (SE-0292)
- Triggers on `release` → `published` events, uses `swift package-registry publish` (Swift 6.0) to publish the source archive
- Makes the package available to Tuist Registry and other SE-0292 compliant package resolution tools

Closes #2520

## How it works

1. The workflow triggers whenever a GitHub release is published
2. It authenticates with GitHub's Swift Package Registry using the built-in `GITHUB_TOKEN`
3. It runs `swift package-registry publish` which creates a source archive and uploads it to `https://swift.pkg.github.com/DataDog`

No additional secrets or configuration are required — the `GITHUB_TOKEN` with `packages: write` permission handles authentication.

## Notes

- Uses `macos-15` runner (ships with Swift 6.0 via Xcode 16) since `swift package-registry publish` requires Swift 6.0+
- The checkout action SHA is pinned to match the convention in existing workflows
- Tag format is handled with `${GITHUB_REF_NAME#v}` to strip an optional `v` prefix, though current releases use bare semver (e.g., `3.13.0`)

## Test plan

- [ ] Verify the workflow YAML is syntactically valid
- [ ] Trigger a test release to confirm the publish step succeeds
- [ ] Confirm the package appears in GitHub Packages after publishing