### PR TITLE
[RUM-17113] Add binaryImages() to BacktraceReporting and implement in KSCrashBacktrace

### DIFF
--- a/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
+++ b/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
@@ -59,19 +59,17 @@ internal struct KSCrashBacktrace: BacktraceReporting {
             return nil
         }
 
-        var binaryImages: [UInt64: BinaryImage] = [:]
+        var binaryImages: [String: BinaryImage] = [:]
         let stack = (0..<count).compactMap { index in
             let address = addresses[index]
 
             guard
                 let rawBinaryImage = symbolicate(address: address),
-                let imageName = rawBinaryImage.name,
-                let path = NSString(utf8String: imageName)
+                let binaryImage = BinaryImage(rawBinaryImage)
             else {
                 return String(format: "%-4ld ??? 0x%016llx 0x0 + 0", index, address) // no binary image info
             }
 
-            let libraryName = path.lastPathComponent
             let loadAddress = rawBinaryImage.address
 
             let offset: UInt64
@@ -82,12 +80,12 @@ internal struct KSCrashBacktrace: BacktraceReporting {
                 telemetry.error("Invalid image load address, symbolication will fail")
             }
 
-            if binaryImages[loadAddress] == nil, let binaryImage = BinaryImage(rawBinaryImage) {
-                binaryImages[loadAddress] = binaryImage
+            if binaryImages[binaryImage.loadAddress] == nil {
+                binaryImages[binaryImage.loadAddress] = binaryImage
             }
 
             // Format: frame_index (4 chars left-aligned) + library_name (35 chars left-aligned) + addresses + offset
-            return String(format: "%-4ld %-35@ 0x%016llx 0x%016llx + %lld", index, libraryName, address, loadAddress, offset)
+            return String(format: "%-4ld %-35@ 0x%016llx 0x%016llx + %lld", index, binaryImage.libraryName, address, loadAddress, offset)
         }
         .joined(separator: "\n")
 
@@ -132,7 +130,7 @@ internal struct KSCrashBacktrace: BacktraceReporting {
                 return nil
             }
 
-            return BinaryImage(binaryImage, fallbackName: imageName)
+            return BinaryImage(binaryImage)
         }
     }
 
@@ -183,25 +181,15 @@ private func symbolicate(address: uintptr_t) -> KSBinaryImage? {
     return binaryImage
 }
 
-private extension UnsafePointer where Pointee == UInt8 {
-    var isZeroUUID: Bool {
-        UnsafeBufferPointer(start: self, count: 16).allSatisfy { $0 == 0 }
-    }
-}
-
 private extension BinaryImage {
     /// Creates a `BinaryImage` from a KSCrash `KSBinaryImage`.
     ///
-    /// - Parameter fallbackName: Used when `image.name` is unavailable.
     /// - Returns: `nil` when the image lacks the fields required for symbolication.
-    init?(_ image: KSBinaryImage, fallbackName: UnsafePointer<CChar>? = nil) {
+    init?(_ image: KSBinaryImage) {
         guard
-            let imageName = image.name ?? fallbackName,
+            let imageName = image.name,
             let path = NSString(utf8String: imageName),
-            !path.lastPathComponent.isEmpty,
-            let imageUUID = image.uuid,
-            !imageUUID.isZeroUUID,
-            image.size > 0
+            let imageUUID = image.uuid
         else {
             return nil
         }

--- a/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
+++ b/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
@@ -122,6 +122,58 @@ internal struct KSCrashBacktrace: BacktraceReporting {
         )
     }
 
+    func binaryImages() -> [BinaryImage]? {
+        let images = enumerateBinaryImages()
+        return images.isEmpty ? nil : images
+    }
+
+    private func enumerateBinaryImages() -> [BinaryImage] {
+        (0..<_dyld_image_count()).compactMap { imageIndex in
+            guard
+                let header = _dyld_get_image_header(imageIndex),
+                let imageName = _dyld_get_image_name(imageIndex)
+            else {
+                return nil
+            }
+
+            var binaryImage = KSBinaryImage()
+            guard ksdl_binaryImageForHeader(UnsafeRawPointer(header), imageName, &binaryImage) else {
+                return nil
+            }
+
+            return makeBinaryImage(from: binaryImage, fallbackName: imageName)
+        }
+    }
+
+    private func makeBinaryImage(from binaryImage: KSBinaryImage, fallbackName: UnsafePointer<CChar>) -> BinaryImage? {
+        let imageName = binaryImage.name ?? fallbackName
+
+        guard
+            let path = NSString(utf8String: imageName),
+            !path.lastPathComponent.isEmpty,
+            let imageUUID = binaryImage.uuid,
+            !imageUUID.isZeroUUID,
+            binaryImage.size > 0
+        else {
+            return nil
+        }
+
+        let uuid = UUID(uuid: imageUUID.withMemoryRebound(to: uuid_t.self, capacity: 1) { $0.pointee })
+        let architecture = String(cString: kscpu_archForCPU(
+            cpu_type_t(binaryImage.cpuType),
+            cpu_subtype_t(binaryImage.cpuSubType)
+        ))
+
+        return BinaryImage(
+            libraryName: path.lastPathComponent,
+            uuid: uuid.uuidString,
+            architecture: architecture,
+            path: path,
+            loadAddress: binaryImage.address,
+            maxAddress: binaryImage.address + binaryImage.size
+        )
+    }
+
     /// Get the name of a pthread
     private func getThreadName(pthread: pthread_t) -> String? {
         var buffer = [CChar](repeating: 0, count: 256)
@@ -167,4 +219,10 @@ private func symbolicate(address: uintptr_t) -> KSBinaryImage? {
     }
 
     return binaryImage
+}
+
+private extension UnsafePointer where Pointee == UInt8 {
+    var isZeroUUID: Bool {
+        UnsafeBufferPointer(start: self, count: 16).allSatisfy { $0 == 0 }
+    }
 }

--- a/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
+++ b/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
@@ -128,10 +128,16 @@ internal struct KSCrashBacktrace: BacktraceReporting {
     }
 
     private func enumerateBinaryImages() -> [BinaryImage] {
-        (0..<_dyld_image_count()).compactMap { imageIndex in
+        ksbic_init()
+        var count: UInt32 = 0
+        guard let images = ksbic_getImages(&count) else {
+            return []
+        }
+        return (0..<Int(count)).compactMap { i in
+            let info = images[i]
             guard
-                let header = _dyld_get_image_header(imageIndex),
-                let imageName = _dyld_get_image_name(imageIndex)
+                let header = info.imageLoadAddress,
+                let imageName = info.imageFilePath
             else {
                 return nil
             }

--- a/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
+++ b/DatadogCrashReporting/Sources/KSCrashIntegration/KSCrashBacktrace.swift
@@ -64,17 +64,15 @@ internal struct KSCrashBacktrace: BacktraceReporting {
             let address = addresses[index]
 
             guard
-                let binaryImage = symbolicate(address: address),
-                let imageName = binaryImage.name,
-                let path = NSString(utf8String: imageName),
-                let imageUUID = binaryImage.uuid
+                let rawBinaryImage = symbolicate(address: address),
+                let imageName = rawBinaryImage.name,
+                let path = NSString(utf8String: imageName)
             else {
                 return String(format: "%-4ld ??? 0x%016llx 0x0 + 0", index, address) // no binary image info
             }
 
             let libraryName = path.lastPathComponent
-            let loadAddress = binaryImage.address
-            let uuid = UUID(uuid: imageUUID.withMemoryRebound(to: uuid_t.self, capacity: 1) { $0.pointee })
+            let loadAddress = rawBinaryImage.address
 
             let offset: UInt64
             if address >= loadAddress {
@@ -84,21 +82,8 @@ internal struct KSCrashBacktrace: BacktraceReporting {
                 telemetry.error("Invalid image load address, symbolication will fail")
             }
 
-            // Get architecture from binary image's CPU type
-            let architecture = String(cString: kscpu_archForCPU(
-                cpu_type_t(binaryImage.cpuType),
-                cpu_subtype_t(binaryImage.cpuSubType)
-            ))
-
-            if binaryImages[loadAddress] == nil {
-                binaryImages[loadAddress] = BinaryImage(
-                    libraryName: libraryName,
-                    uuid: uuid.uuidString,
-                    architecture: architecture,
-                    path: path,
-                    loadAddress: loadAddress,
-                    maxAddress: loadAddress + binaryImage.size
-                )
+            if binaryImages[loadAddress] == nil, let binaryImage = BinaryImage(rawBinaryImage) {
+                binaryImages[loadAddress] = binaryImage
             }
 
             // Format: frame_index (4 chars left-aligned) + library_name (35 chars left-aligned) + addresses + offset
@@ -122,7 +107,7 @@ internal struct KSCrashBacktrace: BacktraceReporting {
         )
     }
 
-    func binaryImages() -> [BinaryImage]? {
+    func binaryImages() throws -> [BinaryImage]? {
         let images = enumerateBinaryImages()
         return images.isEmpty ? nil : images
     }
@@ -147,37 +132,8 @@ internal struct KSCrashBacktrace: BacktraceReporting {
                 return nil
             }
 
-            return makeBinaryImage(from: binaryImage, fallbackName: imageName)
+            return BinaryImage(binaryImage, fallbackName: imageName)
         }
-    }
-
-    private func makeBinaryImage(from binaryImage: KSBinaryImage, fallbackName: UnsafePointer<CChar>) -> BinaryImage? {
-        let imageName = binaryImage.name ?? fallbackName
-
-        guard
-            let path = NSString(utf8String: imageName),
-            !path.lastPathComponent.isEmpty,
-            let imageUUID = binaryImage.uuid,
-            !imageUUID.isZeroUUID,
-            binaryImage.size > 0
-        else {
-            return nil
-        }
-
-        let uuid = UUID(uuid: imageUUID.withMemoryRebound(to: uuid_t.self, capacity: 1) { $0.pointee })
-        let architecture = String(cString: kscpu_archForCPU(
-            cpu_type_t(binaryImage.cpuType),
-            cpu_subtype_t(binaryImage.cpuSubType)
-        ))
-
-        return BinaryImage(
-            libraryName: path.lastPathComponent,
-            uuid: uuid.uuidString,
-            architecture: architecture,
-            path: path,
-            loadAddress: binaryImage.address,
-            maxAddress: binaryImage.address + binaryImage.size
-        )
     }
 
     /// Get the name of a pthread
@@ -230,5 +186,39 @@ private func symbolicate(address: uintptr_t) -> KSBinaryImage? {
 private extension UnsafePointer where Pointee == UInt8 {
     var isZeroUUID: Bool {
         UnsafeBufferPointer(start: self, count: 16).allSatisfy { $0 == 0 }
+    }
+}
+
+private extension BinaryImage {
+    /// Creates a `BinaryImage` from a KSCrash `KSBinaryImage`.
+    ///
+    /// - Parameter fallbackName: Used when `image.name` is unavailable.
+    /// - Returns: `nil` when the image lacks the fields required for symbolication.
+    init?(_ image: KSBinaryImage, fallbackName: UnsafePointer<CChar>? = nil) {
+        guard
+            let imageName = image.name ?? fallbackName,
+            let path = NSString(utf8String: imageName),
+            !path.lastPathComponent.isEmpty,
+            let imageUUID = image.uuid,
+            !imageUUID.isZeroUUID,
+            image.size > 0
+        else {
+            return nil
+        }
+
+        let uuid = UUID(uuid: imageUUID.withMemoryRebound(to: uuid_t.self, capacity: 1) { $0.pointee })
+        let architecture = String(cString: kscpu_archForCPU(
+            cpu_type_t(image.cpuType),
+            cpu_subtype_t(image.cpuSubType)
+        ))
+
+        self.init(
+            libraryName: path.lastPathComponent,
+            uuid: uuid.uuidString,
+            architecture: architecture,
+            path: path,
+            loadAddress: image.address,
+            maxAddress: image.address + image.size
+        )
     }
 }

--- a/DatadogCrashReporting/Tests/KSCrashIntegration/KSCrashBacktraceTests.swift
+++ b/DatadogCrashReporting/Tests/KSCrashIntegration/KSCrashBacktraceTests.swift
@@ -120,6 +120,71 @@ class KSCrashBacktraceTests: XCTestCase {
         XCTAssertNil(report, "Should return nil for invalid thread ID")
     }
 
+    // MARK: - Binary Images Tests
+
+    func testBinaryImagesReturnsNonEmptyList() throws {
+        // Given
+        let backtrace = KSCrashBacktrace()
+
+        // When
+        let images = try XCTUnwrap(backtrace.binaryImages())
+
+        // Then
+        XCTAssertGreaterThan(images.count, 0, "Binary images should not be empty")
+    }
+
+    func testBinaryImagesContainValidFields() throws {
+        // Given
+        let backtrace = KSCrashBacktrace()
+
+        // When
+        let images = try XCTUnwrap(backtrace.binaryImages())
+
+        // Then
+        for image in images {
+            XCTAssertFalse(image.libraryName.isEmpty, "Library name should not be empty")
+            XCTAssertNotNil(UUID(uuidString: image.uuid), "UUID should be valid: \(image.uuid)")
+            XCTAssertFalse(image.architecture.isEmpty, "Architecture should not be empty")
+
+            let loadAddress = UInt64(image.loadAddress.dropFirst(2), radix: 16)
+            let maxAddress = UInt64(image.maxAddress.dropFirst(2), radix: 16)
+            XCTAssertNotNil(loadAddress, "Load address should be valid hex: \(image.loadAddress)")
+            XCTAssertNotNil(maxAddress, "Max address should be valid hex: \(image.maxAddress)")
+            if let load = loadAddress, let max = maxAddress {
+                XCTAssertGreaterThan(max, load, "Max address should be greater than load address")
+            }
+        }
+    }
+
+    func testBinaryImagesContainTestTarget() throws {
+        // Given
+        let backtrace = KSCrashBacktrace()
+
+        // When
+        let images = try XCTUnwrap(backtrace.binaryImages())
+
+        // Then
+        let testImage = try XCTUnwrap(
+            images.first { $0.libraryName.contains("DatadogCrashReportingTests") },
+            "Binary images should include the test target"
+        )
+        XCTAssertFalse(testImage.isSystemLibrary, "Test target should not be a system library")
+    }
+
+    func testBinaryImagesSystemLibraryFlag() throws {
+        // Given
+        let backtrace = KSCrashBacktrace()
+
+        // When
+        let images = try XCTUnwrap(backtrace.binaryImages())
+
+        // Then
+        XCTAssertTrue(
+            images.contains { $0.isSystemLibrary },
+            "Binary images should include at least one system library"
+        )
+    }
+
     // MARK: - watchOS Tests
 
     /// On watchOS, `thread_get_state` is not available, so KSCrash cannot capture machine context

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -26,6 +26,11 @@ public protocol BacktraceReporting: Sendable {
     /// - Returns: A `BacktraceReport` starting on the given thread and containing information about all other threads
     ///            running in the process. Returns `nil` if the backtrace report cannot be generated.
     func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport?
+
+    /// Returns binary images loaded in the current process.
+    ///
+    /// Returns `nil` if binary images cannot be obtained.
+    func binaryImages() -> [BinaryImage]?
 }
 
 public extension BacktraceReporting {
@@ -39,6 +44,8 @@ public extension BacktraceReporting {
         let callerThreadID = Thread.currentThreadID
         return try generateBacktrace(threadID: callerThreadID)
     }
+
+    func binaryImages() -> [BinaryImage]? { nil }
 }
 
 internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
@@ -69,6 +76,10 @@ internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
             return nil
         }
         return try backtraceFeature.reporter.generateBacktrace(threadID: threadID)
+    }
+
+    func binaryImages() -> [BinaryImage]? {
+        core?.get(feature: BacktraceReportingFeature.self)?.reporter.binaryImages()
     }
 }
 

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -45,7 +45,7 @@ public extension BacktraceReporting {
         return try generateBacktrace(threadID: callerThreadID)
     }
 
-    func binaryImages() -> [BinaryImage]? { nil }
+    func binaryImages() -> [BinaryImage]? { try? generateBacktrace()?.binaryImages }
 }
 
 internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -30,7 +30,7 @@ public protocol BacktraceReporting: Sendable {
     /// Returns binary images loaded in the current process.
     ///
     /// Returns `nil` if binary images cannot be obtained.
-    func binaryImages() -> [BinaryImage]?
+    func binaryImages() throws -> [BinaryImage]?
 }
 
 public extension BacktraceReporting {
@@ -45,7 +45,7 @@ public extension BacktraceReporting {
         return try generateBacktrace(threadID: callerThreadID)
     }
 
-    func binaryImages() -> [BinaryImage]? { try? generateBacktrace()?.binaryImages }
+    func binaryImages() throws -> [BinaryImage]? { try generateBacktrace()?.binaryImages }
 }
 
 internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
@@ -78,8 +78,8 @@ internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
         return try backtraceFeature.reporter.generateBacktrace(threadID: threadID)
     }
 
-    func binaryImages() -> [BinaryImage]? {
-        core?.get(feature: BacktraceReportingFeature.self)?.reporter.binaryImages()
+    func binaryImages() throws -> [BinaryImage]? {
+        try core?.get(feature: BacktraceReportingFeature.self)?.reporter.binaryImages()
     }
 }
 

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -152,7 +152,11 @@ internal final class RemoteLogger: LoggerProtocol, Sendable {
             // When binary images are requested, add them
             var binaryImages: [BinaryImage]?
             if addBinaryImages {
-                binaryImages = self.backtraceReporter?.binaryImages()
+                do {
+                    binaryImages = try self.backtraceReporter?.binaryImages()
+                } catch {
+                    self.featureScope.telemetry.error(error)
+                }
             }
 
             let builder = LogEventBuilder(

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -152,8 +152,7 @@ internal final class RemoteLogger: LoggerProtocol, Sendable {
             // When binary images are requested, add them
             var binaryImages: [BinaryImage]?
             if addBinaryImages {
-                // TODO: RUM-4072 Replace full backtrace reporter with simpler binary image fetcher
-                binaryImages = try? self.backtraceReporter?.generateBacktrace()?.binaryImages
+                binaryImages = self.backtraceReporter?.binaryImages()
             }
 
             let builder = LogEventBuilder(

--- a/DatadogLogs/Tests/RemoteLoggerTests.swift
+++ b/DatadogLogs/Tests/RemoteLoggerTests.swift
@@ -100,6 +100,28 @@ class RemoteLoggerTests: XCTestCase {
         }
     }
 
+    func testWhenBinaryImagesGenerationFails_itReportsErrorToTelemetryAndOmitsBinaryImages() throws {
+        // Given
+        let generationError = ErrorMock("binary images generation failed")
+        let logger = RemoteLogger(
+            featureScope: featureScope,
+            globalAttributes: .mockAny(),
+            configuration: .mockAny(),
+            dateProvider: RelativeDateProvider(),
+            rumContextIntegration: false,
+            activeSpanIntegration: false,
+            backtraceReporter: BacktraceReporterMock(backtraceGenerationError: generationError)
+        )
+
+        // When
+        logger.error("Information message", error: ErrorMock(), attributes: [CrossPlatformAttributes.includeBinaryImages: true])
+
+        // Then
+        let errorMessage = try XCTUnwrap(featureScope.messagesSent().firstPayload as? RUMErrorMessage)
+        XCTAssertNil(errorMessage.binaryImages, "Binary images should be omitted when generation fails")
+        XCTAssertNotNil(featureScope.telemetryMock.messages.firstError(), "The generation error should be reported to telemetry")
+    }
+
     func testWhenErrorLogged_itPostsToMessageBus_withOtherCrossPlatformAttributesIntact() throws {
         // Given
         let logger = RemoteLogger(

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -727,7 +727,11 @@ extension RUMViewScope {
         if commandAttributes.removeValue(forKey: CrossPlatformAttributes.includeBinaryImages)?.dd.decode() == true {
             // Don't try to get binary images if we already have them.
             if binaryImages == nil {
-                binaryImages = dependencies.backtraceReporter?.binaryImages()?.compactMap { $0.toRUMDataFormat }
+                do {
+                    binaryImages = try dependencies.backtraceReporter?.binaryImages()?.compactMap { $0.toRUMDataFormat }
+                } catch {
+                    dependencies.telemetry.error(error)
+                }
             }
         }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -727,8 +727,7 @@ extension RUMViewScope {
         if commandAttributes.removeValue(forKey: CrossPlatformAttributes.includeBinaryImages)?.dd.decode() == true {
             // Don't try to get binary images if we already have them.
             if binaryImages == nil {
-                // TODO: RUM-4072 Replace full backtrace reporter with simpler binary image fetcher
-                binaryImages = try? dependencies.backtraceReporter?.generateBacktrace()?.binaryImages.compactMap { $0.toRUMDataFormat }
+                binaryImages = dependencies.backtraceReporter?.binaryImages()?.compactMap { $0.toRUMDataFormat }
             }
         }
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2356,6 +2356,62 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNil(error.context!.contextInfo[RUM.Attributes.errorFingerprint])
     }
 
+    func testGivenStartedView_whenBinaryImagesGenerationFails_itReportsErrorToTelemetryAndOmitsBinaryImages() throws {
+        // Given
+        let generationError = ErrorMock("binary images generation failed")
+        let featureScope = FeatureScopeMock()
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+
+        let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
+            parent: parent,
+            dependencies: .mockWith(
+                featureScope: featureScope,
+                backtraceReporter: BacktraceReporterMock(backtraceGenerationError: generationError)
+            ),
+            identity: .mockViewIdentifier(),
+            path: "UIViewController",
+            name: "ViewName",
+            customTimings: [:],
+            startTime: currentTime,
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: INVMetricMock(),
+            viewIndexInSession: .mockAny()
+        )
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: [:], identity: .mockViewIdentifier()),
+                context: context,
+                writer: writer
+            )
+        )
+
+        currentTime.addTimeInterval(1)
+
+        // When
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddCurrentViewErrorCommand.mockWithErrorMessage(
+                    time: currentTime,
+                    message: "view error",
+                    source: .source,
+                    stack: nil,
+                    attributes: [
+                        CrossPlatformAttributes.includeBinaryImages: true
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let error = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).last)
+        XCTAssertNil(error.error.binaryImages, "Binary images should be omitted when generation fails")
+        XCTAssertNotNil(featureScope.telemetryMock.messages.firstError(), "The generation error should be reported to telemetry")
+    }
+
     func testGivenStartedView_whenErrorWithIncludeBinaryImagesAttributesIsAdded_itAddsBinaryImagesToError() throws {
         // Given
         let mockBacktrace: BacktraceReport = .mockRandom()

--- a/TestUtilities/Sources/Mocks/CrashReporting/BacktraceReportingMocks.swift
+++ b/TestUtilities/Sources/Mocks/CrashReporting/BacktraceReportingMocks.swift
@@ -14,14 +14,23 @@ public struct BacktraceReporterMock: BacktraceReporting, @unchecked Sendable {
     /// The error thrown that will be thrown by this mock during backtrace generation. It takes priority over returning the `backtrace` value.
     @ReadWriteLock
     public var backtraceGenerationError: Error?
+    /// The binary images returned by this mock. If not set, binary images are derived from `backtrace`.
+    @ReadWriteLock
+    public var binaryImagesList: [BinaryImage]?
 
     /// Creates backtrace reporter mock.
     /// - Parameters:
     ///   - backtrace: The backtrace that will be returned.
     ///   - backtraceGenerationError: The error thrown during backtrace generation. It takes priority over returning the `backtrace`.
-    public init(backtrace: BacktraceReport? = .mockAny(), backtraceGenerationError: Error? = nil) {
+    ///   - binaryImages: The binary images that will be returned. If `nil`, binary images are derived from `backtrace?.binaryImages`. Pass `[]` to simulate "no binary images" independently of `backtrace`.
+    public init(
+        backtrace: BacktraceReport? = .mockAny(),
+        backtraceGenerationError: Error? = nil,
+        binaryImages: [BinaryImage]? = nil
+    ) {
         self.backtrace = backtrace
         self.backtraceGenerationError = backtraceGenerationError
+        self.binaryImagesList = binaryImages
     }
 
     public func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport? {
@@ -29,5 +38,9 @@ public struct BacktraceReporterMock: BacktraceReporting, @unchecked Sendable {
             throw error
         }
         return backtrace
+    }
+
+    public func binaryImages() -> [BinaryImage]? {
+        binaryImagesList ?? backtrace?.binaryImages
     }
 }

--- a/TestUtilities/Sources/Mocks/CrashReporting/BacktraceReportingMocks.swift
+++ b/TestUtilities/Sources/Mocks/CrashReporting/BacktraceReportingMocks.swift
@@ -34,13 +34,18 @@ public struct BacktraceReporterMock: BacktraceReporting, @unchecked Sendable {
     }
 
     public func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport? {
-        if let error = backtraceGenerationError {
-            throw error
-        }
+        try throwIfNeeded()
         return backtrace
     }
 
-    public func binaryImages() -> [BinaryImage]? {
-        binaryImagesList ?? backtrace?.binaryImages
+    public func binaryImages() throws -> [BinaryImage]? {
+        try throwIfNeeded()
+        return binaryImagesList ?? backtrace?.binaryImages
+    }
+
+    private func throwIfNeeded() throws {
+        if let error = backtraceGenerationError {
+            throw error
+        }
     }
 }


### PR DESCRIPTION
### What and why?

Currently, Logs and RUM obtain binary images for cross-platform error symbolization by calling generateBacktrace(), which performs a full KSCrash stack capture, then extracting .binaryImages as a byproduct. This is expensive and can run twice in the Logs → RUM integration.

This PR replaces that with a dedicated binaryImages() method on BacktraceReporting that enumerates loaded dylibs directly via ksdl_binaryImageForHeader(), without capturing a stack trace.

### How?

- Add binaryImages() -> [BinaryImage]? to the BacktraceReporting protocol with a default { nil } to avoid source-breaking external conformers
- Update CoreBacktraceReporter to delegate binaryImages() to the registered feature reporter
- Implement binaryImages() in KSCrashBacktrace using _dyld_image_count() / _dyld_get_image_header() and ksdl_binaryImageForHeader(). Skips images with zero UUID, empty name, or zero size
- Update BacktraceReporterMock to implement binaryImages(), deriving from backtrace?.binaryImages by default to avoid churn in existing tests
- Replace both TODO call sites in RemoteLogger and RUMViewScope


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — not applicable, internal optimization with no user-facing behavior change
- [ ] Add Objective-C interface for public APIs — not applicable, no new public API
- [x] Run make api-surface when adding new APIs — ran make api-surface-verify, passed
