### PR TITLE
RUM-16423: Add `PROFILING_FEATURE.md`

### DIFF
--- a/.claude/skills/update-feature-docs/SKILL.md
+++ b/.claude/skills/update-feature-docs/SKILL.md
@@ -26,9 +26,9 @@ To add a new feature doc to the system, create a `*_FEATURE.md` file following t
 1. **Discover feature docs** — find all `*_FEATURE.md` files in the repo (excluding `build/` and `artifacts/`).
 
 2. **For each doc, read its frontmatter** — extract `verified_against_commit` and `tracked_files`.
-   - If `tracked_files` is missing, derive the list from the doc's "Key Files" section (every source file path it references). Treat the doc as fully out of date and proceed to step 4 — the diff in step 3 cannot be computed.
+   - If `tracked_files` is missing, derive the list from public API and configuration source files in the doc's "Key Files" section. Internal implementation files in "Key Files" are navigation references, not frontmatter drift triggers. Treat the doc as fully out of date and proceed to step 4 — the diff in step 3 cannot be computed.
    - If `verified_against_commit` is missing, treat the doc as fully out of date and proceed to step 4 — the diff in step 3 cannot be computed.
-   - **Audit `tracked_files` coverage** against the doc's "Key Files" section. Every public-API source file path referenced in "Key Files" must also appear in `tracked_files`. This audit must happen *here*, before step 3 — otherwise drift in untracked files is silently ignored. If any are missing, add them to `tracked_files` and treat the doc as fully out of date so the newly-tracked files are inspected in step 4.
+   - **Audit `tracked_files` coverage** against the doc's "Key Files" section. Every public API or configuration source file path referenced in "Key Files" must also appear in `tracked_files`. Cross-feature APIs belong to the feature doc that owns them. Do not add internal implementation files solely because they are listed as navigation references. This audit must happen *here*, before step 3 — otherwise drift in untracked public files is silently ignored. If any public API or configuration files are missing, add them to `tracked_files` and treat the doc as fully out of date so the newly-tracked files are inspected in step 4.
 
 3. **Get the diff since that commit** — first ensure the tracked source files have no uncommitted changes:
    ```

--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -8,6 +8,7 @@ on:
             - 'DatadogRUM/RUM_FEATURE.md'
             - 'DatadogSessionReplay/SESSION_REPLAY_FEATURE.md'
             - 'DatadogTrace/TRACE_FEATURE.md'
+            - 'DatadogProfiling/PROFILING_FEATURE.md'
 permissions:
     contents: read
 jobs:
@@ -31,6 +32,9 @@ jobs:
 
                   cp DatadogTrace/TRACE_FEATURE.md publish_folder/dd-sdk-ios-trace-feature.md
                   echo "Publishing TRACE_FEATURE.md"
+
+                  cp DatadogProfiling/PROFILING_FEATURE.md publish_folder/dd-sdk-ios-profiling-feature.md
+                  echo "Publishing PROFILING_FEATURE.md"
 
             - name: Publish Markdown to Confluence
               uses: markdown-confluence/publish-action@7767a0a7f438bb1497ee7ffd7d3d685b81dfe700 # v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ docs/
 Feature-specific docs (in each module directory):
 ├── DatadogRUM/RUM_FEATURE.md
 ├── DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
-└── DatadogTrace/TRACE_FEATURE.md
+├── DatadogTrace/TRACE_FEATURE.md
+└── DatadogProfiling/PROFILING_FEATURE.md
 ```
 
 ## Where to Look First
@@ -52,6 +53,7 @@ Feature-specific docs (in each module directory):
 | Work on RUM specifically | `DatadogRUM/RUM_FEATURE.md` |
 | Work on Session Replay specifically | `DatadogSessionReplay/SESSION_REPLAY_FEATURE.md` |
 | Work on Trace (APM) specifically | `DatadogTrace/TRACE_FEATURE.md` |
+| Work on Profiling specifically | `DatadogProfiling/PROFILING_FEATURE.md` |
 | Update a `*_FEATURE.md` file | `docs/LLM_FEATURE_DOCS_GUIDELINES.md` |
 
 ## Critical Rules (always apply)

--- a/DatadogProfiling/PROFILING_FEATURE.md
+++ b/DatadogProfiling/PROFILING_FEATURE.md
@@ -1,0 +1,250 @@
+---
+last_updated: 2026-07-06
+sdk_version: 3.12.0
+verified_against_commit: 64e66698c
+tracked_files:
+  - DatadogProfiling/Sources/Profiling.swift
+  - DatadogProfiling/Sources/ProfilingConfiguration.swift
+  - DatadogInternal/Sources/Models/Profiling/ProfilingOptions.swift
+  - DatadogRUM/Sources/RUMMonitorProtocol.swift
+  - DatadogRUM/Sources/RUM+objc.swift
+  - DatadogProfiling/Sources/ProfilerFeature.swift
+  - DatadogProfiling/Sources/AppLaunchProfiler.swift
+  - DatadogProfiling/Sources/DatadogProfiler.swift
+  - DatadogProfiling/Sources/ProfilingSamplerProvider.swift
+  - DatadogProfiling/Sources/ProfilingQuotaChecker.swift
+  - DatadogProfiling/Sources/ProfilingHandler.swift
+  - DatadogProfiling/Sources/RequestBuilder.swift
+  - DatadogProfiling/Sources/ProfileEvent.swift
+  - DatadogProfiling/Sources/Models/ProfileAttachments.swift
+  - DatadogProfiling/Sources/Models/ProfilingConditions.swift
+  - DatadogProfiling/Mach/dd_profiler.cpp
+  - DatadogProfiling/Mach/mach_sampling_profiler.cpp
+  - DatadogProfiling/Mach/aggregation_worker.cpp
+  - DatadogProfiling/Mach/profile.cpp
+  - DatadogProfiling/Mach/dd_pprof.cpp
+  - DatadogProfiling/Mach/profile_pprof_packer.cpp
+  - DatadogProfiling/Mach/include/dd_profiler.h
+  - DatadogProfiling/Mach/include/dd_pprof.h
+---
+
+# Profiling Feature
+
+## Overview
+
+Profiling captures pprof wall-time samples from Apple application processes and correlates them with RUM context. It supports three profiling paths:
+
+- **Application launch profiling**: captures process startup and writes the launch profile when RUM emits the TTID app-launch vital.
+- **Continuous Profiling**: periodically records profiles for sampled-in RUM sessions and links long tasks and app hangs.
+- **Custom Profiling**: starts around sampled RUM operations created with `ProfilingOptions`.
+
+Profiling requires `Datadog.initialize()` before `Profiling.enable()`. RUM is not a compile-time module dependency, but the feature depends on RUM context and RUM payload messages for session-linked sampling, quota checks, and profile correlation.
+
+**Platform**: iOS, tvOS, visionOS. The Swift sources and Mach profiler are compiled out on watchOS with `#if !os(watchOS)`.
+
+**API status**: `Profiling.enable(with:in:)` is experimental. RUM operation APIs used for custom profiling are in preview.
+
+## Quick Start Example
+
+```swift
+import Foundation
+import DatadogCore
+import DatadogRUM
+import DatadogProfiling
+
+// 1. Initialize Core SDK first
+Datadog.initialize(
+    with: Datadog.Configuration(
+        clientToken: "<client_token>",
+        env: "<environment>"
+    ),
+    trackingConsent: .granted
+)
+
+// 2. Enable RUM so Profiling can receive session context and operation/vital messages
+RUM.enable(
+    with: RUM.Configuration(
+        applicationID: "<rum_application_id>",
+        uiKitViewsPredicate: DefaultUIKitRUMViewsPredicate(),
+        uiKitActionsPredicate: DefaultUIKitRUMActionsPredicate(),
+
+        // Continuous Profiling can attach app hangs and long tasks to profiles
+        // when these RUM performance features are enabled.
+        // longTaskThreshold default: 0.1 seconds
+        longTaskThreshold: 0.1,
+        // appHangThreshold default: nil (disabled)
+        appHangThreshold: 2.0
+    )
+)
+
+// 3. Enable Profiling
+Profiling.enable(
+    with: Profiling.Configuration(
+        // Custom intake endpoint for profile uploads.
+        // Default: nil (uses Datadog intake at /api/v2/profile)
+        customEndpoint: nil,
+
+        // Application launch profiling sample rate.
+        // 100 = all launches profiled, 0 = none profiled.
+        // Applies to the next process launch.
+        // Default: 5.0
+        applicationLaunchSampleRate: 5.0,
+
+        // Continuous Profiling sample rate, composed with the RUM session sampler.
+        // 100 = all sampled-in RUM sessions eligible, 0 = continuous profiling disabled.
+        // Default: 5.0
+        continuousSampleRate: 5.0
+    )
+)
+
+let monitor = RUMMonitor.shared()
+
+// 4. (Optional) Report TTFD so continuous profiles can correlate with full-display timing
+monitor.reportAppFullyDisplayed()
+
+// 5. (Optional) Custom Profiling around a RUM operation
+monitor.startOperation(
+    name: "checkout_flow",
+    operationKey: "cart-123",
+    attributes: ["screen": "checkout"],
+    options: ProfilingOptions(sampleRate: 100.0)
+)
+
+// Work being profiled...
+
+monitor.succeedOperation(
+    name: "checkout_flow",
+    operationKey: "cart-123",
+    attributes: ["result": "success"]
+)
+```
+
+## Architecture Overview
+
+Profiling is a `DatadogRemoteFeature` named `profiler`. `Profiling.enable(with:in:)` registers `ProfilerFeature`, which builds a request builder, session sampler provider, quota checker, app-launch profiler, and the main `DatadogProfiler` message receiver.
+
+The low-level sampler lives in `DatadogProfiling/Mach`. It uses Mach APIs to sample application threads, aggregates stack traces into a pprof profile, and exposes C functions such as `dd_profiler_start()`, `dd_profiler_stop()`, and `dd_profiler_flush_and_get_profile()` to Swift. Default native sampling is about 101 Hz, with up to 100 threads and 128 frames per trace.
+
+`ProfilerFeature` writes UserDefaults keys consumed by the native auto-start path for app-launch profiling. The Swift side then decides when to keep the native profiler running, when to flush profiles, and whether to write or drop a profile.
+
+```mermaid
+flowchart TD
+    Enable["Profiling.enable(with:)"] --> Feature["ProfilerFeature"]
+    Feature --> Native["Mach sampler / pprof aggregator"]
+    Feature --> Receivers["CombinedFeatureMessageReceiver"]
+    Receivers --> Context["RUMCoreContext + DatadogContext"]
+    Receivers --> RUMPayloads["TTID, TTFD/operation, app hang, long task messages"]
+    Context --> Sampling["RUM-composed sampling + quota"]
+    RUMPayloads --> Correlation["RUM event correlation"]
+    Native --> Flush["Flush pprof profile"]
+    Sampling --> Flush
+    Correlation --> Event["ProfileEvent + ProfileAttachments"]
+    Flush --> Event
+    Event --> Upload["multipart /api/v2/profile"]
+```
+
+`ProfilingContext` is published into core context so RUM events can include whether profiling is running, stopped, or in an error state.
+
+## Key Files
+
+### Feature Entry Point
+- **`DatadogProfiling/Sources/Profiling.swift`** - Main entry point. Call `Profiling.enable(with:in:)` to register the feature with core.
+
+### Configuration
+- **`DatadogProfiling/Sources/ProfilingConfiguration.swift`** - Customer-facing configuration: `customEndpoint`, `applicationLaunchSampleRate`, and `continuousSampleRate`.
+
+### Runtime Orchestration
+- **`DatadogProfiling/Sources/ProfilerFeature.swift`** - Internal feature composition. Registers message receivers, configures app-launch UserDefaults, creates samplers and quota checks.
+- **`DatadogProfiling/Sources/AppLaunchProfiler.swift`** - Handles app-launch profiles and flushes them when TTID arrives.
+- **`DatadogProfiling/Sources/DatadogProfiler.swift`** - Main Continuous and Custom Profiling state machine. Starts/stops native profiling, handles RUM operation/app hang/long task messages, and flushes profiles.
+- **`DatadogProfiling/Sources/ProfilingSamplerProvider.swift`** - Stores continuous profiling configuration and session-linked sampling decisions.
+- **`DatadogProfiling/Sources/ProfilingQuotaChecker.swift`** - Checks session-scoped profiling quota admission.
+- **`DatadogProfiling/Sources/Models/ProfilingConditions.swift`** - Blocks profiling in low battery, Low Power Mode, or background conditions.
+
+### Event Writing and Upload
+- **`DatadogProfiling/Sources/ProfilingHandler.swift`** - Shared write path for app-launch, continuous, and custom profiles. Serializes pprof data and RUM events into a profile event.
+- **`DatadogProfiling/Sources/RequestBuilder.swift`** - Builds the multipart upload to `/api/v2/profile`.
+- **`DatadogProfiling/Sources/ProfileEvent.swift`** - JSON event metadata for a profile.
+- **`DatadogProfiling/Sources/Models/ProfileAttachments.swift`** - pprof and RUM event attachments (`wall.pprof`, `rum-mobile-events.json`).
+
+### Native Profiler
+- **`DatadogProfiling/Mach/`** - Native Mach sampler and pprof aggregation layer exposed to Swift through `dd_profiler.h` and `dd_pprof.h`.
+
+## Configuration Categories
+
+### Upload
+- **`customEndpoint`**: Optional replacement URL for profile uploads. Default: `nil`, which uses the Datadog site endpoint plus `/api/v2/profile`.
+
+### Sampling
+- **Application launch**: `applicationLaunchSampleRate` default is `5.0`. The value is stored in the profiling UserDefaults suite for the native app-launch path and takes effect on the next process launch. If multiple SDK instances set it, the native side uses the lowest sample rate.
+- **Continuous Profiling**: `continuousSampleRate` default is `5.0`. A value above zero configures continuous profiling. The final decision is composed with the current RUM session sampler via `RUMCoreContext.sessionSampler.combined(with: continuousSampleRate)`.
+- **Custom Profiling**: Pass `ProfilingOptions(sampleRate:)` to `RUMMonitor.shared().startOperation(...)`. RUM composes this operation sample rate with the session sampler before sending operation messages to Profiling. Operation-based custom profiling controls the profiling window only when Continuous Profiling is disabled or sampled out; otherwise sampled operation steps are attached to the continuous profile.
+
+### Runtime Conditions
+Profiling is suspended when `ProfilingConditions` sees any blocker:
+- Battery is below 10% and not charging.
+- Low Power Mode is enabled.
+- The app is in the background.
+
+Continuous profiles are also flushed when the app backgrounds after foreground activity. Custom profiling keeps the native profiler alive only while sampled operations are ongoing, with a 60 second cutoff.
+
+### Quota
+`ProfilingQuotaChecker` asks `quota.<site>/api/v2/profiling/quota?session_id=<rum_session_id>` after observing a sampled-in RUM session with granted consent. Quota is session-scoped:
+- Pending, timeout, backend unavailable, and client API errors fail open.
+- Explicit `quota_exceeded`, `org_disabled`, or undefined rejected responses stop profiling and drop pending profile data for that session.
+- A new RUM session clears the prior quota result before the next check completes.
+
+### Native Sampling
+The native profiler samples wall time and aggregates stack traces into pprof:
+- Sampling frequency: about 101 Hz.
+- Max buffered samples: 10,000.
+- Max stack depth: 128 frames.
+- Max sampled threads per cycle: 100.
+
+### Upload Format
+Profiling writes one profile per stored event because the profiling intake accepts one profile per request. Uploads are multipart/form-data with:
+- `event` / `event.json`: profile metadata.
+- `wall.pprof`: serialized pprof bytes.
+- `rum-mobile-events.json`: correlated RUM vitals, app hangs, and long tasks when present.
+
+## Common Troubleshooting Patterns
+
+### "No profiles appear"
+1. Verify `Datadog.initialize()` and `Profiling.enable()` were called.
+2. Verify RUM is enabled and tracking consent is `.granted`; Profiling relies on RUM context for session-linked sampling and quota.
+3. Check `applicationLaunchSampleRate`, `continuousSampleRate`, or operation `ProfilingOptions(sampleRate:)` are greater than zero.
+4. Confirm the app is not on watchOS, in Low Power Mode, below the battery threshold, or running only in background.
+5. Ensure the session was not rejected by the profiling quota API.
+
+### "Continuous profiles are not written even though profiling runs"
+1. Continuous profiles are written only when the RUM session samples continuous profiling in.
+2. A continuous profile needs correlated RUM data currently collected by Profiling: RUM vitals such as TTFD or sampled operation steps, app hangs, or long tasks.
+3. Report TTFD with `monitor.reportAppFullyDisplayed()`, use sampled RUM operation steps, or enable RUM long tasks (`longTaskThreshold`) and app hangs (`appHangThreshold`) if those correlations are expected.
+
+### "Custom operation profiles are missing"
+1. Use `startOperation(name:operationKey:attributes:options:)` with `ProfilingOptions(sampleRate:)`. Deprecated `startFeatureOperation` does not accept profiling options.
+2. Use matching `name` and `operationKey` in `succeedOperation` or `failOperation`.
+3. Keep the operation active long enough for the native profiler to collect useful samples; Profiling enforces a 5 second minimum profile duration before flushing custom profiles.
+4. Remember that the operation sample rate is composed with the RUM session sampler.
+5. Operation-based custom profiling takes over only when Continuous Profiling is disabled or sampled out. If Continuous Profiling is sampled in, sampled operation steps are attached to the continuous profile instead of creating a separate custom profile.
+
+### "App launch profile is missing"
+1. Ensure RUM is enabled early enough to emit the TTID message consumed by `AppLaunchProfiler`.
+2. Do not rely on `monitor.reportAppFullyDisplayed()` to emit TTID. It reports TTFD, which is delivered as a vital/operation message for continuous profile correlation.
+3. Verify `applicationLaunchSampleRate` is greater than zero.
+4. Remember that app-launch profiling settings are read at library load, before `Profiling.enable()` runs. Enabling profiling or changing `applicationLaunchSampleRate` affects the next process launch, not the current launch.
+5. App launch profiling may stop with `prewarmed` status when iOS app prewarming is detected.
+
+### "Profiles stop when the app backgrounds"
+This is expected. Background state is a profiling blocker, and the profiler flushes current data when the app transitions to background after foreground activity.
+
+## Feature Interactions
+
+- **RUM**: Profiling reads RUM context and RUM payload messages for session-linked sampling, quota checks, and profile correlation.
+
+## Additional Context
+
+- Only one `DatadogProfiler` instance can be active in a process. The initializer returns `nil` if another instance is already active.
+- Native profiling can restart from `DD_PROFILER_STATUS_STOPPED` when profiling conditions become valid again, such as after the app returns to foreground. Preserve this stop/start lifecycle when changing condition handling.
+- The profile event tags include service, version, SDK version, runtime version, env, source, language `swift`, format `pprof`, remote symbols `yes`, and operation (`launch`, `continuous`, or `custom`).
+- The profiling intake accepts one profile per request, so `ProfilerFeature.performanceOverride` limits stored batches to one object per file.

--- a/DatadogProfiling/PROFILING_FEATURE.md
+++ b/DatadogProfiling/PROFILING_FEATURE.md
@@ -6,26 +6,6 @@ tracked_files:
   - DatadogProfiling/Sources/Profiling.swift
   - DatadogProfiling/Sources/ProfilingConfiguration.swift
   - DatadogInternal/Sources/Models/Profiling/ProfilingOptions.swift
-  - DatadogRUM/Sources/RUMMonitorProtocol.swift
-  - DatadogRUM/Sources/RUM+objc.swift
-  - DatadogProfiling/Sources/ProfilerFeature.swift
-  - DatadogProfiling/Sources/AppLaunchProfiler.swift
-  - DatadogProfiling/Sources/DatadogProfiler.swift
-  - DatadogProfiling/Sources/ProfilingSamplerProvider.swift
-  - DatadogProfiling/Sources/ProfilingQuotaChecker.swift
-  - DatadogProfiling/Sources/ProfilingHandler.swift
-  - DatadogProfiling/Sources/RequestBuilder.swift
-  - DatadogProfiling/Sources/ProfileEvent.swift
-  - DatadogProfiling/Sources/Models/ProfileAttachments.swift
-  - DatadogProfiling/Sources/Models/ProfilingConditions.swift
-  - DatadogProfiling/Mach/dd_profiler.cpp
-  - DatadogProfiling/Mach/mach_sampling_profiler.cpp
-  - DatadogProfiling/Mach/aggregation_worker.cpp
-  - DatadogProfiling/Mach/profile.cpp
-  - DatadogProfiling/Mach/dd_pprof.cpp
-  - DatadogProfiling/Mach/profile_pprof_packer.cpp
-  - DatadogProfiling/Mach/include/dd_profiler.h
-  - DatadogProfiling/Mach/include/dd_pprof.h
 ---
 
 # Profiling Feature
@@ -123,7 +103,7 @@ monitor.succeedOperation(
 
 Profiling is a `DatadogRemoteFeature` named `profiler`. `Profiling.enable(with:in:)` registers `ProfilerFeature`, which builds a request builder, session sampler provider, quota checker, app-launch profiler, and the main `DatadogProfiler` message receiver.
 
-The low-level sampler lives in `DatadogProfiling/Mach`. It uses Mach APIs to sample application threads, aggregates stack traces into a pprof profile, and exposes C functions such as `dd_profiler_start()`, `dd_profiler_stop()`, and `dd_profiler_flush_and_get_profile()` to Swift. Default native sampling is about 101 Hz, with up to 100 threads and 128 frames per trace.
+The low-level sampler lives in `DatadogProfiling/Mach`. It samples application threads with Mach APIs, aggregates stack traces into a pprof profile, and exposes the native profiler to Swift through a C interface.
 
 `ProfilerFeature` writes UserDefaults keys consumed by the native auto-start path for app-launch profiling. The Swift side then decides when to keep the native profiler running, when to flush profiles, and whether to write or drop a profile.
 
@@ -165,7 +145,7 @@ flowchart TD
 - **`DatadogProfiling/Sources/ProfilingHandler.swift`** - Shared write path for app-launch, continuous, and custom profiles. Serializes pprof data and RUM events into a profile event.
 - **`DatadogProfiling/Sources/RequestBuilder.swift`** - Builds the multipart upload to `/api/v2/profile`.
 - **`DatadogProfiling/Sources/ProfileEvent.swift`** - JSON event metadata for a profile.
-- **`DatadogProfiling/Sources/Models/ProfileAttachments.swift`** - pprof and RUM event attachments (`wall.pprof`, `rum-mobile-events.json`).
+- **`DatadogProfiling/Sources/Models/ProfileAttachments.swift`** - pprof and RUM event attachments.
 
 ### Native Profiler
 - **`DatadogProfiling/Mach/`** - Native Mach sampler and pprof aggregation layer exposed to Swift through `dd_profiler.h` and `dd_pprof.h`.
@@ -186,26 +166,13 @@ Profiling is suspended when `ProfilingConditions` sees any blocker:
 - Low Power Mode is enabled.
 - The app is in the background.
 
-Continuous profiles are also flushed when the app backgrounds after foreground activity. Custom profiling keeps the native profiler alive only while sampled operations are ongoing, with a 60 second cutoff.
+Continuous profiles are also flushed when the app backgrounds after foreground activity. Custom profiling keeps the native profiler alive while sampled operations are ongoing.
 
 ### Quota
-`ProfilingQuotaChecker` asks `quota.<site>/api/v2/profiling/quota?session_id=<rum_session_id>` after observing a sampled-in RUM session with granted consent. Quota is session-scoped:
-- Pending, timeout, backend unavailable, and client API errors fail open.
-- Explicit `quota_exceeded`, `org_disabled`, or undefined rejected responses stop profiling and drop pending profile data for that session.
-- A new RUM session clears the prior quota result before the next check completes.
-
-### Native Sampling
-The native profiler samples wall time and aggregates stack traces into pprof:
-- Sampling frequency: about 101 Hz.
-- Max buffered samples: 10,000.
-- Max stack depth: 128 frames.
-- Max sampled threads per cycle: 100.
+`ProfilingQuotaChecker` checks whether the active RUM session is allowed to write profiles after Profiling has RUM session context and granted consent. Temporary quota lookup failures do not block profiling, while explicit quota rejection stops profiling for that session. A new RUM session triggers a fresh quota decision.
 
 ### Upload Format
-Profiling writes one profile per stored event because the profiling intake accepts one profile per request. Uploads are multipart/form-data with:
-- `event` / `event.json`: profile metadata.
-- `wall.pprof`: serialized pprof bytes.
-- `rum-mobile-events.json`: correlated RUM vitals, app hangs, and long tasks when present.
+Profile uploads are multipart/form-data requests that include profile metadata, serialized pprof data, and correlated RUM events when present.
 
 ## Common Troubleshooting Patterns
 
@@ -224,7 +191,7 @@ Profiling writes one profile per stored event because the profiling intake accep
 ### "Custom operation profiles are missing"
 1. Use `startOperation(name:operationKey:attributes:options:)` with `ProfilingOptions(sampleRate:)`. Deprecated `startFeatureOperation` does not accept profiling options.
 2. Use matching `name` and `operationKey` in `succeedOperation` or `failOperation`.
-3. Keep the operation active long enough for the native profiler to collect useful samples; Profiling enforces a 5 second minimum profile duration before flushing custom profiles.
+3. Keep the operation active long enough for the native profiler to collect useful samples.
 4. Remember that the operation sample rate is composed with the RUM session sampler.
 5. Operation-based custom profiling takes over only when Continuous Profiling is disabled or sampled out. If Continuous Profiling is sampled in, sampled operation steps are attached to the continuous profile instead of creating a separate custom profile.
 
@@ -245,6 +212,5 @@ This is expected. Background state is a profiling blocker, and the profiler flus
 ## Additional Context
 
 - Only one `DatadogProfiler` instance can be active in a process. The initializer returns `nil` if another instance is already active.
-- Native profiling can restart from `DD_PROFILER_STATUS_STOPPED` when profiling conditions become valid again, such as after the app returns to foreground. Preserve this stop/start lifecycle when changing condition handling.
-- The profile event tags include service, version, SDK version, runtime version, env, source, language `swift`, format `pprof`, remote symbols `yes`, and operation (`launch`, `continuous`, or `custom`).
-- The profiling intake accepts one profile per request, so `ProfilerFeature.performanceOverride` limits stored batches to one object per file.
+- Profiling can stop when runtime conditions block sampling and restart when conditions become valid again, such as after the app returns to foreground.
+- Profile uploads include pprof data, correlated RUM events, and profile metadata.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,17 @@ Common oversights:
 9. `RequestBuilder` wraps batch in HTTP POST to Datadog intake
 10. `HTTPClient` sends request; on success files are deleted; on failure backoff/retry applies
 
+### Profiling Pipeline
+
+1. App calls `Profiling.enable(with:in:)` after `Datadog.initialize()`.
+2. `ProfilerFeature` registers as a remote feature, configures the native app-launch UserDefaults flags, and installs message receivers for RUM context, RUM payloads, and quota checks.
+3. The native Mach profiler samples application threads and aggregates stack traces into pprof data.
+4. RUM context provides session IDs and deterministic session sampling; Profiling composes `continuousSampleRate` with the active RUM session sampler for Continuous Profiling.
+5. For Custom Profiling, RUM composes `ProfilingOptions(sampleRate:)` with the active session sampler before sending sampled operation payloads to Profiling.
+6. RUM payload messages provide TTID, operation, app hang, and long task data for profile correlation.
+7. `ProfilingHandler` serializes a `ProfileEvent` plus `wall.pprof` and optional `rum-mobile-events.json` attachments.
+8. `RequestBuilder` sends one multipart upload per profile to `/api/v2/profile`.
+
 ### Storage Pipeline
 
 ```
@@ -181,7 +192,7 @@ The SDK must **never throw exceptions** to customer code:
 
 - **Auth**: Client token passed as `DD-API-KEY` header
 - **Custom headers**: `DD-EVP-ORIGIN`, `DD-EVP-ORIGIN-VERSION`, `DD-REQUEST-ID`
-- **Formats**: JSON, NDJSON (batches), multipart/form-data (Session Replay, crashes)
+- **Formats**: JSON, NDJSON (batches), multipart/form-data (Session Replay, crashes, profiles)
 - **Compression**: Gzip (`Content-Encoding: gzip`)
 - **Endpoints by site**: `.us1` → `browser-intake-datadoghq.com`, `.eu1` → `browser-intake-datadoghq.eu`, etc.
 - **Header builder**: `DatadogInternal/Sources/Upload/URLRequestBuilder.swift`

--- a/docs/LLM_FEATURE_DOCS_GUIDELINES.md
+++ b/docs/LLM_FEATURE_DOCS_GUIDELINES.md
@@ -45,11 +45,11 @@ tracked_files:
 - **last_updated**: Date when the file was last reviewed/updated.
 - **sdk_version**: SDK version the documentation was verified against.
 - **verified_against_commit**: Short git commit hash at which the doc was last verified to match the source. The verify script uses `git diff <verified_against_commit>..HEAD -- <tracked_files>` to detect drift.
-- **tracked_files**: List of public-API source files whose changes should trigger a doc update.
+- **tracked_files**: List of public API and configuration source files whose changes should trigger a doc update. Cross-feature APIs should be tracked by the feature doc that owns them. Internal implementation files can be referenced in "Key Files" for navigation without being tracked.
 
 ## Sections
 
-Every feature doc contains these sections, in order:
+Every feature doc contains these core sections, in order. Optional sections are called out below and should keep the same relative position when used.
 
 ### Overview
 - Brief description of feature purpose
@@ -63,8 +63,11 @@ A complete, compilable Swift code snippet that:
 - Has accurate inline comments describing each option and its default
 - Includes optional features (manual control, per-view overrides) where applicable
 
+### Architecture Overview (optional)
+Use a `## Architecture Overview` section after Quick Start when the feature spans multiple runtime components, message flows, native layers, or cross-feature coordination. Keep it high-level and use "Key Files" for source navigation.
+
 ### Key Files
-Full relative paths from repository root, with a brief description of each file's purpose. Group by role (Feature Entry Point, Configuration, Public API, Implementation).
+Full relative paths from repository root, with a brief description of each file's purpose. Include public API/configuration files and the most useful internal implementation files for navigation. Group by role (Feature Entry Point, Configuration, Public API, Implementation).
 
 ### Configuration Categories
 Logical groupings of configuration options (Sampling, Privacy, Performance Monitoring, Event Modification, etc.). Reference defaults and explain interactions between options.
@@ -93,7 +96,7 @@ The Quick Start snippet should be valid Swift against the current SDK version. P
 Cases marked `@available(*, deprecated, message:)` — enum cases, methods, properties — must appear in the doc with a clear deprecation note. They remain on the public API and customers can still encounter them.
 
 ### Coverage
-Every source file referenced in the "Key Files" section should also appear in `tracked_files` (the `update-feature-docs` skill audits this).
+Every public API or configuration source file referenced in the "Key Files" section should also appear in `tracked_files` (the `update-feature-docs` skill audits this). Internal implementation files in "Key Files" are navigation references and do not need to be frontmatter drift triggers.
 
 ### What to skip
 - Don't replicate customer-facing public documentation verbatim — these files are LLM-optimized, not customer-facing.

--- a/docs/LLM_FEATURE_DOCS_GUIDELINES.md
+++ b/docs/LLM_FEATURE_DOCS_GUIDELINES.md
@@ -22,6 +22,7 @@ Each feature module contains a `*_FEATURE.md` file at its root:
 DatadogRUM/RUM_FEATURE.md
 DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
 DatadogTrace/TRACE_FEATURE.md
+DatadogProfiling/PROFILING_FEATURE.md
 DatadogLogs/LOGS_FEATURE.md            # (future)
 DatadogWebViewTracking/WEBVIEW_FEATURE.md  # (future)
 ```

--- a/tools/feature-docs-verify.sh
+++ b/tools/feature-docs-verify.sh
@@ -57,10 +57,21 @@ def parse_frontmatter(path):
 
     return commit, files
 
-# Discover all *_FEATURE.md files, skipping generated output directories
+# Discover all *_FEATURE.md files, skipping generated output directories,
+# local agent worktrees, and vendored dependency checkouts.
 docs = []
+ignored_dirs = {
+    ".build",
+    ".claude",
+    ".git",
+    "artifacts",
+    "build",
+    "Carthage",
+    "Checkouts",
+    "DerivedData",
+}
 for dirpath, dirnames, filenames in os.walk(repo_root):
-    dirnames[:] = [d for d in dirnames if d not in ("build", "artifacts")]
+    dirnames[:] = [d for d in dirnames if d not in ignored_dirs]
     for name in filenames:
         if name.endswith("_FEATURE.md"):
             docs.append(os.path.join(dirpath, name))


### PR DESCRIPTION
### What and why?

This PR adds feature documentation for Datadog Profiling and includes it in the `feature-docs` sync/verification system.

It documents the current continuous, custom and app launch profiling behavior in the same format used by the other feature markdown files.

### How?

- Adds `DatadogProfiling/PROFILING_FEATURE.md` with an overview, quick start, architecture overview, key files, configuration categories, troubleshooting, feature interactions and additional context.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
