### PR TITLE
Fix SIGTRAP in testRegisteredDelegate_detectsFirstPartyHosts

### DIFF
--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -2146,9 +2146,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testRegisteredDelegate_detectsFirstPartyHosts() throws {
-        let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let server = ServerMock(delivery: .success(response: .mockWith(statusCode: 200, mimeType: "application/json"), data: .mock(ofSize: 10)))
-        scopeHandler(to: server)
+        let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
         // Given
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
@@ -2171,7 +2169,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             .resume()
 
         // Then
-        waitForExpectations(timeout: 5, handler: nil)
+        wait(for: [notifyInterceptionDidStart, notifyInterceptionDidComplete], timeout: 5, enforceOrder: true)
         _ = server.waitAndReturnRequests(count: 1)
     }
 


### PR DESCRIPTION
### What and why?

`testRegisteredDelegate_detectsFirstPartyHosts` was crashing with SIGTRAP. `ServerMock.deinit` fired on the background queue `com.datadoghq.network-instrumentation` because the test returned while a pending async block still held the last strong reference to `server` (via a weak load in the `scopeHandler` closure).

### How?

Refactor the test to use `setupInterceptionTest()` like all other `testRegisteredDelegate_*` tests. This brings in `skipIsMainThreadCheck: true` on `ServerMock` and — crucially — a second expectation for `interceptionDidComplete`, which forces the test to wait until the background queue fully drains before returning and releasing `server`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs