### PR TITLE
patch: Disable standalone custom profiling

### DIFF
--- a/Datadog/IntegrationUnitTests/Profiling/ProfilingRUMIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Profiling/ProfilingRUMIntegrationTests.swift
@@ -209,7 +209,7 @@ final class ProfilingRUMIntegrationTests: XCTestCase {
         assertNoProfileOutput(timeout: timeout(after: 0.1))
     }
 
-    func testContinuousProfilingSamplesOut_customVitalStillSendsProfileEvent() throws {
+    func testContinuousProfilingSamplesOut_customVitalDoesNotSendProfileEvent() throws {
         // Given
         let sessionUUID = Fixtures.deterministicSessionUUID
         let vitalName = "vital-name"
@@ -231,19 +231,18 @@ final class ProfilingRUMIntegrationTests: XCTestCase {
         waitAndAssertRUMViewEvents()
         waitUntilContinuousProfilingSampled(false)
 
+        // Stop the setup-started profiler so this verifies only the custom vital start behavior.
+        dd_profiler_stop()
+        waitUntilProfilerStatus(DD_PROFILER_STATUS_STOPPED, description: "profiler is stopped before the custom vital")
+
         startVital(name: vitalName, operationKey: operationKey)
-        waitUntilProfilerStatus(DD_PROFILER_STATUS_RUNNING, description: "profiler is running for the custom vital")
-        wait(during: Fixtures.minProfileDuration) {}
+        core.flush()
+        waitUntilProfilerStatus(DD_PROFILER_STATUS_STOPPED, description: "custom vital does not start the profiler")
 
         finishVital(name: vitalName, operationKey: operationKey)
-        waitUntilProfilerStatus(DD_PROFILER_STATUS_STOPPED, description: "profiler is stopped after the custom vital")
-
-        let profileAttachments = waitForProfileAttachments()
-        XCTAssertEqual(profileAttachments.count, 1)
-        let attachments = try XCTUnwrap(profileAttachments.last)
-        let rumVitals = try rumVitals(from: attachments)
-        XCTAssertEqual(rumVitals.count, 1)
-        XCTAssertEqual(rumVitals.first?["name"] as? String, vitalName)
+        core.flush()
+        waitUntilProfilerStatus(DD_PROFILER_STATUS_STOPPED, description: "profiler is still stopped after the custom vital")
+        assertNoProfileOutput(timeout: timeout(after: Fixtures.minProfileDuration + 0.1))
     }
 }
 

--- a/DatadogProfiling/Mach/mach_sampling_profiler.cpp
+++ b/DatadogProfiling/Mach/mach_sampling_profiler.cpp
@@ -395,7 +395,7 @@ static void walk_frames(
         // so fp must be at or above sp when a stack snapshot is available.
         if (stack_base != 0 && fp_addr < stack_base) break;
 
-        frame_pointer_pair_t next_frame;
+        frame_pointer_pair_t next_frame = {};
         if (!read_frame_pair_from_snapshot(fp_addr, stack_base, stack_buf, bytes_read, &next_frame)) {
             if (!allow_memory_fallback || !read_frame_pair_from_memory(fp_addr, &next_frame)) {
                 break;

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -351,11 +351,13 @@ private extension DatadogProfiler {
     func updateProfilerState(canProfile: Bool) {
         switch ProfilingContext.Status.current {
         case .stopped, .unknown: // When `.unknown` status, mostly profiler NOT_CREATED, it will try to start the profiler
-            if canProfile {
+            if canProfile && !isCustomProfiling {
                 dd_profiler_start()
                 previousCustomProfilingStartDate = dateProvider.now
                 updateProfilingContext()
                 startTimer()
+            } else if isCustomProfiling {
+                currentRUMVitals.removeAll()
             }
         case .running:
             if canProfile {

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -578,7 +578,7 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 
-    func testReceiveOperationStart_afterContinuousProfilingSamplesOut_startsCustomProfiling() {
+    func testReceiveOperationStart_afterContinuousProfilingSamplesOut_doesNotStartCustomProfiling() {
         // Given
         core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
@@ -614,11 +614,11 @@ extension DatadogProfilerTests {
         flushQueue()
 
         // Then
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
         withExtendedLifetime(profiler) {}
     }
 
-    func testReceiveOperationStartWhenContinuousProfilingSamplesOut_andVitalStarts() {
+    func testReceiveOperationStartWhenContinuousProfilingSamplesOut_doesNotStartProfiler() {
         // Given
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let dateProvider = DateProviderMock()
@@ -643,7 +643,7 @@ extension DatadogProfilerTests {
         flushQueue()
 
         // Then
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
         withExtendedLifetime(profiler) {}
     }
 
@@ -725,8 +725,8 @@ extension DatadogProfilerTests {
             additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
         )
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
 
         let startOperation = Vital.mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(
@@ -1001,21 +1001,21 @@ extension DatadogProfilerTests {
         withExtendedLifetime(profiler) {}
     }
 
-    func testCustomProfiler_startsProfilerOnFirstRUMOperationStart() {
+    func testCustomProfiler_doesNotStartProfilerOnFirstRUMOperationStart() {
         // Given
         dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
         let dateProvider = DateProviderMock()
         let profiler = customProfiler(dateProvider: dateProvider)
-        shareCurrentContext(with: profiler)
 
         // When
+        let operation = Vital.mockWith(stepType: .start, date: dateProvider.now + 1)
         _ = profiler.receive(
             message: .payload(
                 OperationMessage(
                     attributes: mockRandomAttributes(),
-                    operation: .mockWith(stepType: .start, date: dateProvider.now + 1)
+                    operation: operation
                 )
             ),
             from: core
@@ -1023,11 +1023,41 @@ extension DatadogProfilerTests {
         flushQueue()
 
         // Then
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING, "Custom profiler should start on first RUM operation")
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
+
+        // When
+        _ = profiler.receive(
+            message: .payload(
+                OperationMessage(
+                    attributes: mockRandomAttributes(),
+                    operation: .mockWith(
+                        name: operation.name,
+                        operationKey: operation.operationKey,
+                        stepType: .end,
+                        date: dateProvider.now + 2
+                    )
+                )
+            ),
+            from: core
+        )
+        flushQueue()
+
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        core.context = .mockWith(applicationStateHistory: .mockWith(
+            initialState: .active,
+            date: dateProvider.now.addingTimeInterval(-1),
+            transitions: [(state: .background, date: dateProvider.now)]
+        ))
+        waitForProfileWrite(expectingWrite: false) {
+            _ = profiler.receive(message: .context(core.context), from: core)
+        }
+
+        // Then
+        XCTAssertTrue(core.metadata.isEmpty)
         withExtendedLifetime(profiler) {}
     }
 
-    func testCustomProfiler_doesNotRestartRunningProfilerOnOperation() {
+    func testCustomProfiler_doesNotRestartProfilerStoppedByContextOnOperation() {
         // Given
         dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
@@ -1035,6 +1065,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock()
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
 
         // When
         _ = profiler.receive(
@@ -1048,8 +1079,8 @@ extension DatadogProfilerTests {
         )
         flushQueue()
 
-        // Then - profiler stays running without error
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        // Then - custom operation does not restart the stopped profiler.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
         withExtendedLifetime(profiler) {}
     }
 
@@ -1098,12 +1129,10 @@ extension DatadogProfilerTests {
         core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)))
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        // Put profiler in NOT_STARTED state (fresh instance, never started) so the custom profiler can start it
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
-        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
-        // Custom profiler auto-starts on first .start operation
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
         flushQueue()
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
@@ -1133,7 +1162,7 @@ extension DatadogProfilerTests {
         core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)))
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp = Vital.mockWith(id: "start-id", name: "operation", stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -1180,7 +1209,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -1202,7 +1231,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp: Vital = .mockWith(date: dateProvider.now.addingTimeInterval(1))
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -1222,7 +1251,7 @@ extension DatadogProfilerTests {
         let dateProvider = DateProviderMock(now: Date())
         let profiler = customProfiler(dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -1539,7 +1568,7 @@ extension DatadogProfilerTests {
         core.context = .mockWith(applicationStateHistory: .mockAppInForeground(since: initialDate.addingTimeInterval(-1)))
         let profiler = customProfiler(telemetryController: telemetryController, dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOperation = Vital.mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOperation)), from: core)
@@ -1949,12 +1978,12 @@ extension DatadogProfilerTests {
             profilingSamplerProvider: profilingSamplerProvider,
             quotaChecker: quotaChecker
         )
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         _ = profiler.receive(
             message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith())),
             from: core
         )
         flushQueue()
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)


### PR DESCRIPTION
> [!IMPORTANT]
> This is a temporary patch to align the iOS SDK behavior with the Android SDK. It keeps the custom profiling code path in place, but prevents custom profiling from independently starting the native profiler. 

### What and why?

This PR disables custom profiling as a standalone way to start profiling. When continuous profiling is sampled out and there are no other vitals keeping the profiler running, starting a custom profiled operation no longer starts the native profiler or sends a profile event.
If the profiler is already running because of continuous profiling, custom profiling continues to attach operation data as before.

### How?

The `DatadogProfiler` now guards the two places where custom profiling could start the native profiler: 
- operation start handling;
- profiler state transitions from `stopped`/`unknown`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
