### PR TITLE
[RUM-16416] Add remoteConfigurationId to DatadogContext and RUM view events

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -530,7 +530,8 @@ extension DatadogContextProvider {
         serverDateProvider: ServerDateProvider,
         notificationCenter: NotificationCenter,
         appLaunchHandler: AppLaunchHandling,
-        appStateProvider: AppStateProvider
+        appStateProvider: AppStateProvider,
+        remoteConfigurationId: String?
     ) {
         // `ContextProvider` must be initialized on the main thread for two key reasons:
         // - It interacts with UIKit APIs to read the initial app state, which is only safe on the main thread.
@@ -563,7 +564,8 @@ extension DatadogContextProvider {
             localeInfo: locale,
             nativeSourceOverride: nativeSourceOverride,
             launchInfo: launchInfo,
-            applicationStateHistory: appStateHistory
+            applicationStateHistory: appStateHistory,
+            remoteConfigurationId: remoteConfigurationId
         )
 
         self.init(context: context)

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -468,7 +468,8 @@ extension DatadogCore {
                 serverDateProvider: configuration.serverDateProvider,
                 notificationCenter: configuration.notificationCenter,
                 appLaunchHandler: configuration.appLaunchHandler,
-                appStateProvider: configuration.appStateProvider
+                appStateProvider: configuration.appStateProvider,
+                remoteConfigurationId: configuration.remoteConfigurationID
             ),
             applicationVersion: applicationVersion,
             maxBatchesPerUpload: configuration.batchProcessingLevel.maxBatchesPerUpload,

--- a/DatadogCore/Tests/Datadog/DatadogTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogTests.swift
@@ -546,7 +546,9 @@ class DatadogTests: XCTestCase {
 
         // Then
         let core = try XCTUnwrap(CoreRegistry.default as? DatadogCore)
+        let context = core.contextProvider.read()
         XCTAssertNotNil(core.remoteConfigurationProvider)
+        XCTAssertEqual(context.remoteConfigurationId, "test-id")
     }
 
     func testCustomSDKInstance() throws {

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -951,6 +951,41 @@ class CrashReportReceiverTests: XCTestCase {
         )
     }
 
+    func testGivenCrashWithNoActiveViewAndRemoteConfigurationId_whenSendingRUMViewEvent_itIncludesRemoteConfigurationId() throws {
+        // Given
+        let randomRemoteConfigurationId: String = .mockRandom()
+        let crashDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            trackingConsent: .granted,
+            lastRUMViewEvent: nil, // means there was no active RUM view (view is synthesized from crash context)
+            lastRUMSessionState: .mockWith(isSampled: true, isInitialSession: true, hasTrackedAnyView: false),
+            lastIsAppInForeground: true,
+            remoteConfigurationId: randomRemoteConfigurationId
+        )
+
+        let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(using: crashDate),
+            trackBackgroundEvents: true
+        )
+
+        // When
+        XCTAssertTrue(
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
+            ), from: NOPDatadogCore())
+        )
+
+        // Then
+        let sentRUMView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).first)
+        XCTAssertEqual(
+            sentRUMView.dd.configuration?.remoteConfigurationId,
+            randomRemoteConfigurationId,
+            "The synthesized crash view event must carry the configured remote configuration id"
+        )
+    }
+
     func testGivenCrashDuringRUMSessionWithNoActiveViewAndOverriddenSourceType_whenSendingRUMViewEvent_itSendsOverriddenSourceType() throws {
         func test(
             lastRUMSessionState: RUMSessionState,

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -57,7 +57,7 @@ public struct DatadogContext {
     /// It is only set if the SDK is running with a context passed from [Swift Tests](https://docs.datadoghq.com/continuous_integration/setup_tests/swift/?tab=swiftpackagemanager) library.
     public let ciAppOrigin: String?
 
-    /// The identifier of the remote configuration applied to the SDK.
+    /// The identifier of the remote configuration the SDK was configured with, if any.
     public let remoteConfigurationId: String?
 
     /// Interval between device and server time.

--- a/DatadogInternal/Sources/Context/DatadogContext.swift
+++ b/DatadogInternal/Sources/Context/DatadogContext.swift
@@ -57,6 +57,9 @@ public struct DatadogContext {
     /// It is only set if the SDK is running with a context passed from [Swift Tests](https://docs.datadoghq.com/continuous_integration/setup_tests/swift/?tab=swiftpackagemanager) library.
     public let ciAppOrigin: String?
 
+    /// The identifier of the remote configuration applied to the SDK.
+    public let remoteConfigurationId: String?
+
     /// Interval between device and server time.
     ///
     /// The value can change as the device continue to sync with the server.
@@ -165,6 +168,7 @@ public struct DatadogContext {
         batteryStatus: BatteryStatus? = nil,
         brightnessLevel: BrightnessLevel? = nil,
         isLowPowerModeEnabled: Bool = false,
+        remoteConfigurationId: String? = nil,
         additionalContext: [String: AdditionalContext] = [:]
     ) {
         self.site = site
@@ -197,6 +201,7 @@ public struct DatadogContext {
         self.batteryStatus = batteryStatus
         self.brightnessLevel = brightnessLevel
         self.isLowPowerModeEnabled = isLowPowerModeEnabled
+        self.remoteConfigurationId = remoteConfigurationId
         self.additionalContext = additionalContext
         self.ddTags = buildDDTags()
     }

--- a/DatadogInternal/Sources/Models/CrashReporting/CrashContext.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/CrashContext.swift
@@ -71,6 +71,9 @@ public struct CrashContext: Codable, Equatable {
     /// The last _"Is app in foreground?"_ information from crashed app process.
     public let lastIsAppInForeground: Bool
 
+    /// The identifier of the remote configuration the SDK was configured with.
+    public let remoteConfigurationId: String?
+
     /// The last RUM view in crashed app process.
     public var lastRUMViewEvent: RUMViewEvent?
 
@@ -105,7 +108,8 @@ public struct CrashContext: Codable, Equatable {
         lastRUMViewEvent: RUMViewEvent?,
         lastRUMSessionState: RUMSessionState?,
         lastRUMAttributes: RUMEventAttributes?,
-        lastLogAttributes: LogEventAttributes?
+        lastLogAttributes: LogEventAttributes?,
+        remoteConfigurationId: String? = nil
     ) {
         self.serverTimeOffset = serverTimeOffset
         self.service = service.sanitizedToDDTags()
@@ -123,6 +127,7 @@ public struct CrashContext: Codable, Equatable {
         self.carrierInfo = carrierInfo
         self.lastIsAppInForeground = lastIsAppInForeground
         self.appLaunchDate = appLaunchDate
+        self.remoteConfigurationId = remoteConfigurationId
         self.lastRUMViewEvent = lastRUMViewEvent
         self.lastRUMSessionState = lastRUMSessionState
         self.lastRUMAttributes = lastRUMAttributes
@@ -151,6 +156,7 @@ public struct CrashContext: Codable, Equatable {
         self.networkConnectionInfo = context.networkConnectionInfo
         self.carrierInfo = context.carrierInfo
         self.lastIsAppInForeground = context.applicationStateHistory.currentState.isRunningInForeground
+        self.remoteConfigurationId = context.remoteConfigurationId
 
         self.lastRUMViewEvent = lastRUMViewEvent
         self.lastRUMSessionState = lastRUMSessionState

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -549,7 +549,7 @@ public struct RUMActionEvent: RUMDataModel {
                 /// Height of the target element (in pixels)
                 public let height: Int64?
 
-                /// Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                /// Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
                 public let permanentId: String?
 
                 /// CSS selector path of the target element
@@ -571,7 +571,7 @@ public struct RUMActionEvent: RUMDataModel {
                 /// - Parameters:
                 ///   - composedPathSelector: Selector data based on the click event composed path
                 ///   - height: Height of the target element (in pixels)
-                ///   - permanentId: Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path (32 lowercase hex characters). Used to correlate actions with mobile session replay wireframes.
+                ///   - permanentId: Mobile-only: a globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate actions with mobile session replay wireframes.
                 ///   - selector: CSS selector path of the target element
                 ///   - width: Width of the target element (in pixels)
                 public init(
@@ -1314,7 +1314,7 @@ public struct RUMConnectivity: Codable {
 /// Schema of all properties of an Error event
 public struct RUMErrorEvent: RUMDataModel {
     /// Internal properties
-    public let dd: DD
+    public var dd: DD
 
     /// Account properties
     public var account: RUMAccount?
@@ -1524,6 +1524,9 @@ public struct RUMErrorEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public let configuration: Configuration?
 
+        /// Mapping of source file URLs to their debug IDs for source map deobfuscation
+        public var debugIds: DebugIds?
+
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
@@ -1551,6 +1554,7 @@ public struct RUMErrorEvent: RUMDataModel {
         public enum CodingKeys: String, CodingKey {
             case browserSdkVersion = "browser_sdk_version"
             case configuration = "configuration"
+            case debugIds = "debug_ids"
             case formatVersion = "format_version"
             case parentSpanId = "parent_span_id"
             case profiling = "profiling"
@@ -1566,6 +1570,7 @@ public struct RUMErrorEvent: RUMDataModel {
         /// - Parameters:
         ///   - browserSdkVersion: Browser SDK version
         ///   - configuration: Subset of the SDK configuration options in use during its execution
+        ///   - debugIds: Mapping of source file URLs to their debug IDs for source map deobfuscation
         ///   - parentSpanId: parent span identifier in decimal format
         ///   - profiling: Profiling context
         ///   - rulePsr: trace sample rate in decimal format
@@ -1576,6 +1581,7 @@ public struct RUMErrorEvent: RUMDataModel {
         public init(
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
+            debugIds: DebugIds? = nil,
             parentSpanId: String? = nil,
             profiling: Profiling? = nil,
             rulePsr: Double? = nil,
@@ -1586,6 +1592,7 @@ public struct RUMErrorEvent: RUMDataModel {
         ) {
             self.browserSdkVersion = browserSdkVersion
             self.configuration = configuration
+            self.debugIds = debugIds
             self.parentSpanId = parentSpanId
             self.profiling = profiling
             self.rulePsr = rulePsr
@@ -1636,6 +1643,22 @@ public struct RUMErrorEvent: RUMDataModel {
             }
         }
 
+        /// Mapping of source file URLs to their debug IDs for source map deobfuscation
+        public struct DebugIds: Codable {
+            /// Debug ID (UUID) for the source file
+            public var debugIdsInfo: [String: String]
+
+            /// Mapping of source file URLs to their debug IDs for source map deobfuscation
+            ///
+            /// - Parameters:
+            ///   - debugIdsInfo: Debug ID (UUID) for the source file
+            public init(
+                debugIdsInfo: [String: String]
+            ) {
+                self.debugIdsInfo = debugIdsInfo
+            }
+        }
+
         /// Profiling context
         public struct Profiling: Codable {
             /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
@@ -1646,6 +1669,18 @@ public struct RUMErrorEvent: RUMDataModel {
             /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
             public let errorReason: ErrorReason?
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public let quotaReason: QuotaReason?
 
             /// Used to track the status of the RUM Profiler.
             ///
@@ -1659,6 +1694,7 @@ public struct RUMErrorEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case errorReason = "error_reason"
+                case quotaReason = "quota_reason"
                 case status = "status"
             }
 
@@ -1672,6 +1708,16 @@ public struct RUMErrorEvent: RUMDataModel {
             /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
             /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            ///   - quotaReason: The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
             ///   - status: Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -1682,9 +1728,11 @@ public struct RUMErrorEvent: RUMDataModel {
             /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
             public init(
                 errorReason: ErrorReason? = nil,
+                quotaReason: QuotaReason? = nil,
                 status: Status? = nil
             ) {
                 self.errorReason = errorReason
+                self.quotaReason = quotaReason
                 self.status = status
             }
 
@@ -1700,6 +1748,26 @@ public struct RUMErrorEvent: RUMDataModel {
                 case failedToLazyLoad = "failed-to-lazy-load"
                 case missingDocumentPolicyHeader = "missing-document-policy-header"
                 case unexpectedException = "unexpected-exception"
+            }
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public enum QuotaReason: String, Codable {
+                case quotaOk = "quota_ok"
+                case quotaExceeded = "quota_exceeded"
+                case orgDisabled = "org_disabled"
+                case backendUnavailable = "backend_unavailable"
+                case undefined = "undefined"
+                case timeout = "timeout"
+                case apiError = "api-error"
             }
 
             /// Used to track the status of the RUM Profiler.
@@ -2609,6 +2677,26 @@ public struct RUMErrorEvent: RUMDataModel {
     }
 }
 
+extension RUMErrorEvent.DD.DebugIds {
+    public func encode(to encoder: Encoder) throws {
+        // Encode dynamic properties:
+        var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        debugIdsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode other properties into [String: String] dictionary:
+        let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+        self.debugIdsInfo = [:]
+
+        try dynamicContainer.allKeys.forEach {
+            self.debugIdsInfo[$0.stringValue] = try dynamicContainer.decode(String.self, forKey: $0)
+        }
+    }
+}
+
 extension RUMErrorEvent.FeatureFlags {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
@@ -2838,7 +2926,7 @@ public struct RUMGraphql: Codable {
 /// Schema of all properties of a Long Task event
 public struct RUMLongTaskEvent: RUMDataModel {
     /// Internal properties
-    public let dd: DD
+    public var dd: DD
 
     /// Account properties
     public var account: RUMAccount?
@@ -3034,6 +3122,9 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public let configuration: Configuration?
 
+        /// Mapping of source file URLs to their debug IDs for source map deobfuscation
+        public var debugIds: DebugIds?
+
         /// Whether the long task should be discarded or indexed
         public let discarded: Bool?
 
@@ -3052,6 +3143,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         public enum CodingKeys: String, CodingKey {
             case browserSdkVersion = "browser_sdk_version"
             case configuration = "configuration"
+            case debugIds = "debug_ids"
             case discarded = "discarded"
             case formatVersion = "format_version"
             case profiling = "profiling"
@@ -3064,6 +3156,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// - Parameters:
         ///   - browserSdkVersion: Browser SDK version
         ///   - configuration: Subset of the SDK configuration options in use during its execution
+        ///   - debugIds: Mapping of source file URLs to their debug IDs for source map deobfuscation
         ///   - discarded: Whether the long task should be discarded or indexed
         ///   - profiling: Profiling context
         ///   - sdkName: SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
@@ -3071,6 +3164,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         public init(
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
+            debugIds: DebugIds? = nil,
             discarded: Bool? = nil,
             profiling: Profiling? = nil,
             sdkName: String? = nil,
@@ -3078,6 +3172,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         ) {
             self.browserSdkVersion = browserSdkVersion
             self.configuration = configuration
+            self.debugIds = debugIds
             self.discarded = discarded
             self.profiling = profiling
             self.sdkName = sdkName
@@ -3125,6 +3220,22 @@ public struct RUMLongTaskEvent: RUMDataModel {
             }
         }
 
+        /// Mapping of source file URLs to their debug IDs for source map deobfuscation
+        public struct DebugIds: Codable {
+            /// Debug ID (UUID) for the source file
+            public var debugIdsInfo: [String: String]
+
+            /// Mapping of source file URLs to their debug IDs for source map deobfuscation
+            ///
+            /// - Parameters:
+            ///   - debugIdsInfo: Debug ID (UUID) for the source file
+            public init(
+                debugIdsInfo: [String: String]
+            ) {
+                self.debugIdsInfo = debugIdsInfo
+            }
+        }
+
         /// Profiling context
         public struct Profiling: Codable {
             /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
@@ -3135,6 +3246,18 @@ public struct RUMLongTaskEvent: RUMDataModel {
             /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
             public let errorReason: ErrorReason?
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public let quotaReason: QuotaReason?
 
             /// Used to track the status of the RUM Profiler.
             ///
@@ -3148,6 +3271,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case errorReason = "error_reason"
+                case quotaReason = "quota_reason"
                 case status = "status"
             }
 
@@ -3161,6 +3285,16 @@ public struct RUMLongTaskEvent: RUMDataModel {
             /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
             /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            ///   - quotaReason: The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
             ///   - status: Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -3171,9 +3305,11 @@ public struct RUMLongTaskEvent: RUMDataModel {
             /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
             public init(
                 errorReason: ErrorReason? = nil,
+                quotaReason: QuotaReason? = nil,
                 status: Status? = nil
             ) {
                 self.errorReason = errorReason
+                self.quotaReason = quotaReason
                 self.status = status
             }
 
@@ -3189,6 +3325,26 @@ public struct RUMLongTaskEvent: RUMDataModel {
                 case failedToLazyLoad = "failed-to-lazy-load"
                 case missingDocumentPolicyHeader = "missing-document-policy-header"
                 case unexpectedException = "unexpected-exception"
+            }
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public enum QuotaReason: String, Codable {
+                case quotaOk = "quota_ok"
+                case quotaExceeded = "quota_exceeded"
+                case orgDisabled = "org_disabled"
+                case backendUnavailable = "backend_unavailable"
+                case undefined = "undefined"
+                case timeout = "timeout"
+                case apiError = "api-error"
             }
 
             /// Used to track the status of the RUM Profiler.
@@ -3711,6 +3867,26 @@ public struct RUMLongTaskEvent: RUMDataModel {
             self.name = name
             self.referrer = referrer
             self.url = url
+        }
+    }
+}
+
+extension RUMLongTaskEvent.DD.DebugIds {
+    public func encode(to encoder: Encoder) throws {
+        // Encode dynamic properties:
+        var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        debugIdsInfo.forEach { name, value in
+            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        // Decode other properties into [String: String] dictionary:
+        let dynamicContainer = try decoder.container(keyedBy: DynamicCodingKey.self)
+        self.debugIdsInfo = [:]
+
+        try dynamicContainer.allKeys.forEach {
+            self.debugIdsInfo[$0.stringValue] = try dynamicContainer.decode(String.self, forKey: $0)
         }
     }
 }
@@ -5489,6 +5665,9 @@ public struct RUMViewEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// The id of the remote configuration applied to the SDK, if any
+            public let remoteConfigurationId: String?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -5503,6 +5682,7 @@ public struct RUMViewEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case remoteConfigurationId = "remote_configuration_id"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
@@ -5513,18 +5693,21 @@ public struct RUMViewEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - remoteConfigurationId: The id of the remote configuration applied to the SDK, if any
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - startSessionReplayRecordingManually: Whether session replay recording configured to start manually
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                remoteConfigurationId: String? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 startSessionReplayRecordingManually: Bool? = nil,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.remoteConfigurationId = remoteConfigurationId
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.startSessionReplayRecordingManually = startSessionReplayRecordingManually
@@ -5579,6 +5762,18 @@ public struct RUMViewEvent: RUMDataModel {
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
             public let errorReason: ErrorReason?
 
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public let quotaReason: QuotaReason?
+
             /// Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -5591,6 +5786,7 @@ public struct RUMViewEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case errorReason = "error_reason"
+                case quotaReason = "quota_reason"
                 case status = "status"
             }
 
@@ -5604,6 +5800,16 @@ public struct RUMViewEvent: RUMDataModel {
             /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
             /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            ///   - quotaReason: The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
             ///   - status: Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -5614,9 +5820,11 @@ public struct RUMViewEvent: RUMDataModel {
             /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
             public init(
                 errorReason: ErrorReason? = nil,
+                quotaReason: QuotaReason? = nil,
                 status: Status? = nil
             ) {
                 self.errorReason = errorReason
+                self.quotaReason = quotaReason
                 self.status = status
             }
 
@@ -5632,6 +5840,26 @@ public struct RUMViewEvent: RUMDataModel {
                 case failedToLazyLoad = "failed-to-lazy-load"
                 case missingDocumentPolicyHeader = "missing-document-policy-header"
                 case unexpectedException = "unexpected-exception"
+            }
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public enum QuotaReason: String, Codable {
+                case quotaOk = "quota_ok"
+                case quotaExceeded = "quota_exceeded"
+                case orgDisabled = "org_disabled"
+                case backendUnavailable = "backend_unavailable"
+                case undefined = "undefined"
+                case timeout = "timeout"
+                case apiError = "api-error"
             }
 
             /// Used to track the status of the RUM Profiler.
@@ -7632,6 +7860,9 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         /// Browser SDK version
         public let browserSdkVersion: String?
 
+        /// Additional information of the reported Cumulative Layout Shift
+        public let cls: CLS?
+
         /// Subset of the SDK configuration options in use during its execution
         public let configuration: Configuration?
 
@@ -7641,6 +7872,15 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
+        /// List of the page states during the view
+        public let pageStates: [PageStates]?
+
+        /// Profiling context
+        public let profiling: Profiling?
+
+        /// Debug metadata for Replay Sessions
+        public let replayStats: ReplayStats?
+
         /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         public let sdkName: String?
 
@@ -7649,9 +7889,13 @@ public struct RUMViewUpdateEvent: RUMDataModel {
 
         public enum CodingKeys: String, CodingKey {
             case browserSdkVersion = "browser_sdk_version"
+            case cls = "cls"
             case configuration = "configuration"
             case documentVersion = "document_version"
             case formatVersion = "format_version"
+            case pageStates = "page_states"
+            case profiling = "profiling"
+            case replayStats = "replay_stats"
             case sdkName = "sdk_name"
             case session = "session"
         }
@@ -7660,22 +7904,54 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         ///
         /// - Parameters:
         ///   - browserSdkVersion: Browser SDK version
+        ///   - cls: Additional information of the reported Cumulative Layout Shift
         ///   - configuration: Subset of the SDK configuration options in use during its execution
         ///   - documentVersion: Version of the update of the view event
+        ///   - pageStates: List of the page states during the view
+        ///   - profiling: Profiling context
+        ///   - replayStats: Debug metadata for Replay Sessions
         ///   - sdkName: SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         ///   - session: Session-related internal properties
         public init(
             browserSdkVersion: String? = nil,
+            cls: CLS? = nil,
             configuration: Configuration? = nil,
             documentVersion: Int64,
+            pageStates: [PageStates]? = nil,
+            profiling: Profiling? = nil,
+            replayStats: ReplayStats? = nil,
             sdkName: String? = nil,
             session: Session? = nil
         ) {
             self.browserSdkVersion = browserSdkVersion
+            self.cls = cls
             self.configuration = configuration
             self.documentVersion = documentVersion
+            self.pageStates = pageStates
+            self.profiling = profiling
+            self.replayStats = replayStats
             self.sdkName = sdkName
             self.session = session
+        }
+
+        /// Additional information of the reported Cumulative Layout Shift
+        public struct CLS: Codable {
+            /// Pixel ratio of the device where the layout shift was reported
+            public let devicePixelRatio: Double?
+
+            public enum CodingKeys: String, CodingKey {
+                case devicePixelRatio = "device_pixel_ratio"
+            }
+
+            /// Additional information of the reported Cumulative Layout Shift
+            ///
+            /// - Parameters:
+            ///   - devicePixelRatio: Pixel ratio of the device where the layout shift was reported
+            public init(
+                devicePixelRatio: Double? = nil
+            ) {
+                self.devicePixelRatio = devicePixelRatio
+            }
         }
 
         /// Subset of the SDK configuration options in use during its execution
@@ -7683,19 +7959,27 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// The id of the remote configuration applied to the SDK, if any
+            public let remoteConfigurationId: String?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
             /// The percentage of sessions tracked
             public let sessionSampleRate: Double
 
+            /// Whether session replay recording configured to start manually
+            public let startSessionReplayRecordingManually: Bool?
+
             /// The percentage of sessions with traced resources
             public let traceSampleRate: Double?
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case remoteConfigurationId = "remote_configuration_id"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
+                case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
                 case traceSampleRate = "trace_sample_rate"
             }
 
@@ -7703,19 +7987,222 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - remoteConfigurationId: The id of the remote configuration applied to the SDK, if any
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
+            ///   - startSessionReplayRecordingManually: Whether session replay recording configured to start manually
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                remoteConfigurationId: String? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
+                startSessionReplayRecordingManually: Bool? = nil,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.remoteConfigurationId = remoteConfigurationId
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
+                self.startSessionReplayRecordingManually = startSessionReplayRecordingManually
                 self.traceSampleRate = traceSampleRate
+            }
+        }
+
+        /// Properties of the page state
+        public struct PageStates: Codable {
+            /// Duration in ns between start of the view and start of the page state
+            public let start: Int64
+
+            /// Page state name
+            public let state: State
+
+            public enum CodingKeys: String, CodingKey {
+                case start = "start"
+                case state = "state"
+            }
+
+            /// Properties of the page state
+            ///
+            /// - Parameters:
+            ///   - start: Duration in ns between start of the view and start of the page state
+            ///   - state: Page state name
+            public init(
+                start: Int64,
+                state: State
+            ) {
+                self.start = start
+                self.state = state
+            }
+
+            /// Page state name
+            public enum State: String, Codable {
+                case active = "active"
+                case passive = "passive"
+                case hidden = "hidden"
+                case frozen = "frozen"
+                case terminated = "terminated"
+            }
+        }
+
+        /// Profiling context
+        public struct Profiling: Codable {
+            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+            ///
+            /// Possible values:
+            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            public let errorReason: ErrorReason?
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public let quotaReason: QuotaReason?
+
+            /// Used to track the status of the RUM Profiler.
+            ///
+            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+            ///
+            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
+            /// - `running`: The Profiler is running.
+            /// - `stopped`: The Profiler is stopped.
+            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
+            public let status: Status?
+
+            public enum CodingKeys: String, CodingKey {
+                case errorReason = "error_reason"
+                case quotaReason = "quota_reason"
+                case status = "status"
+            }
+
+            /// Profiling context
+            ///
+            /// - Parameters:
+            ///   - errorReason: The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+            ///
+            /// Possible values:
+            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            ///   - quotaReason: The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            ///   - status: Used to track the status of the RUM Profiler.
+            ///
+            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+            ///
+            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
+            /// - `running`: The Profiler is running.
+            /// - `stopped`: The Profiler is stopped.
+            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
+            public init(
+                errorReason: ErrorReason? = nil,
+                quotaReason: QuotaReason? = nil,
+                status: Status? = nil
+            ) {
+                self.errorReason = errorReason
+                self.quotaReason = quotaReason
+                self.status = status
+            }
+
+            /// The reason the Profiler encountered an error. This attribute is only present if the status is `error`.
+            ///
+            /// Possible values:
+            /// - `not-supported-by-browser`: The browser does not support the Profiler (i.e., `window.Profiler` is not available).
+            /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
+            /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
+            /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            public enum ErrorReason: String, Codable {
+                case notSupportedByBrowser = "not-supported-by-browser"
+                case failedToLazyLoad = "failed-to-lazy-load"
+                case missingDocumentPolicyHeader = "missing-document-policy-header"
+                case unexpectedException = "unexpected-exception"
+            }
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public enum QuotaReason: String, Codable {
+                case quotaOk = "quota_ok"
+                case quotaExceeded = "quota_exceeded"
+                case orgDisabled = "org_disabled"
+                case backendUnavailable = "backend_unavailable"
+                case undefined = "undefined"
+                case timeout = "timeout"
+                case apiError = "api-error"
+            }
+
+            /// Used to track the status of the RUM Profiler.
+            ///
+            /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
+            ///
+            /// - `starting`: The Profiler is starting (i.e., when the SDK just started). This is the initial status.
+            /// - `running`: The Profiler is running.
+            /// - `stopped`: The Profiler is stopped.
+            /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
+            public enum Status: String, Codable {
+                case starting = "starting"
+                case running = "running"
+                case stopped = "stopped"
+                case error = "error"
+            }
+        }
+
+        /// Debug metadata for Replay Sessions
+        public struct ReplayStats: Codable {
+            /// The number of records produced during this view lifetime
+            public let recordsCount: Int64?
+
+            /// The number of segments sent during this view lifetime
+            public let segmentsCount: Int64?
+
+            /// The total size in bytes of the segments sent during this view lifetime
+            public let segmentsTotalRawSize: Int64?
+
+            public enum CodingKeys: String, CodingKey {
+                case recordsCount = "records_count"
+                case segmentsCount = "segments_count"
+                case segmentsTotalRawSize = "segments_total_raw_size"
+            }
+
+            /// Debug metadata for Replay Sessions
+            ///
+            /// - Parameters:
+            ///   - recordsCount: The number of records produced during this view lifetime
+            ///   - segmentsCount: The number of segments sent during this view lifetime
+            ///   - segmentsTotalRawSize: The total size in bytes of the segments sent during this view lifetime
+            public init(
+                recordsCount: Int64? = nil,
+                segmentsCount: Int64? = nil,
+                segmentsTotalRawSize: Int64? = nil
+            ) {
+                self.recordsCount = recordsCount
+                self.segmentsCount = segmentsCount
+                self.segmentsTotalRawSize = segmentsTotalRawSize
             }
         }
 
@@ -9758,6 +10245,18 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
             public let errorReason: ErrorReason?
 
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public let quotaReason: QuotaReason?
+
             /// Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -9770,6 +10269,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case errorReason = "error_reason"
+                case quotaReason = "quota_reason"
                 case status = "status"
             }
 
@@ -9783,6 +10283,16 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
             /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            ///   - quotaReason: The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
             ///   - status: Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -9793,9 +10303,11 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
             public init(
                 errorReason: ErrorReason? = nil,
+                quotaReason: QuotaReason? = nil,
                 status: Status? = nil
             ) {
                 self.errorReason = errorReason
+                self.quotaReason = quotaReason
                 self.status = status
             }
 
@@ -9811,6 +10323,26 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
                 case failedToLazyLoad = "failed-to-lazy-load"
                 case missingDocumentPolicyHeader = "missing-document-policy-header"
                 case unexpectedException = "unexpected-exception"
+            }
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public enum QuotaReason: String, Codable {
+                case quotaOk = "quota_ok"
+                case quotaExceeded = "quota_exceeded"
+                case orgDisabled = "org_disabled"
+                case backendUnavailable = "backend_unavailable"
+                case undefined = "undefined"
+                case timeout = "timeout"
+                case apiError = "api-error"
             }
 
             /// Used to track the status of the RUM Profiler.
@@ -10502,6 +11034,18 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
             public let errorReason: ErrorReason?
 
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public let quotaReason: QuotaReason?
+
             /// Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -10514,6 +11058,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case errorReason = "error_reason"
+                case quotaReason = "quota_reason"
                 case status = "status"
             }
 
@@ -10527,6 +11072,16 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
             /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            ///   - quotaReason: The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
             ///   - status: Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -10537,9 +11092,11 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
             public init(
                 errorReason: ErrorReason? = nil,
+                quotaReason: QuotaReason? = nil,
                 status: Status? = nil
             ) {
                 self.errorReason = errorReason
+                self.quotaReason = quotaReason
                 self.status = status
             }
 
@@ -10555,6 +11112,26 @@ public struct RUMVitalDurationEvent: RUMDataModel {
                 case failedToLazyLoad = "failed-to-lazy-load"
                 case missingDocumentPolicyHeader = "missing-document-policy-header"
                 case unexpectedException = "unexpected-exception"
+            }
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public enum QuotaReason: String, Codable {
+                case quotaOk = "quota_ok"
+                case quotaExceeded = "quota_exceeded"
+                case orgDisabled = "org_disabled"
+                case backendUnavailable = "backend_unavailable"
+                case undefined = "undefined"
+                case timeout = "timeout"
+                case apiError = "api-error"
             }
 
             /// Used to track the status of the RUM Profiler.
@@ -11206,6 +11783,18 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
             public let errorReason: ErrorReason?
 
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public let quotaReason: QuotaReason?
+
             /// Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -11218,6 +11807,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case errorReason = "error_reason"
+                case quotaReason = "quota_reason"
                 case status = "status"
             }
 
@@ -11231,6 +11821,16 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             /// - `failed-to-lazy-load`: The Profiler script failed to be loaded by the browser (may be a connection issue or the chunk was not found).
             /// - `missing-document-policy-header`: The Profiler failed to start because its missing `Document-Policy: js-profiling` HTTP response header.
             /// - `unexpected-exception`: An exception occurred when starting the Profiler.
+            ///   - quotaReason: The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
             ///   - status: Used to track the status of the RUM Profiler.
             ///
             /// They are defined in order of when they can happen, from the moment the SDK is initialized to the moment the Profiler is actually running.
@@ -11241,9 +11841,11 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             /// - `error`: The Profiler encountered an error. See `error_reason` for more details.
             public init(
                 errorReason: ErrorReason? = nil,
+                quotaReason: QuotaReason? = nil,
                 status: Status? = nil
             ) {
                 self.errorReason = errorReason
+                self.quotaReason = quotaReason
                 self.status = status
             }
 
@@ -11259,6 +11861,26 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
                 case failedToLazyLoad = "failed-to-lazy-load"
                 case missingDocumentPolicyHeader = "missing-document-policy-header"
                 case unexpectedException = "unexpected-exception"
+            }
+
+            /// The reason provided by the profiling quota admission API. This attribute is only present if the status is `stopped` due to quota.
+            ///
+            /// Possible values:
+            /// - `quota_ok`: Quota check passed.
+            /// - `quota_exceeded`: The organization has exceeded its profiling quota.
+            /// - `org_disabled`: The organization has profiling disabled.
+            /// - `backend_unavailable`: The quota admission API is unavailable or not initialized.
+            /// - `undefined`: The quota reason is undefined.
+            /// - `timeout`: The quota check timed out on the client side.
+            /// - `api-error`: An API error occurred on the client side.
+            public enum QuotaReason: String, Codable {
+                case quotaOk = "quota_ok"
+                case quotaExceeded = "quota_exceeded"
+                case orgDisabled = "org_disabled"
+                case backendUnavailable = "backend_unavailable"
+                case undefined = "undefined"
+                case timeout = "timeout"
+                case apiError = "api-error"
             }
 
             /// Used to track the status of the RUM Profiler.
@@ -11768,7 +12390,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
     /// Action properties
     public struct Action: Codable {
         /// UUID of the action
-        public let id: String
+        public let id: RUMActionID
 
         public enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -11779,7 +12401,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
         /// - Parameters:
         ///   - id: UUID of the action
         public init(
-            id: String
+            id: RUMActionID
         ) {
             self.id = id
         }
@@ -11906,6 +12528,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
 
             /// The upload frequency of batches (in milliseconds)
             public let batchUploadFrequency: Int64?
+
+            /// Whether the beta partial view updates feature is enabled
+            public var betaEnableViewUpdates: Bool?
 
             /// Whether the beta encode cookie options is enabled
             public var betaEncodeCookieOptions: Bool?
@@ -12180,6 +12805,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case batchProcessingLevel = "batch_processing_level"
                 case batchSize = "batch_size"
                 case batchUploadFrequency = "batch_upload_frequency"
+                case betaEnableViewUpdates = "beta_enable_view_updates"
                 case betaEncodeCookieOptions = "beta_encode_cookie_options"
                 case compressIntakeRequests = "compress_intake_requests"
                 case dartVersion = "dart_version"
@@ -12281,6 +12907,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - batchProcessingLevel: Maximum number of batches processed sequentially without a delay
             ///   - batchSize: The window duration for batches sent by the SDK (in milliseconds)
             ///   - batchUploadFrequency: The upload frequency of batches (in milliseconds)
+            ///   - betaEnableViewUpdates: Whether the beta partial view updates feature is enabled
             ///   - betaEncodeCookieOptions: Whether the beta encode cookie options is enabled
             ///   - compressIntakeRequests: Whether intake requests are compressed
             ///   - dartVersion: The version of Dart used in a Flutter application
@@ -12378,6 +13005,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 batchProcessingLevel: Int64? = nil,
                 batchSize: Int64? = nil,
                 batchUploadFrequency: Int64? = nil,
+                betaEnableViewUpdates: Bool? = nil,
                 betaEncodeCookieOptions: Bool? = nil,
                 compressIntakeRequests: Bool? = nil,
                 dartVersion: String? = nil,
@@ -12475,6 +13103,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.batchProcessingLevel = batchProcessingLevel
                 self.batchSize = batchSize
                 self.batchUploadFrequency = batchUploadFrequency
+                self.betaEnableViewUpdates = betaEnableViewUpdates
                 self.betaEncodeCookieOptions = betaEncodeCookieOptions
                 self.compressIntakeRequests = compressIntakeRequests
                 self.dartVersion = dartVersion
@@ -12922,7 +13551,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
     /// Action properties
     public struct Action: Codable {
         /// UUID of the action
-        public let id: String
+        public let id: RUMActionID
 
         public enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -12933,7 +13562,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
         /// - Parameters:
         ///   - id: UUID of the action
         public init(
-            id: String
+            id: RUMActionID
         ) {
             self.id = id
         }
@@ -13212,7 +13841,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
     /// Action properties
     public struct Action: Codable {
         /// UUID of the action
-        public let id: String
+        public let id: RUMActionID
 
         public enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -13223,7 +13852,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
         /// - Parameters:
         ///   - id: UUID of the action
         public init(
-            id: String
+            id: RUMActionID
         ) {
             self.id = id
         }
@@ -13538,7 +14167,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
     /// Action properties
     public struct Action: Codable {
         /// UUID of the action
-        public let id: String
+        public let id: RUMActionID
 
         public enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -13549,7 +14178,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
         /// - Parameters:
         ///   - id: UUID of the action
         public init(
-            id: String
+            id: RUMActionID
         ) {
             self.id = id
         }
@@ -14422,4 +15051,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ed69a908b5f05a97b984498526d50c0e97284c06
+// Generated from https://github.com/DataDog/rum-events-format/tree/740734dfd21f4d83fb2dacbc1cde09a16f326175

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -1413,6 +1413,10 @@ public class objc_RUMErrorEventDD: NSObject {
         root.swiftModel.dd.configuration != nil ? objc_RUMErrorEventDDConfiguration(root: root) : nil
     }
 
+    public var debugIds: objc_RUMErrorEventDDDebugIds? {
+        root.swiftModel.dd.debugIds != nil ? objc_RUMErrorEventDDDebugIds(root: root) : nil
+    }
+
     public var formatVersion: NSNumber {
         root.swiftModel.dd.formatVersion as NSNumber
     }
@@ -1473,6 +1477,22 @@ public class objc_RUMErrorEventDDConfiguration: NSObject {
     }
 }
 
+@objc(DDRUMErrorEventDDDebugIds)
+@objcMembers
+@_spi(objc)
+public class objc_RUMErrorEventDDDebugIds: NSObject {
+    internal let root: objc_RUMErrorEvent
+
+    internal init(root: objc_RUMErrorEvent) {
+        self.root = root
+    }
+
+    public var debugIdsInfo: [String: String] {
+        set { root.swiftModel.dd.debugIds!.debugIdsInfo = newValue }
+        get { root.swiftModel.dd.debugIds!.debugIdsInfo }
+    }
+}
+
 @objc(DDRUMErrorEventDDProfiling)
 @objcMembers
 @_spi(objc)
@@ -1485,6 +1505,10 @@ public class objc_RUMErrorEventDDProfiling: NSObject {
 
     public var errorReason: objc_RUMErrorEventDDProfilingErrorReason {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
+    }
+
+    public var quotaReason: objc_RUMErrorEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
     }
 
     public var status: objc_RUMErrorEventDDProfilingStatus {
@@ -1520,6 +1544,45 @@ public enum objc_RUMErrorEventDDProfilingErrorReason: Int {
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+}
+
+@objc(DDRUMErrorEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMErrorEventDDProfilingQuotaReason: Int {
+    internal init(swift: RUMErrorEvent.DD.Profiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: RUMErrorEvent.DD.Profiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 }
 
 @objc(DDRUMErrorEventDDProfilingStatus)
@@ -3283,6 +3346,10 @@ public class objc_RUMLongTaskEventDD: NSObject {
         root.swiftModel.dd.configuration != nil ? objc_RUMLongTaskEventDDConfiguration(root: root) : nil
     }
 
+    public var debugIds: objc_RUMLongTaskEventDDDebugIds? {
+        root.swiftModel.dd.debugIds != nil ? objc_RUMLongTaskEventDDDebugIds(root: root) : nil
+    }
+
     public var discarded: NSNumber? {
         root.swiftModel.dd.discarded as NSNumber?
     }
@@ -3331,6 +3398,22 @@ public class objc_RUMLongTaskEventDDConfiguration: NSObject {
     }
 }
 
+@objc(DDRUMLongTaskEventDDDebugIds)
+@objcMembers
+@_spi(objc)
+public class objc_RUMLongTaskEventDDDebugIds: NSObject {
+    internal let root: objc_RUMLongTaskEvent
+
+    internal init(root: objc_RUMLongTaskEvent) {
+        self.root = root
+    }
+
+    public var debugIdsInfo: [String: String] {
+        set { root.swiftModel.dd.debugIds!.debugIdsInfo = newValue }
+        get { root.swiftModel.dd.debugIds!.debugIdsInfo }
+    }
+}
+
 @objc(DDRUMLongTaskEventDDProfiling)
 @objcMembers
 @_spi(objc)
@@ -3343,6 +3426,10 @@ public class objc_RUMLongTaskEventDDProfiling: NSObject {
 
     public var errorReason: objc_RUMLongTaskEventDDProfilingErrorReason {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
+    }
+
+    public var quotaReason: objc_RUMLongTaskEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
     }
 
     public var status: objc_RUMLongTaskEventDDProfilingStatus {
@@ -3378,6 +3465,45 @@ public enum objc_RUMLongTaskEventDDProfilingErrorReason: Int {
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+}
+
+@objc(DDRUMLongTaskEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMLongTaskEventDDProfilingQuotaReason: Int {
+    internal init(swift: RUMLongTaskEvent.DD.Profiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: RUMLongTaskEvent.DD.Profiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 }
 
 @objc(DDRUMLongTaskEventDDProfilingStatus)
@@ -6259,6 +6385,10 @@ public class objc_RUMViewEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var remoteConfigurationId: String? {
+        root.swiftModel.dd.configuration!.remoteConfigurationId
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -6340,6 +6470,10 @@ public class objc_RUMViewEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMViewEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMViewEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -6373,6 +6507,45 @@ public enum objc_RUMViewEventDDProfilingErrorReason: Int {
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+}
+
+@objc(DDRUMViewEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMViewEventDDProfilingQuotaReason: Int {
+    internal init(swift: RUMViewEvent.DD.Profiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.DD.Profiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 }
 
 @objc(DDRUMViewEventDDProfilingStatus)
@@ -8303,6 +8476,10 @@ public class objc_RUMViewUpdateEventDD: NSObject {
         root.swiftModel.dd.browserSdkVersion
     }
 
+    public var cls: objc_RUMViewUpdateEventDDCLS? {
+        root.swiftModel.dd.cls != nil ? objc_RUMViewUpdateEventDDCLS(root: root) : nil
+    }
+
     public var configuration: objc_RUMViewUpdateEventDDConfiguration? {
         root.swiftModel.dd.configuration != nil ? objc_RUMViewUpdateEventDDConfiguration(root: root) : nil
     }
@@ -8315,12 +8492,39 @@ public class objc_RUMViewUpdateEventDD: NSObject {
         root.swiftModel.dd.formatVersion as NSNumber
     }
 
+    public var pageStates: [objc_RUMViewUpdateEventDDPageStates]? {
+        root.swiftModel.dd.pageStates?.map { objc_RUMViewUpdateEventDDPageStates(swiftModel: $0) }
+    }
+
+    public var profiling: objc_RUMViewUpdateEventDDProfiling? {
+        root.swiftModel.dd.profiling != nil ? objc_RUMViewUpdateEventDDProfiling(root: root) : nil
+    }
+
+    public var replayStats: objc_RUMViewUpdateEventDDReplayStats? {
+        root.swiftModel.dd.replayStats != nil ? objc_RUMViewUpdateEventDDReplayStats(root: root) : nil
+    }
+
     public var sdkName: String? {
         root.swiftModel.dd.sdkName
     }
 
     public var session: objc_RUMViewUpdateEventDDSession? {
         root.swiftModel.dd.session != nil ? objc_RUMViewUpdateEventDDSession(root: root) : nil
+    }
+}
+
+@objc(DDRUMViewUpdateEventDDCLS)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventDDCLS: NSObject {
+    internal let root: objc_RUMViewUpdateEvent
+
+    internal init(root: objc_RUMViewUpdateEvent) {
+        self.root = root
+    }
+
+    public var devicePixelRatio: NSNumber? {
+        root.swiftModel.dd.cls!.devicePixelRatio as NSNumber?
     }
 }
 
@@ -8338,6 +8542,10 @@ public class objc_RUMViewUpdateEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var remoteConfigurationId: String? {
+        root.swiftModel.dd.configuration!.remoteConfigurationId
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -8346,8 +8554,207 @@ public class objc_RUMViewUpdateEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.sessionSampleRate as NSNumber
     }
 
+    public var startSessionReplayRecordingManually: NSNumber? {
+        root.swiftModel.dd.configuration!.startSessionReplayRecordingManually as NSNumber?
+    }
+
     public var traceSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.traceSampleRate as NSNumber?
+    }
+}
+
+@objc(DDRUMViewUpdateEventDDPageStates)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventDDPageStates: NSObject {
+    internal var swiftModel: RUMViewUpdateEvent.DD.PageStates
+    internal var root: objc_RUMViewUpdateEventDDPageStates { self }
+
+    internal init(swiftModel: RUMViewUpdateEvent.DD.PageStates) {
+        self.swiftModel = swiftModel
+    }
+
+    public var start: NSNumber {
+        root.swiftModel.start as NSNumber
+    }
+
+    public var state: objc_RUMViewUpdateEventDDPageStatesState {
+        .init(swift: root.swiftModel.state)
+    }
+}
+
+@objc(DDRUMViewUpdateEventDDPageStatesState)
+@_spi(objc)
+public enum objc_RUMViewUpdateEventDDPageStatesState: Int {
+    internal init(swift: RUMViewUpdateEvent.DD.PageStates.State) {
+        switch swift {
+        case .active: self = .active
+        case .passive: self = .passive
+        case .hidden: self = .hidden
+        case .frozen: self = .frozen
+        case .terminated: self = .terminated
+        }
+    }
+
+    internal var toSwift: RUMViewUpdateEvent.DD.PageStates.State {
+        switch self {
+        case .active: return .active
+        case .passive: return .passive
+        case .hidden: return .hidden
+        case .frozen: return .frozen
+        case .terminated: return .terminated
+        }
+    }
+
+    case active
+    case passive
+    case hidden
+    case frozen
+    case terminated
+}
+
+@objc(DDRUMViewUpdateEventDDProfiling)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventDDProfiling: NSObject {
+    internal let root: objc_RUMViewUpdateEvent
+
+    internal init(root: objc_RUMViewUpdateEvent) {
+        self.root = root
+    }
+
+    public var errorReason: objc_RUMViewUpdateEventDDProfilingErrorReason {
+        .init(swift: root.swiftModel.dd.profiling!.errorReason)
+    }
+
+    public var quotaReason: objc_RUMViewUpdateEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
+    public var status: objc_RUMViewUpdateEventDDProfilingStatus {
+        .init(swift: root.swiftModel.dd.profiling!.status)
+    }
+}
+
+@objc(DDRUMViewUpdateEventDDProfilingErrorReason)
+@_spi(objc)
+public enum objc_RUMViewUpdateEventDDProfilingErrorReason: Int {
+    internal init(swift: RUMViewUpdateEvent.DD.Profiling.ErrorReason?) {
+        switch swift {
+        case nil: self = .none
+        case .notSupportedByBrowser?: self = .notSupportedByBrowser
+        case .failedToLazyLoad?: self = .failedToLazyLoad
+        case .missingDocumentPolicyHeader?: self = .missingDocumentPolicyHeader
+        case .unexpectedException?: self = .unexpectedException
+        }
+    }
+
+    internal var toSwift: RUMViewUpdateEvent.DD.Profiling.ErrorReason? {
+        switch self {
+        case .none: return nil
+        case .notSupportedByBrowser: return .notSupportedByBrowser
+        case .failedToLazyLoad: return .failedToLazyLoad
+        case .missingDocumentPolicyHeader: return .missingDocumentPolicyHeader
+        case .unexpectedException: return .unexpectedException
+        }
+    }
+
+    case none
+    case notSupportedByBrowser
+    case failedToLazyLoad
+    case missingDocumentPolicyHeader
+    case unexpectedException
+}
+
+@objc(DDRUMViewUpdateEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMViewUpdateEventDDProfilingQuotaReason: Int {
+    internal init(swift: RUMViewUpdateEvent.DD.Profiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: RUMViewUpdateEvent.DD.Profiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+}
+
+@objc(DDRUMViewUpdateEventDDProfilingStatus)
+@_spi(objc)
+public enum objc_RUMViewUpdateEventDDProfilingStatus: Int {
+    internal init(swift: RUMViewUpdateEvent.DD.Profiling.Status?) {
+        switch swift {
+        case nil: self = .none
+        case .starting?: self = .starting
+        case .running?: self = .running
+        case .stopped?: self = .stopped
+        case .error?: self = .error
+        }
+    }
+
+    internal var toSwift: RUMViewUpdateEvent.DD.Profiling.Status? {
+        switch self {
+        case .none: return nil
+        case .starting: return .starting
+        case .running: return .running
+        case .stopped: return .stopped
+        case .error: return .error
+        }
+    }
+
+    case none
+    case starting
+    case running
+    case stopped
+    case error
+}
+
+@objc(DDRUMViewUpdateEventDDReplayStats)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventDDReplayStats: NSObject {
+    internal let root: objc_RUMViewUpdateEvent
+
+    internal init(root: objc_RUMViewUpdateEvent) {
+        self.root = root
+    }
+
+    public var recordsCount: NSNumber? {
+        root.swiftModel.dd.replayStats!.recordsCount as NSNumber?
+    }
+
+    public var segmentsCount: NSNumber? {
+        root.swiftModel.dd.replayStats!.segmentsCount as NSNumber?
+    }
+
+    public var segmentsTotalRawSize: NSNumber? {
+        root.swiftModel.dd.replayStats!.segmentsTotalRawSize as NSNumber?
     }
 }
 
@@ -10284,6 +10691,10 @@ public class objc_RUMVitalAppLaunchEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMVitalAppLaunchEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMVitalAppLaunchEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -10317,6 +10728,45 @@ public enum objc_RUMVitalAppLaunchEventDDProfilingErrorReason: Int {
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+}
+
+@objc(DDRUMVitalAppLaunchEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMVitalAppLaunchEventDDProfilingQuotaReason: Int {
+    internal init(swift: RUMVitalAppLaunchEvent.DD.Profiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: RUMVitalAppLaunchEvent.DD.Profiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 }
 
 @objc(DDRUMVitalAppLaunchEventDDProfilingStatus)
@@ -11397,6 +11847,10 @@ public class objc_RUMVitalDurationEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMVitalDurationEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMVitalDurationEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -11430,6 +11884,45 @@ public enum objc_RUMVitalDurationEventDDProfilingErrorReason: Int {
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+}
+
+@objc(DDRUMVitalDurationEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMVitalDurationEventDDProfilingQuotaReason: Int {
+    internal init(swift: RUMVitalDurationEvent.DD.Profiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: RUMVitalDurationEvent.DD.Profiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 }
 
 @objc(DDRUMVitalDurationEventDDProfilingStatus)
@@ -12449,6 +12942,10 @@ public class objc_RUMVitalOperationStepEventDDProfiling: NSObject {
         .init(swift: root.swiftModel.dd.profiling!.errorReason)
     }
 
+    public var quotaReason: objc_RUMVitalOperationStepEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
     public var status: objc_RUMVitalOperationStepEventDDProfilingStatus {
         .init(swift: root.swiftModel.dd.profiling!.status)
     }
@@ -12482,6 +12979,45 @@ public enum objc_RUMVitalOperationStepEventDDProfilingErrorReason: Int {
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+}
+
+@objc(DDRUMVitalOperationStepEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMVitalOperationStepEventDDProfilingQuotaReason: Int {
+    internal init(swift: RUMVitalOperationStepEvent.DD.Profiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: RUMVitalOperationStepEvent.DD.Profiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 }
 
 @objc(DDRUMVitalOperationStepEventDDProfilingStatus)
@@ -13464,8 +14000,33 @@ public class objc_TelemetryConfigurationEventAction: NSObject {
         self.root = root
     }
 
-    public var id: String {
-        root.swiftModel.action!.id
+    public var id: objc_TelemetryConfigurationEventActionRUMActionID {
+        objc_TelemetryConfigurationEventActionRUMActionID(root: root)
+    }
+}
+
+@objc(DDTelemetryConfigurationEventActionRUMActionID)
+@objcMembers
+@_spi(objc)
+public class objc_TelemetryConfigurationEventActionRUMActionID: NSObject {
+    internal let root: objc_TelemetryConfigurationEvent
+
+    internal init(root: objc_TelemetryConfigurationEvent) {
+        self.root = root
+    }
+
+    public var string: String? {
+        guard case .string(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
+    }
+
+    public var stringsArray: [String]? {
+        guard case .stringsArray(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
     }
 }
 
@@ -13616,6 +14177,11 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
 
     public var batchUploadFrequency: NSNumber? {
         root.swiftModel.telemetry.configuration.batchUploadFrequency as NSNumber?
+    }
+
+    public var betaEnableViewUpdates: NSNumber? {
+        set { root.swiftModel.telemetry.configuration.betaEnableViewUpdates = newValue?.boolValue }
+        get { root.swiftModel.telemetry.configuration.betaEnableViewUpdates as NSNumber? }
     }
 
     public var betaEncodeCookieOptions: NSNumber? {
@@ -14448,8 +15014,33 @@ public class objc_TelemetryDebugEventAction: NSObject {
         self.root = root
     }
 
-    public var id: String {
-        root.swiftModel.action!.id
+    public var id: objc_TelemetryDebugEventActionRUMActionID {
+        objc_TelemetryDebugEventActionRUMActionID(root: root)
+    }
+}
+
+@objc(DDTelemetryDebugEventActionRUMActionID)
+@objcMembers
+@_spi(objc)
+public class objc_TelemetryDebugEventActionRUMActionID: NSObject {
+    internal let root: objc_TelemetryDebugEvent
+
+    internal init(root: objc_TelemetryDebugEvent) {
+        self.root = root
+    }
+
+    public var string: String? {
+        guard case .string(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
+    }
+
+    public var stringsArray: [String]? {
+        guard case .stringsArray(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
     }
 }
 
@@ -14726,8 +15317,33 @@ public class objc_TelemetryErrorEventAction: NSObject {
         self.root = root
     }
 
-    public var id: String {
-        root.swiftModel.action!.id
+    public var id: objc_TelemetryErrorEventActionRUMActionID {
+        objc_TelemetryErrorEventActionRUMActionID(root: root)
+    }
+}
+
+@objc(DDTelemetryErrorEventActionRUMActionID)
+@objcMembers
+@_spi(objc)
+public class objc_TelemetryErrorEventActionRUMActionID: NSObject {
+    internal let root: objc_TelemetryErrorEvent
+
+    internal init(root: objc_TelemetryErrorEvent) {
+        self.root = root
+    }
+
+    public var string: String? {
+        guard case .string(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
+    }
+
+    public var stringsArray: [String]? {
+        guard case .stringsArray(let value) = root.swiftModel.action!.id else {
+            return nil
+        }
+        return value
     }
 }
 
@@ -14940,4 +15556,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/ed69a908b5f05a97b984498526d50c0e97284c06
+// Generated from https://github.com/DataDog/rum-events-format/tree/740734dfd21f4d83fb2dacbc1cde09a16f326175

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -321,6 +321,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 browserSdkVersion: nil,
                 cls: nil,
                 configuration: .init(
+                    remoteConfigurationId: context.remoteConfigurationId,
                     sessionReplaySampleRate: nil,
                     sessionSampleRate: Double(self.sessionSampler.samplingRate),
                     startSessionReplayRecordingManually: nil

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -123,7 +123,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryDebugEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(self.sampler.samplingRate),
@@ -169,7 +169,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryErrorEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(self.sampler.samplingRate),
@@ -200,7 +200,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryUsageEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(usage.sampleRate.composed(with: self.sampler.samplingRate)),
@@ -240,7 +240,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryConfigurationEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(self.configurationExtraSampler.samplingRate.composed(with: self.sampler.samplingRate)),
@@ -284,7 +284,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
             let event = TelemetryDebugEvent(
                 dd: .init(),
-                action: rum?.userActionID.map { .init(id: $0) },
+                action: rum?.userActionID.map { .init(id: .string(value: $0)) },
                 application: rum.map { .init(id: $0.applicationID) },
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(effectiveSampleRate),

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -571,6 +571,7 @@ extension RUMViewScope {
                 browserSdkVersion: nil,
                 cls: nil,
                 configuration: .init(
+                    remoteConfigurationId: context.remoteConfigurationId,
                     sessionReplaySampleRate: sessionReplayConfig.map { Double($0.sampleRate) },
                     sessionSampleRate: Double(dependencies.samplingRate),
                     startSessionReplayRecordingManually: sessionReplayConfig?.startRecordingManually,

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -102,7 +102,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.application?.id, rumContext.applicationID)
         XCTAssertEqual(event?.session?.id, rumContext.sessionID)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
-        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertEqual(event?.telemetry.telemetryInfo["foo"] as? Int, 42)
         XCTAssertEqual(event?.effectiveSampleRate, 100)
     }
@@ -122,7 +122,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.application?.id, rumContext.applicationID)
         XCTAssertEqual(event?.session?.id, rumContext.sessionID)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
-        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertEqual(event?.effectiveSampleRate, 100)
     }
 
@@ -508,7 +508,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.application?.id, rumContext.applicationID)
         XCTAssertEqual(event?.session?.id, rumContext.sessionID)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
-        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertEqual(event?.effectiveSampleRate, 100)
         let device = try XCTUnwrap(event?.telemetry.device)
         XCTAssertEqual(device.model, deviceMock.model)
@@ -537,7 +537,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.application?.id, rumContext.applicationID)
         XCTAssertEqual(event?.session?.id, sessionIDOverride)
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
-        XCTAssertEqual(event?.action?.id, rumContext.userActionID)
+        XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertNil(event?.telemetry.telemetryInfo[SDKMetricFields.sessionIDOverrideKey], "It should delete `sessionIDOverrideKey` from metric attributes")
     }
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -116,7 +116,16 @@ class RUMViewScopeTests: XCTestCase {
         let hasReplay: Bool = .mockRandom()
         let sessionReplaySampleRate: SampleRate = .mockRandom(min: 0, max: 100)
         let startRecordingManually: Bool = .random()
-        var context = self.context
+        let remoteConfigurationId: String = .mockRandom()
+        var context = DatadogContext.mockWith(
+            service: self.context.service,
+            version: self.context.version,
+            buildNumber: self.context.buildNumber,
+            buildId: self.context.buildId,
+            device: self.context.device,
+            os: self.context.os,
+            remoteConfigurationId: remoteConfigurationId
+        )
         context.set(additionalContext: SessionReplayCoreContext.HasReplay(value: hasReplay))
         context.set(additionalContext: SessionReplayCoreContext.RecordsCount(value: [scope.viewUUID.toRUMDataFormat: 1]))
         context.set(additionalContext: SessionReplayCoreContext.Configuration(
@@ -151,6 +160,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.dd.configuration?.traceSampleRate, Double(traceSampleRate))
         XCTAssertEqual(event.dd.configuration?.sessionReplaySampleRate, Double(sessionReplaySampleRate))
         XCTAssertEqual(event.dd.configuration?.startSessionReplayRecordingManually, startRecordingManually)
+        XCTAssertEqual(event.dd.configuration?.remoteConfigurationId, remoteConfigurationId)
         XCTAssertEqual(event.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
         XCTAssertEqual(event.source, .ios)
         XCTAssertEqual(event.service, "test-service")

--- a/TestUtilities/Sources/Mocks/CrashReporting/CrashReportingFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/CrashReporting/CrashReportingFeatureMocks.swift
@@ -146,6 +146,7 @@ extension CrashContext {
         lastRUMSessionState: RUMSessionState? = nil,
         lastIsAppInForeground: Bool = .mockAny(),
         appLaunchDate: Date? = .mockRandomInThePast(),
+        remoteConfigurationId: String? = nil,
         lastRUMAttributes: RUMEventAttributes? = nil,
         lastLogAttributes: LogEventAttributes? = nil
     ) -> Self {
@@ -169,7 +170,8 @@ extension CrashContext {
             lastRUMViewEvent: lastRUMViewEvent,
             lastRUMSessionState: lastRUMSessionState,
             lastRUMAttributes: lastRUMAttributes,
-            lastLogAttributes: lastLogAttributes
+            lastLogAttributes: lastLogAttributes,
+            remoteConfigurationId: remoteConfigurationId
         )
     }
 
@@ -194,7 +196,8 @@ extension CrashContext {
             lastRUMViewEvent: .mockRandom(),
             lastRUMSessionState: .mockRandom(),
             lastRUMAttributes: .mockRandom(),
-            lastLogAttributes: .mockRandom()
+            lastLogAttributes: .mockRandom(),
+            remoteConfigurationId: .mockRandom()
         )
     }
 

--- a/TestUtilities/Sources/Mocks/DatadogInternal/DatadogContextMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/DatadogContextMock.swift
@@ -41,6 +41,7 @@ extension DatadogContext: AnyMockable, RandomMockable {
         batteryStatus: BatteryStatus? = .mockAny(),
         brightnessLevel: BrightnessLevel? = .mockAny(),
         isLowPowerModeEnabled: Bool = false,
+        remoteConfigurationId: String? = nil,
         additionalContext: [AdditionalContext] = []
     ) -> DatadogContext {
         var context = DatadogContext(
@@ -73,7 +74,8 @@ extension DatadogContext: AnyMockable, RandomMockable {
             carrierInfo: carrierInfo,
             batteryStatus: batteryStatus,
             brightnessLevel: brightnessLevel,
-            isLowPowerModeEnabled: isLowPowerModeEnabled
+            isLowPowerModeEnabled: isLowPowerModeEnabled,
+            remoteConfigurationId: remoteConfigurationId
         )
 
         additionalContext.forEach { context.set(additionalContext: $0) }
@@ -109,7 +111,8 @@ extension DatadogContext: AnyMockable, RandomMockable {
             networkConnectionInfo: .mockRandom(),
             carrierInfo: .mockRandom(),
             batteryStatus: nil,
-            isLowPowerModeEnabled: .mockRandom()
+            isLowPowerModeEnabled: .mockRandom(),
+            remoteConfigurationId: .mockRandom()
         )
     }
 }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -652,6 +652,7 @@ public class objc_RUMErrorEvent: NSObject
 public class objc_RUMErrorEventDD: NSObject
     public var browserSdkVersion: String?
     public var configuration: objc_RUMErrorEventDDConfiguration?
+    public var debugIds: objc_RUMErrorEventDDDebugIds?
     public var formatVersion: NSNumber
     public var parentSpanId: String?
     public var profiling: objc_RUMErrorEventDDProfiling?
@@ -665,8 +666,11 @@ public class objc_RUMErrorEventDDConfiguration: NSObject
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
+public class objc_RUMErrorEventDDDebugIds: NSObject
+    public var debugIdsInfo: [String: String]
 public class objc_RUMErrorEventDDProfiling: NSObject
     public var errorReason: objc_RUMErrorEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMErrorEventDDProfilingQuotaReason
     public var status: objc_RUMErrorEventDDProfilingStatus
 public enum objc_RUMErrorEventDDProfilingErrorReason: Int
     case none
@@ -674,6 +678,15 @@ public enum objc_RUMErrorEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMErrorEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMErrorEventDDProfilingStatus: Int
     case none
     case starting
@@ -1025,6 +1038,7 @@ public class objc_RUMLongTaskEvent: NSObject
 public class objc_RUMLongTaskEventDD: NSObject
     public var browserSdkVersion: String?
     public var configuration: objc_RUMLongTaskEventDDConfiguration?
+    public var debugIds: objc_RUMLongTaskEventDDDebugIds?
     public var discarded: NSNumber?
     public var formatVersion: NSNumber
     public var profiling: objc_RUMLongTaskEventDDProfiling?
@@ -1035,8 +1049,11 @@ public class objc_RUMLongTaskEventDDConfiguration: NSObject
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
+public class objc_RUMLongTaskEventDDDebugIds: NSObject
+    public var debugIdsInfo: [String: String]
 public class objc_RUMLongTaskEventDDProfiling: NSObject
     public var errorReason: objc_RUMLongTaskEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMLongTaskEventDDProfilingQuotaReason
     public var status: objc_RUMLongTaskEventDDProfilingStatus
 public enum objc_RUMLongTaskEventDDProfilingErrorReason: Int
     case none
@@ -1044,6 +1061,15 @@ public enum objc_RUMLongTaskEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMLongTaskEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMLongTaskEventDDProfilingStatus: Int
     case none
     case starting
@@ -1611,6 +1637,7 @@ public class objc_RUMViewEventDDCLS: NSObject
     public var devicePixelRatio: NSNumber?
 public class objc_RUMViewEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var remoteConfigurationId: String?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var startSessionReplayRecordingManually: NSNumber?
@@ -1626,6 +1653,7 @@ public enum objc_RUMViewEventDDPageStatesState: Int
     case terminated
 public class objc_RUMViewEventDDProfiling: NSObject
     public var errorReason: objc_RUMViewEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMViewEventDDProfilingQuotaReason
     public var status: objc_RUMViewEventDDProfilingStatus
 public enum objc_RUMViewEventDDProfilingErrorReason: Int
     case none
@@ -1633,6 +1661,15 @@ public enum objc_RUMViewEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMViewEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMViewEventDDProfilingStatus: Int
     case none
     case starting
@@ -2014,16 +2051,62 @@ public class objc_RUMViewUpdateEvent: NSObject
     public var view: objc_RUMViewUpdateEventView
 public class objc_RUMViewUpdateEventDD: NSObject
     public var browserSdkVersion: String?
+    public var cls: objc_RUMViewUpdateEventDDCLS?
     public var configuration: objc_RUMViewUpdateEventDDConfiguration?
     public var documentVersion: NSNumber
     public var formatVersion: NSNumber
+    public var pageStates: [objc_RUMViewUpdateEventDDPageStates]?
+    public var profiling: objc_RUMViewUpdateEventDDProfiling?
+    public var replayStats: objc_RUMViewUpdateEventDDReplayStats?
     public var sdkName: String?
     public var session: objc_RUMViewUpdateEventDDSession?
+public class objc_RUMViewUpdateEventDDCLS: NSObject
+    public var devicePixelRatio: NSNumber?
 public class objc_RUMViewUpdateEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var remoteConfigurationId: String?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
+    public var startSessionReplayRecordingManually: NSNumber?
     public var traceSampleRate: NSNumber?
+public class objc_RUMViewUpdateEventDDPageStates: NSObject
+    public var start: NSNumber
+    public var state: objc_RUMViewUpdateEventDDPageStatesState
+public enum objc_RUMViewUpdateEventDDPageStatesState: Int
+    case active
+    case passive
+    case hidden
+    case frozen
+    case terminated
+public class objc_RUMViewUpdateEventDDProfiling: NSObject
+    public var errorReason: objc_RUMViewUpdateEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMViewUpdateEventDDProfilingQuotaReason
+    public var status: objc_RUMViewUpdateEventDDProfilingStatus
+public enum objc_RUMViewUpdateEventDDProfilingErrorReason: Int
+    case none
+    case notSupportedByBrowser
+    case failedToLazyLoad
+    case missingDocumentPolicyHeader
+    case unexpectedException
+public enum objc_RUMViewUpdateEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+public enum objc_RUMViewUpdateEventDDProfilingStatus: Int
+    case none
+    case starting
+    case running
+    case stopped
+    case error
+public class objc_RUMViewUpdateEventDDReplayStats: NSObject
+    public var recordsCount: NSNumber?
+    public var segmentsCount: NSNumber?
+    public var segmentsTotalRawSize: NSNumber?
 public class objc_RUMViewUpdateEventDDSession: NSObject
     public var plan: objc_RUMViewUpdateEventDDSessionPlan
     public var sessionPrecondition: objc_RUMViewUpdateEventDDSessionRUMSessionPrecondition
@@ -2406,6 +2489,7 @@ public class objc_RUMVitalAppLaunchEventDDConfiguration: NSObject
     public var traceSampleRate: NSNumber?
 public class objc_RUMVitalAppLaunchEventDDProfiling: NSObject
     public var errorReason: objc_RUMVitalAppLaunchEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMVitalAppLaunchEventDDProfilingQuotaReason
     public var status: objc_RUMVitalAppLaunchEventDDProfilingStatus
 public enum objc_RUMVitalAppLaunchEventDDProfilingErrorReason: Int
     case none
@@ -2413,6 +2497,15 @@ public enum objc_RUMVitalAppLaunchEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMVitalAppLaunchEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMVitalAppLaunchEventDDProfilingStatus: Int
     case none
     case starting
@@ -2626,6 +2719,7 @@ public class objc_RUMVitalDurationEventDDConfiguration: NSObject
     public var traceSampleRate: NSNumber?
 public class objc_RUMVitalDurationEventDDProfiling: NSObject
     public var errorReason: objc_RUMVitalDurationEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMVitalDurationEventDDProfilingQuotaReason
     public var status: objc_RUMVitalDurationEventDDProfilingStatus
 public enum objc_RUMVitalDurationEventDDProfilingErrorReason: Int
     case none
@@ -2633,6 +2727,15 @@ public enum objc_RUMVitalDurationEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMVitalDurationEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMVitalDurationEventDDProfilingStatus: Int
     case none
     case starting
@@ -2835,6 +2938,7 @@ public class objc_RUMVitalOperationStepEventDDConfiguration: NSObject
     public var traceSampleRate: NSNumber?
 public class objc_RUMVitalOperationStepEventDDProfiling: NSObject
     public var errorReason: objc_RUMVitalOperationStepEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMVitalOperationStepEventDDProfilingQuotaReason
     public var status: objc_RUMVitalOperationStepEventDDProfilingStatus
 public enum objc_RUMVitalOperationStepEventDDProfilingErrorReason: Int
     case none
@@ -2842,6 +2946,15 @@ public enum objc_RUMVitalOperationStepEventDDProfilingErrorReason: Int
     case failedToLazyLoad
     case missingDocumentPolicyHeader
     case unexpectedException
+public enum objc_RUMVitalOperationStepEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
 public enum objc_RUMVitalOperationStepEventDDProfilingStatus: Int
     case none
     case starting
@@ -3033,7 +3146,10 @@ public class objc_TelemetryConfigurationEvent: NSObject
 public class objc_TelemetryConfigurationEventDD: NSObject
     public var formatVersion: NSNumber
 public class objc_TelemetryConfigurationEventAction: NSObject
-    public var id: String
+    public var id: objc_TelemetryConfigurationEventActionRUMActionID
+public class objc_TelemetryConfigurationEventActionRUMActionID: NSObject
+    public var string: String?
+    public var stringsArray: [String]?
 public class objc_TelemetryConfigurationEventApplication: NSObject
     public var id: String
 public class objc_TelemetryConfigurationEventSession: NSObject
@@ -3064,6 +3180,7 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject
     public var batchProcessingLevel: NSNumber?
     public var batchSize: NSNumber?
     public var batchUploadFrequency: NSNumber?
+    public var betaEnableViewUpdates: NSNumber?
     public var betaEncodeCookieOptions: NSNumber?
     public var compressIntakeRequests: NSNumber?
     public var dartVersion: String?
@@ -3229,7 +3346,10 @@ public class objc_TelemetryDebugEvent: NSObject
 public class objc_TelemetryDebugEventDD: NSObject
     public var formatVersion: NSNumber
 public class objc_TelemetryDebugEventAction: NSObject
-    public var id: String
+    public var id: objc_TelemetryDebugEventActionRUMActionID
+public class objc_TelemetryDebugEventActionRUMActionID: NSObject
+    public var string: String?
+    public var stringsArray: [String]?
 public class objc_TelemetryDebugEventApplication: NSObject
     public var id: String
 public class objc_TelemetryDebugEventSession: NSObject
@@ -3284,7 +3404,10 @@ public class objc_TelemetryErrorEvent: NSObject
 public class objc_TelemetryErrorEventDD: NSObject
     public var formatVersion: NSNumber
 public class objc_TelemetryErrorEventAction: NSObject
-    public var id: String
+    public var id: objc_TelemetryErrorEventActionRUMActionID
+public class objc_TelemetryErrorEventActionRUMActionID: NSObject
+    public var string: String?
+    public var stringsArray: [String]?
 public class objc_TelemetryErrorEventApplication: NSObject
     public var id: String
 public class objc_TelemetryErrorEventSession: NSObject


### PR DESCRIPTION
### What and why?

Adds `remoteConfigurationId` to `DatadogContext` and propagates it into RUM view events (`dd.configuration.remote_configuration_id`), so the remote configuration applied at SDK initialization is reflected in the telemetry.

### How?

- Added `remoteConfigurationId: String?` as an immutable property on `DatadogContext`, threaded through the `DatadogContextProvider` convenience init and populated from `Datadog.Configuration.remoteConfigurationID`.
- Injected `context.remoteConfigurationId` into `RUMViewEvent.DD.Configuration` in `RUMViewScope`.
- Updated `DatadogContextMock` and `RUMViewScopeTests` with assertions covering the new field.
- Fixed `TelemetryReceiver` and its tests to use `RUMActionID.string(value:)` following the regenerated schema.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs