### PR TITLE
[RUM-17096] Add client-side stats flush telemetry

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1189,6 +1189,7 @@
 		E7CSS01129C4D5A800000011 /* SpanSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS01429C4D5A800000014 /* SpanSnapshot.swift */; };
 		E7CSS01329C4D5A800000013 /* SpanSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS01629C4D5A800000016 /* SpanSnapshotTests.swift */; };
 		E7CSS00129C4D5A800000001 /* ClientStatsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */; };
+		E7CSS08129C4D5A800000081 /* TraceClientStatsMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS08429C4D5A800000084 /* TraceClientStatsMetric.swift */; };
 		E7CSS00229C4D5A800000002 /* StatsRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */; };
 		E7CSS00329C4D5A800000003 /* ClientStatsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */; };
 		E7CSS02129C4D5A800000021 /* StatsConcentrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CSS02429C4D5A800000024 /* StatsConcentrator.swift */; };
@@ -2875,6 +2876,7 @@
 		E7CSS01429C4D5A800000014 /* SpanSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSnapshot.swift; sourceTree = "<group>"; };
 		E7CSS01629C4D5A800000016 /* SpanSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSnapshotTests.swift; sourceTree = "<group>"; };
 		E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeature.swift; sourceTree = "<group>"; };
+		E7CSS08429C4D5A800000084 /* TraceClientStatsMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceClientStatsMetric.swift; sourceTree = "<group>"; };
 		E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRequestBuilder.swift; sourceTree = "<group>"; };
 		E7CSS00629C4D5A800000006 /* ClientStatsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStatsFeatureTests.swift; sourceTree = "<group>"; };
 		E7CSS02429C4D5A800000024 /* StatsConcentrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsConcentrator.swift; sourceTree = "<group>"; };
@@ -6359,6 +6361,7 @@
 				D2546C0729AF55E90054E00B /* RequestBuilder.swift */,
 				D2546C0A29AF56270054E00B /* MessageReceivers.swift */,
 				E7CSS00429C4D5A800000004 /* ClientStatsFeature.swift */,
+				E7CSS08429C4D5A800000084 /* TraceClientStatsMetric.swift */,
 				E7CSS00529C4D5A800000005 /* StatsRequestBuilder.swift */,
 				E7CSS02429C4D5A800000024 /* StatsConcentrator.swift */,
 			);
@@ -8926,6 +8929,7 @@
 				D2C1A4FA29C4C4CB00946C31 /* SpanSanitizer.swift in Sources */,
 				D2C1A50A29C4C4CB00946C31 /* TraceFeature.swift in Sources */,
 				E7CSS00129C4D5A800000001 /* ClientStatsFeature.swift in Sources */,
+				E7CSS08129C4D5A800000081 /* TraceClientStatsMetric.swift in Sources */,
 				E7CSS00229C4D5A800000002 /* StatsRequestBuilder.swift in Sources */,
 				E7CSS02129C4D5A800000021 /* StatsConcentrator.swift in Sources */,
 				E7CSS03129C4D5A800000031 /* MsgPackEncoder.swift in Sources */,

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -22,6 +22,7 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
     let concentrator: StatsConcentrator
     private let featureScope: FeatureScope
     private let dateProvider: DateProvider
+    private let metricController: TraceClientStatsMetricController
     private var flushTimer: Timer?
 
     /// Interval between periodic flushes (default: 30 seconds).
@@ -43,6 +44,7 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
         self.dateProvider = dateProvider
         self.flushInterval = flushInterval
         self.featureScope = core.scope(for: ClientStatsFeature.self)
+        self.metricController = TraceClientStatsMetricController(telemetry: featureScope.telemetry)
 
         let now = dateProvider.now.timeIntervalSince1970.dd.toNanoseconds
         let concentrator = StatsConcentrator(now: now)
@@ -73,41 +75,14 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
             return
         }
 
-        sendFlushMetric(for: exportedBuckets, force: force)
-
-        featureScope.eventWriteContext { _, writer in
+        featureScope.eventWriteContext { [metricController] _, writer in
             for bucket in exportedBuckets {
                 writer.write(value: bucket)
             }
+            // Report only after the write: in some cases the event write context is not
+            // available, and we do not want to signal a flush that never reached storage.
+            metricController.send(for: exportedBuckets, force: force)
         }
-    }
-
-    /// Emits the "Trace Client Stats Flushed" telemetry summarizing what a non-empty flush
-    /// produced, so we can watch on the Mobile Metrics dashboard that stats are flowing and the
-    /// aggregated volumes look sane during dogfooding.
-    private func sendFlushMetric(for buckets: [ExportedBucket], force: Bool) {
-        var groupsCount = 0
-        var spansCount: UInt64 = 0
-        var errorsCount: UInt64 = 0
-        for bucket in buckets {
-            groupsCount += bucket.stats.count
-            for group in bucket.stats {
-                spansCount += group.hits
-                errorsCount += group.errors
-            }
-        }
-
-        featureScope.telemetry.metric(
-            name: TraceClientStatsFlushedMetric.name,
-            attributes: [
-                SDKMetricFields.typeKey: TraceClientStatsFlushedMetric.typeValue,
-                TraceClientStatsFlushedMetric.bucketsCountKey: buckets.count,
-                TraceClientStatsFlushedMetric.groupsCountKey: groupsCount,
-                TraceClientStatsFlushedMetric.spansCountKey: spansCount,
-                TraceClientStatsFlushedMetric.errorsCountKey: errorsCount,
-                TraceClientStatsFlushedMetric.forcedKey: force
-            ]
-        )
     }
 
     private func startFlushTimer() {

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -73,11 +73,41 @@ internal final class ClientStatsFeature: DatadogRemoteFeature {
             return
         }
 
+        sendFlushMetric(for: exportedBuckets, force: force)
+
         featureScope.eventWriteContext { _, writer in
             for bucket in exportedBuckets {
                 writer.write(value: bucket)
             }
         }
+    }
+
+    /// Emits the "Trace Client Stats Flushed" telemetry summarizing what a non-empty flush
+    /// produced, so we can watch on the Mobile Metrics dashboard that stats are flowing and the
+    /// aggregated volumes look sane during dogfooding.
+    private func sendFlushMetric(for buckets: [ExportedBucket], force: Bool) {
+        var groupsCount = 0
+        var spansCount: UInt64 = 0
+        var errorsCount: UInt64 = 0
+        for bucket in buckets {
+            groupsCount += bucket.stats.count
+            for group in bucket.stats {
+                spansCount += group.hits
+                errorsCount += group.errors
+            }
+        }
+
+        featureScope.telemetry.metric(
+            name: TraceClientStatsFlushedMetric.name,
+            attributes: [
+                SDKMetricFields.typeKey: TraceClientStatsFlushedMetric.typeValue,
+                TraceClientStatsFlushedMetric.bucketsCountKey: buckets.count,
+                TraceClientStatsFlushedMetric.groupsCountKey: groupsCount,
+                TraceClientStatsFlushedMetric.spansCountKey: spansCount,
+                TraceClientStatsFlushedMetric.errorsCountKey: errorsCount,
+                TraceClientStatsFlushedMetric.forcedKey: force
+            ]
+        )
     }
 
     private func startFlushTimer() {

--- a/DatadogTrace/Sources/Feature/TraceClientStatsMetric.swift
+++ b/DatadogTrace/Sources/Feature/TraceClientStatsMetric.swift
@@ -5,19 +5,20 @@
  */
 
 import Foundation
+import DatadogInternal
 
-/// Definition of the "Trace Client Stats Flushed" telemetry.
+/// Definition of the "Trace Client Stats" telemetry.
 ///
 /// Emitted on the client-side stats flush path so we can confirm, during dogfooding and in
 /// production, that stats are actually being produced and that the aggregated numbers look
 /// sane. It is the CSS-specific counterpart to the core's generic upload telemetry.
 ///
 /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
-internal enum TraceClientStatsFlushedMetric {
+internal enum TraceClientStatsMetric {
     /// The name of this metric, included in the telemetry log.
-    static let name = "Trace Client Stats Flushed"
+    static let name = "Trace Client Stats"
     /// Metric type value.
-    static let typeValue = "trace client stats flushed"
+    static let typeValue = "trace client stats"
 
     /// The number of buckets exported in this flush.
     static let bucketsCountKey = "buckets_count"
@@ -29,4 +30,36 @@ internal enum TraceClientStatsFlushedMetric {
     static let errorsCountKey = "errors_count"
     /// Whether the flush was forced (SDK teardown) rather than a periodic flush.
     static let forcedKey = "forced"
+}
+
+/// Builds and emits the "Trace Client Stats" telemetry, keeping the metric responsibility
+/// out of `ClientStatsFeature`.
+internal struct TraceClientStatsMetricController {
+    let telemetry: Telemetry
+
+    /// Emits the metric summarizing what a non-empty flush produced.
+    func send(for buckets: [ExportedBucket], force: Bool) {
+        var groupsCount = 0
+        var spansCount: UInt64 = 0
+        var errorsCount: UInt64 = 0
+        for bucket in buckets {
+            groupsCount += bucket.stats.count
+            for group in bucket.stats {
+                spansCount += group.hits
+                errorsCount += group.errors
+            }
+        }
+
+        telemetry.metric(
+            name: TraceClientStatsMetric.name,
+            attributes: [
+                SDKMetricFields.typeKey: TraceClientStatsMetric.typeValue,
+                TraceClientStatsMetric.bucketsCountKey: buckets.count,
+                TraceClientStatsMetric.groupsCountKey: groupsCount,
+                TraceClientStatsMetric.spansCountKey: spansCount,
+                TraceClientStatsMetric.errorsCountKey: errorsCount,
+                TraceClientStatsMetric.forcedKey: force
+            ]
+        )
+    }
 }

--- a/DatadogTrace/Sources/Feature/TraceClientStatsMetric.swift
+++ b/DatadogTrace/Sources/Feature/TraceClientStatsMetric.swift
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// Definition of the "Trace Client Stats Flushed" telemetry.
+///
+/// Emitted on the client-side stats flush path so we can confirm, during dogfooding and in
+/// production, that stats are actually being produced and that the aggregated numbers look
+/// sane. It is the CSS-specific counterpart to the core's generic upload telemetry.
+///
+/// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
+internal enum TraceClientStatsFlushedMetric {
+    /// The name of this metric, included in the telemetry log.
+    static let name = "Trace Client Stats Flushed"
+    /// Metric type value.
+    static let typeValue = "trace client stats flushed"
+
+    /// The number of buckets exported in this flush.
+    static let bucketsCountKey = "buckets_count"
+    /// The total number of aggregation groups across all exported buckets.
+    static let groupsCountKey = "groups_count"
+    /// The total number of spans aggregated into this flush (sum of group hits).
+    static let spansCountKey = "spans_count"
+    /// The total number of errored spans across all groups (sum of group errors).
+    static let errorsCountKey = "errors_count"
+    /// Whether the flush was forced (SDK teardown) rather than a periodic flush.
+    static let forcedKey = "forced"
+}

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -165,6 +165,92 @@ class ClientStatsFeatureTests: XCTestCase {
         XCTAssertTrue(core.exportedBuckets.isEmpty)
     }
 
+    // MARK: - Flush Telemetry
+
+    func testWhenFlushProducesBuckets_itSendsFlushMetric() throws {
+        // Given
+        let core = FeatureRegistrationPassthroughCoreMock()
+        let dateProvider = RelativeDateProvider(using: Date(timeIntervalSince1970: 0))
+        config.statsComputationEnabled = true
+        config.dateProvider = dateProvider
+
+        Trace.enable(with: config, in: core)
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+
+        // Two spans landing in the same aggregation group, one of them an error.
+        stats.concentrator.add(.mockWith(startTime: 0, duration: 1_000_000_000, isTopLevel: true))
+        stats.concentrator.add(.mockWith(isError: true, startTime: 0, duration: 2_000_000_000, isTopLevel: true))
+
+        // When: advancing past the buffer window makes the bucket flushable.
+        dateProvider.advance(bySeconds: 60)
+        stats.flushStats(force: false)
+
+        // Then
+        let metric = try XCTUnwrap(core.telemetryMock.messages.firstMetric(named: TraceClientStatsFlushedMetric.name))
+        XCTAssertEqual(metric.attributes[SDKMetricFields.typeKey] as? String, TraceClientStatsFlushedMetric.typeValue)
+        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.bucketsCountKey] as? Int, 1)
+        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.groupsCountKey] as? Int, 1)
+        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.spansCountKey] as? UInt64, 2)
+        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.errorsCountKey] as? UInt64, 1)
+        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.forcedKey] as? Bool, false)
+    }
+
+    func testWhenForcedFlushProducesBuckets_itMarksMetricAsForced() throws {
+        // Given
+        let core = FeatureRegistrationPassthroughCoreMock()
+        let dateProvider = RelativeDateProvider(using: Date(timeIntervalSince1970: 0))
+        config.statsComputationEnabled = true
+        config.dateProvider = dateProvider
+
+        Trace.enable(with: config, in: core)
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+        stats.concentrator.add(.mockWith(startTime: 0, duration: 1_000_000_000, isTopLevel: true))
+
+        // When: a forced flush (teardown) exports the still-recent bucket.
+        stats.flushStats(force: true)
+
+        // Then
+        let metric = try XCTUnwrap(core.telemetryMock.messages.firstMetric(named: TraceClientStatsFlushedMetric.name))
+        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.forcedKey] as? Bool, true)
+        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.spansCountKey] as? UInt64, 1)
+    }
+
+    func testWhenFlushProducesNoBuckets_itDoesNotSendFlushMetric() throws {
+        // Given
+        let core = FeatureRegistrationPassthroughCoreMock()
+        config.statsComputationEnabled = true
+        config.dateProvider = RelativeDateProvider(using: Date(timeIntervalSince1970: 0))
+
+        Trace.enable(with: config, in: core)
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+
+        // When: nothing was aggregated, so the flush is empty.
+        stats.flushStats(force: true)
+
+        // Then
+        XCTAssertNil(core.telemetryMock.messages.firstMetric(named: TraceClientStatsFlushedMetric.name))
+    }
+
+    func testWhenConsentIsNotGranted_itDoesNotSendFlushMetric() throws {
+        // Given
+        let core = FeatureRegistrationPassthroughCoreMock()
+        let dateProvider = RelativeDateProvider(using: Date(timeIntervalSince1970: 0))
+        config.statsComputationEnabled = true
+        config.dateProvider = dateProvider
+
+        Trace.enable(with: config, in: core)
+        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
+
+        // When: consent is revoked, aggregation and flush are gated off.
+        stats.concentrator.updateConsent(.notGranted)
+        stats.concentrator.add(.mockWith(startTime: 0, duration: 1_000_000_000, isTopLevel: true))
+        dateProvider.advance(bySeconds: 60)
+        stats.flushStats(force: true)
+
+        // Then: no buckets are exported, so no metric is emitted.
+        XCTAssertNil(core.telemetryMock.messages.firstMetric(named: TraceClientStatsFlushedMetric.name))
+    }
+
     // MARK: - Request Builder - Encoding
 
     func testWhenBuildingRequest_itTargetsStatsIntakeWithMsgPackContentType() throws {
@@ -479,7 +565,8 @@ private final class FeatureRegistrationPassthroughCoreMock: DatadogCoreProtocol,
     }
 
     var dataStore: DataStore { NOPDataStore() }
-    var telemetry: Telemetry { NOPTelemetry() }
+    let telemetryMock = TelemetryMock()
+    var telemetry: Telemetry { telemetryMock }
 
     func set(anonymousId: String?) { }
 

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -186,13 +186,13 @@ class ClientStatsFeatureTests: XCTestCase {
         stats.flushStats(force: false)
 
         // Then
-        let metric = try XCTUnwrap(core.telemetryMock.messages.firstMetric(named: TraceClientStatsFlushedMetric.name))
-        XCTAssertEqual(metric.attributes[SDKMetricFields.typeKey] as? String, TraceClientStatsFlushedMetric.typeValue)
-        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.bucketsCountKey] as? Int, 1)
-        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.groupsCountKey] as? Int, 1)
-        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.spansCountKey] as? UInt64, 2)
-        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.errorsCountKey] as? UInt64, 1)
-        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.forcedKey] as? Bool, false)
+        let metric = try XCTUnwrap(core.telemetryMock.messages.firstMetric(named: TraceClientStatsMetric.name))
+        XCTAssertEqual(metric.attributes[SDKMetricFields.typeKey] as? String, TraceClientStatsMetric.typeValue)
+        XCTAssertEqual(metric.attributes[TraceClientStatsMetric.bucketsCountKey] as? Int, 1)
+        XCTAssertEqual(metric.attributes[TraceClientStatsMetric.groupsCountKey] as? Int, 1)
+        XCTAssertEqual(metric.attributes[TraceClientStatsMetric.spansCountKey] as? UInt64, 2)
+        XCTAssertEqual(metric.attributes[TraceClientStatsMetric.errorsCountKey] as? UInt64, 1)
+        XCTAssertEqual(metric.attributes[TraceClientStatsMetric.forcedKey] as? Bool, false)
     }
 
     func testWhenForcedFlushProducesBuckets_itMarksMetricAsForced() throws {
@@ -210,9 +210,9 @@ class ClientStatsFeatureTests: XCTestCase {
         stats.flushStats(force: true)
 
         // Then
-        let metric = try XCTUnwrap(core.telemetryMock.messages.firstMetric(named: TraceClientStatsFlushedMetric.name))
-        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.forcedKey] as? Bool, true)
-        XCTAssertEqual(metric.attributes[TraceClientStatsFlushedMetric.spansCountKey] as? UInt64, 1)
+        let metric = try XCTUnwrap(core.telemetryMock.messages.firstMetric(named: TraceClientStatsMetric.name))
+        XCTAssertEqual(metric.attributes[TraceClientStatsMetric.forcedKey] as? Bool, true)
+        XCTAssertEqual(metric.attributes[TraceClientStatsMetric.spansCountKey] as? UInt64, 1)
     }
 
     func testWhenFlushProducesNoBuckets_itDoesNotSendFlushMetric() throws {
@@ -228,7 +228,7 @@ class ClientStatsFeatureTests: XCTestCase {
         stats.flushStats(force: true)
 
         // Then
-        XCTAssertNil(core.telemetryMock.messages.firstMetric(named: TraceClientStatsFlushedMetric.name))
+        XCTAssertNil(core.telemetryMock.messages.firstMetric(named: TraceClientStatsMetric.name))
     }
 
     func testWhenConsentIsNotGranted_itDoesNotSendFlushMetric() throws {
@@ -248,7 +248,7 @@ class ClientStatsFeatureTests: XCTestCase {
         stats.flushStats(force: true)
 
         // Then: no buckets are exported, so no metric is emitted.
-        XCTAssertNil(core.telemetryMock.messages.firstMetric(named: TraceClientStatsFlushedMetric.name))
+        XCTAssertNil(core.telemetryMock.messages.firstMetric(named: TraceClientStatsMetric.name))
     }
 
     // MARK: - Request Builder - Encoding


### PR DESCRIPTION
### What and why?

Client-side stats (CSS) currently rides only the core's generic upload telemetry, with nothing specific to the CSS pipeline. Before dogfooding we need a signal to confirm stats are actually produced and that the aggregated numbers look sane on our metrics dashboards.

Targets the `feature/client-side-stats` integration branch, on top of the consent handling from #3027.

Reference: this follows the reviewed "Trace Client Stats" telemetry spec (internal Datadog doc, tracked under RUM-17096).

### How?

Adds a "Trace Client Stats" metric emitted on the flush path. The counting and emission live in a dedicated `TraceClientStatsMetricController`, so `ClientStatsFeature` does not take on the metric responsibility. Attributes: `buckets_count`, `groups_count`, `spans_count` (sum of hits), `errors_count` (sum of errors), and `forced`.

The metric is reported after the buckets are written to storage, so a consent-off flush, an empty flush, or a flush whose event write never happens emits nothing.

Sampling uses the SDK default metric sample rate (`MetricTelemetry.defaultSampleRate`), applied on top of the telemetry sample rate, same as other SDK metrics.

Payload size (only known in `StatsRequestBuilder`) and per-reason dropped-span counts are a follow-up.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes (internal telemetry only, not user facing)
- [ ] Add Objective-C interface for public APIs (no public API change)
- [ ] Run `make api-surface` when adding new APIs (no new APIs)