### PR TITLE
[RUM-16416] Apply remote configuration to RUM module at enablement

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -867,6 +867,8 @@
 		CD91654B77EEEB08CD20B3B0 /* HeatmapIdentifierStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC78B982F5C5B87E754DF44 /* HeatmapIdentifierStoreTests.swift */; };
 		D2023A9E2FFE64B500A80981 /* RemoteConfigurationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A9D2FFE64B500A80981 /* RemoteConfigurationMocks.swift */; };
 		D2023AA02FFE64CE00A80981 /* ProfilingConfiguration+RemoteConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A9F2FFE64CE00A80981 /* ProfilingConfiguration+RemoteConfigurationTests.swift */; };
+		D2023A872FFBE06800A80981 /* RUMConfiguration+RemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A862FFBE06800A80981 /* RUMConfiguration+RemoteConfiguration.swift */; };
+		D2023A892FFBE09C00A80981 /* RUMConfiguration+RemoteConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A882FFBE09C00A80981 /* RUMConfiguration+RemoteConfigurationTests.swift */; };
 		D2056C212BBFE05A0085BC76 /* WireframesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2056C202BBFE05A0085BC76 /* WireframesBuilderTests.swift */; };
 		D20605A3287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A6287476230047275C /* ServerOffsetPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A5287476230047275C /* ServerOffsetPublisher.swift */; };
@@ -2800,6 +2802,8 @@
 		D1E553EF33633FBFBB288899 /* HeatmapIdentifierStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapIdentifierStore.swift; sourceTree = "<group>"; };
 		D2023A9D2FFE64B500A80981 /* RemoteConfigurationMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationMocks.swift; sourceTree = "<group>"; };
 		D2023A9F2FFE64CE00A80981 /* ProfilingConfiguration+RemoteConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfilingConfiguration+RemoteConfigurationTests.swift"; sourceTree = "<group>"; };
+		D2023A862FFBE06800A80981 /* RUMConfiguration+RemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMConfiguration+RemoteConfiguration.swift"; sourceTree = "<group>"; };
+		D2023A882FFBE09C00A80981 /* RUMConfiguration+RemoteConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMConfiguration+RemoteConfigurationTests.swift"; sourceTree = "<group>"; };
 		D2056C202BBFE05A0085BC76 /* WireframesBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireframesBuilderTests.swift; sourceTree = "<group>"; };
 		D20605A2287464F40047275C /* ContextValuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextValuePublisher.swift; sourceTree = "<group>"; };
 		D20605A5287476230047275C /* ServerOffsetPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerOffsetPublisher.swift; sourceTree = "<group>"; };
@@ -6588,6 +6592,7 @@
 				49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */,
 				11EA5C232DC288DD00E8DFA2 /* RUM+objc.swift */,
 				D25FF2EA29CC6D6F0063802D /* RUMConfiguration.swift */,
+				D2023A862FFBE06800A80981 /* RUMConfiguration+RemoteConfiguration.swift */,
 				61E5333524B84B43003D6C4E /* RUMMonitor.swift */,
 				61C713A02A3B78F900FA735A /* RUMMonitorProtocol.swift */,
 				61C713A22A3B78F900FA735A /* RUMMonitorProtocol+Convenience.swift */,
@@ -6635,6 +6640,7 @@
 				6174D6182BFE447600EC7469 /* SDKMetrics */,
 				61411B0E24EC15940012EAB2 /* Utils */,
 				67B718E85203992292E96407 /* Heatmaps */,
+				D2023A882FFBE09C00A80981 /* RUMConfiguration+RemoteConfigurationTests.swift */,
 			);
 			name = DatadogRUMTests;
 			path = ../DatadogRUM/Tests;
@@ -9148,6 +9154,7 @@
 				965497052D761FCB006428EE /* SwiftUIViewNameExtractor.swift in Sources */,
 				11F55FD92DCE183500DE4944 /* RUMDataModels+objc.swift in Sources */,
 				D29A9F7C29DD85BB005C54A4 /* RUMEventBuilder.swift in Sources */,
+				D2023A872FFBE06800A80981 /* RUMConfiguration+RemoteConfiguration.swift in Sources */,
 				118ACA3C2EEED247004E7F20 /* AppLaunchMetricController.swift in Sources */,
 				118ACA3D2EEED247004E7F20 /* AppLaunchMetric.swift in Sources */,
 				D29A9F8829DD85BB005C54A4 /* ErrorMessageReceiver.swift in Sources */,
@@ -9270,6 +9277,7 @@
 				D29A9FB729DDB483005C54A4 /* ViewIdentifierTests.swift in Sources */,
 				96F70D592DDE253F00D3736B /* SwiftUIComponentDetectorTests.swift in Sources */,
 				D29A9FA429DDB483005C54A4 /* WebViewEventReceiverTests.swift in Sources */,
+				D2023A892FFBE09C00A80981 /* RUMConfiguration+RemoteConfigurationTests.swift in Sources */,
 				61536AC02DF21A0500B06D7D /* LaunchReasonResolverTests.swift in Sources */,
 				D29A9F9A29DDB483005C54A4 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
 				117ADDD92EAA8A90008BD9D8 /* StartupTypeHandlerTests.swift in Sources */,

--- a/DatadogRUM/Sources/RUM.swift
+++ b/DatadogRUM/Sources/RUM.swift
@@ -41,6 +41,12 @@ public enum RUM {
             )
         }
 
+        // Merge remote configuration on top of the in-code configuration. Remote values take
+        // precedence for supported behavioral parameters; if no remote configuration is available,
+        // the in-code configuration is used unchanged.
+        var configuration = configuration
+        configuration.apply(remoteConfiguration: core.remoteConfiguration)
+
         // Register RUM feature:
         let rum = try RUMFeature(in: core, configuration: configuration)
         try core.register(feature: rum)

--- a/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
@@ -12,8 +12,10 @@ extension RUM.Configuration {
     ///
     /// Two namespaces are consumed: `rum` overrides the supported behavioral parameters, and `trace`
     /// configures distributed tracing on RUM's network instrumentation. Remote values take precedence,
-    /// while any parameter the remote configuration omits keeps its in-code value; passing `nil` (no
-    /// remote configuration was fetched) therefore leaves the configuration entirely unchanged.
+    /// while most parameters the remote configuration omits keep their in-code value — the exceptions are
+    /// the `longTaskThreshold` and `appHangThreshold`, whose absence disables the corresponding feature
+    /// (see `apply(rum:)`). Passing `nil` (no remote configuration was fetched) leaves the configuration
+    /// entirely unchanged.
     ///
     /// The two namespaces interact through RUM's URLSession instrumentation, which carries both
     /// resource collection and trace propagation: an explicit `rum.trackResources == false` disables
@@ -35,11 +37,16 @@ extension RUM.Configuration {
     /// Applies the `rum` namespace, overriding the supported behavioral parameters with their remote
     /// values.
     ///
-    /// Scalar and enum settings (sample rates, thresholds, tracking flags, vitals frequency) are
-    /// overridden directly. `trackResources` and `trackUserInteractions` have no direct in-code
-    /// equivalent — they are modeled as the presence of a tracking configuration / action predicate —
-    /// so they are toggled through the `override(_:with:)` overloads instead. Thresholds arrive in
-    /// milliseconds and are converted to seconds.
+    /// Scalar and enum settings (sample rates, tracking flags, vitals frequency) are overridden
+    /// directly. `trackResources` and `trackUserInteractions` have no direct in-code equivalent — they
+    /// are modeled as the presence of a tracking configuration / action predicate — so they are toggled
+    /// through the `override(_:with:)` overloads instead.
+    ///
+    /// `longTaskThreshold` and `appHangThreshold` are overridden through `override(_:withMilliseconds:)`,
+    /// which follows "omit to disable" semantics: it converts milliseconds to seconds and, within a
+    /// present `rum` namespace, lets the remote value always drive the property — so an omitted threshold
+    /// clears the in-code value (disabling the feature) rather than keeping it. This mirrors the in-code
+    /// configuration, where a `nil` threshold disables the feature.
     ///
     /// - Parameter rum: The `rum` namespace, or `nil` to leave the configuration unchanged.
     private mutating func apply(rum: RemoteConfiguration.RUM?) {
@@ -51,8 +58,8 @@ extension RUM.Configuration {
         override(\.trackAnonymousUser, with: rum.trackAnonymousUser)
         override(\.trackBackgroundEvents, with: rum.trackBackgroundEvents)
         override(\.trackFrustrations, with: rum.trackFrustrations)
-        override(\.longTaskThreshold, with: rum.longTaskThresholdMs.map { .ddFromMilliseconds(.ddWithNoOverflow($0)) })
-        override(\.appHangThreshold, with: rum.appHangThresholdMs.map { .ddFromMilliseconds(.ddWithNoOverflow($0)) })
+        override(\.longTaskThreshold, withMilliseconds: rum.longTaskThresholdMs)
+        override(\.appHangThreshold, withMilliseconds: rum.appHangThresholdMs)
         override(\.trackSlowFrames, with: rum.trackSlowFrames)
         override(\.trackWatchdogTerminations, with: rum.trackWatchdogTerminations)
         override(\.vitalsUpdateFrequency, with: rum.vitalsUpdateFrequency.map { VitalsFrequency($0) })
@@ -138,6 +145,19 @@ extension RUM.Configuration {
         if let remoteValue {
             self[keyPath: keyPath] = remoteValue
         }
+    }
+
+    /// Overrides a threshold property (stored in seconds) with a remote value in milliseconds.
+    ///
+    /// Unlike `override(_:with:)`, the remote value always drives the property: within a present `rum`
+    /// namespace an omitted (`nil`) threshold disables the feature — matching the in-code configuration,
+    /// where a `nil` threshold disables it. Milliseconds are converted to seconds.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The threshold property to override.
+    ///   - milliseconds: The remote threshold in milliseconds, or `nil` to disable the feature.
+    private mutating func override(_ keyPath: WritableKeyPath<Self, TimeInterval?>, withMilliseconds milliseconds: Double?) {
+        self[keyPath: keyPath] = milliseconds.map { .ddFromMilliseconds(.ddWithNoOverflow($0)) }
     }
 
     /// Toggles resource tracking, which is modeled in-code as the presence of `urlSessionTracking`.

--- a/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
@@ -70,11 +70,28 @@ extension RUM.Configuration {
     /// enables that instrumentation: when the developer provided no `urlSessionTracking`, a default one
     /// is created to hold the tracing configuration. An existing `urlSessionTracking` keeps its other
     /// settings (e.g. resource attributes, header capture) — only its first-party hosts tracing is
-    /// replaced. A `trace` namespace without hosts describes nothing to instrument and is ignored.
+    /// replaced.
+    ///
+    /// The host list drives the outcome: a non-empty list configures (or replaces) trace propagation,
+    /// while an explicit empty list clears it — stopping header injection on an in-code
+    /// `urlSessionTracking` while leaving its other settings intact. When `tracedHosts` is omitted
+    /// (or the whole `trace` namespace is `nil`), nothing is described and the configuration is left
+    /// unchanged; likewise, an empty list is a no-op when no `urlSessionTracking` was configured in
+    /// code (there is nothing to clear).
     ///
     /// - Parameter trace: The `trace` namespace, or `nil` to leave the configuration unchanged.
     private mutating func apply(trace: RemoteConfiguration.Trace?) {
-        guard let firstPartyHostsTracing = trace.flatMap({ URLSessionTracking.FirstPartyHostsTracing($0) }) else {
+        guard let trace, let tracedHosts = trace.tracedHosts else {
+            return
+        }
+
+        // A non-empty list configures propagation; an explicit empty list clears it.
+        let firstPartyHostsTracing = tracedHosts.isEmpty
+            ? nil
+            : URLSessionTracking.FirstPartyHostsTracing(trace)
+
+        // An empty list has nothing to clear when no instrumentation was configured in code.
+        guard urlSessionTracking != nil || firstPartyHostsTracing != nil else {
             return
         }
 

--- a/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
@@ -1,0 +1,163 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+extension RUM.Configuration {
+    /// Merges the remote configuration on top of this in-code configuration.
+    ///
+    /// The `rum` namespace overrides the supported behavioral parameters, and the `trace` namespace
+    /// configures distributed tracing on RUM's network instrumentation. Remote values take precedence;
+    /// parameters absent from the remote configuration keep their in-code value, and passing `nil`
+    /// (no remote configuration available) leaves the configuration unchanged.
+    ///
+    /// The merge is applied once, at `RUM.enable(with:)` time. Live updates after initialization
+    /// are out of scope.
+    ///
+    /// - Parameter remoteConfiguration: The remote configuration, or `nil`.
+    mutating func apply(remoteConfiguration: RemoteConfiguration?) {
+        apply(rum: remoteConfiguration?.rum)
+
+        // Distributed tracing rides on RUM's network instrumentation, so an explicit
+        // `rum.trackResources == false` (resource tracking disabled) also suppresses trace instrumentation.
+        if remoteConfiguration?.rum?.trackResources != false {
+            apply(trace: remoteConfiguration?.trace)
+        }
+    }
+
+    /// Overrides the supported behavioral parameters from the `rum` namespace.
+    private mutating func apply(rum: RemoteConfiguration.RUM?) {
+        guard let rum else {
+            return
+        }
+
+        if let telemetrySampleRate = rum.telemetrySampleRate {
+            self.telemetrySampleRate = SampleRate(telemetrySampleRate)
+        }
+        if let trackAnonymousUser = rum.trackAnonymousUser {
+            self.trackAnonymousUser = trackAnonymousUser
+        }
+        if let trackBackgroundEvents = rum.trackBackgroundEvents {
+            self.trackBackgroundEvents = trackBackgroundEvents
+        }
+        if let trackFrustrations = rum.trackFrustrations {
+            self.trackFrustrations = trackFrustrations
+        }
+        if let longTaskThresholdMs = rum.longTaskThresholdMs {
+            self.longTaskThreshold = .ddFromMilliseconds(.ddWithNoOverflow(longTaskThresholdMs))
+        }
+        if let appHangThresholdMs = rum.appHangThresholdMs {
+            self.appHangThreshold = .ddFromMilliseconds(.ddWithNoOverflow(appHangThresholdMs))
+        }
+        if let trackSlowFrames = rum.trackSlowFrames {
+            self.trackSlowFrames = trackSlowFrames
+        }
+        if let trackWatchdogTerminations = rum.trackWatchdogTerminations {
+            self.trackWatchdogTerminations = trackWatchdogTerminations
+        }
+        if let vitalsUpdateFrequency = rum.vitalsUpdateFrequency {
+            self.vitalsUpdateFrequency = VitalsFrequency(vitalsUpdateFrequency)
+        }
+        // `trackResources` is modeled in-code as the presence of `urlSessionTracking`. Disabling
+        // turns off resource tracking; enabling installs a default configuration only when the
+        // developer did not provide one.
+        if let trackResources = rum.trackResources {
+            if !trackResources {
+                self.urlSessionTracking = nil
+            } else if self.urlSessionTracking == nil {
+                self.urlSessionTracking = .init()
+            }
+        }
+
+        #if !os(watchOS)
+        if let trackMemoryWarnings = rum.trackMemoryWarnings {
+            self.trackMemoryWarnings = trackMemoryWarnings
+        }
+
+        // `trackUserInteractions` is modeled in-code as the presence of action predicates. Disabling
+        // removes any action predicate; enabling installs the default UIKit actions predicate only
+        // when the developer did not provide any action predicate.
+        if let trackUserInteractions = rum.trackUserInteractions {
+            if !trackUserInteractions {
+                self.uiKitActionsPredicate = nil
+                self.swiftUIActionsPredicate = nil
+            } else if self.uiKitActionsPredicate == nil, self.swiftUIActionsPredicate == nil {
+                self.uiKitActionsPredicate = DefaultUIKitRUMActionsPredicate()
+            }
+        }
+        #endif
+    }
+
+    /// Configures distributed tracing for the `trace` namespace's first-party hosts.
+    ///
+    /// As tracing is carried by RUM's network instrumentation, providing traced hosts also enables
+    /// that instrumentation (creating a default `urlSessionTracking` when the developer set none).
+    private mutating func apply(trace: RemoteConfiguration.Trace?) {
+        guard let trace, let tracedHosts = trace.tracedHosts, !tracedHosts.isEmpty else {
+            return
+        }
+
+        let hosts = Set(tracedHosts)
+        let sampleRate = trace.sampleRate.map { SampleRate($0) } ?? .maxSampleRate
+        let traceControlInjection = trace.traceContextInjection.map { TraceContextInjection($0) } ?? .sampled
+
+        let firstPartyHostsTracing: URLSessionTracking.FirstPartyHostsTracing
+        if let tracingHeaderTypes = trace.tracingHeaderTypes, !tracingHeaderTypes.isEmpty {
+            let headerTypes = Set(tracingHeaderTypes.map { TracingHeaderType($0) })
+            firstPartyHostsTracing = .traceWithHeaders(
+                hostsWithHeaders: Dictionary(uniqueKeysWithValues: hosts.map { ($0, headerTypes) }),
+                sampleRate: sampleRate,
+                traceControlInjection: traceControlInjection
+            )
+        } else {
+            firstPartyHostsTracing = .trace(
+                hosts: hosts,
+                sampleRate: sampleRate,
+                traceControlInjection: traceControlInjection
+            )
+        }
+
+        var tracking = urlSessionTracking ?? .init()
+        tracking.firstPartyHostsTracing = firstPartyHostsTracing
+        urlSessionTracking = tracking
+    }
+}
+
+private extension RUM.Configuration.VitalsFrequency {
+    /// Maps a remote vitals update frequency onto the in-code `VitalsFrequency`.
+    /// `.never` disables vitals collection and therefore has no in-code equivalent (`nil`).
+    init?(_ remote: RemoteConfiguration.RUM.VitalsUpdateFrequency) {
+        switch remote {
+        case .frequent: self = .frequent
+        case .average: self = .average
+        case .rare: self = .rare
+        case .never: return nil
+        }
+    }
+}
+
+private extension TraceContextInjection {
+    /// Maps a remote trace context injection strategy onto the in-code `TraceContextInjection`.
+    init(_ remote: RemoteConfiguration.Trace.TraceContextInjection) {
+        switch remote {
+        case .all: self = .all
+        case .sampled: self = .sampled
+        }
+    }
+}
+
+private extension TracingHeaderType {
+    /// Maps a remote tracing header format onto the in-code `TracingHeaderType`.
+    init(_ remote: RemoteConfiguration.Trace.TracingHeaderTypes) {
+        switch remote {
+        case .datadog: self = .datadog
+        case .b3: self = .b3
+        case .b3multi: self = .b3multi
+        case .tracecontext: self = .tracecontext
+        }
+    }
+}

--- a/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
@@ -10,126 +10,158 @@ import DatadogInternal
 extension RUM.Configuration {
     /// Merges the remote configuration on top of this in-code configuration.
     ///
-    /// The `rum` namespace overrides the supported behavioral parameters, and the `trace` namespace
-    /// configures distributed tracing on RUM's network instrumentation. Remote values take precedence;
-    /// parameters absent from the remote configuration keep their in-code value, and passing `nil`
-    /// (no remote configuration available) leaves the configuration unchanged.
+    /// Two namespaces are consumed: `rum` overrides the supported behavioral parameters, and `trace`
+    /// configures distributed tracing on RUM's network instrumentation. Remote values take precedence,
+    /// while any parameter the remote configuration omits keeps its in-code value; passing `nil` (no
+    /// remote configuration was fetched) therefore leaves the configuration entirely unchanged.
     ///
-    /// The merge is applied once, at `RUM.enable(with:)` time. Live updates after initialization
-    /// are out of scope.
+    /// The two namespaces interact through RUM's URLSession instrumentation, which carries both
+    /// resource collection and trace propagation: an explicit `rum.trackResources == false` disables
+    /// that instrumentation, so it also suppresses `trace`, regardless of the hosts it declares.
     ///
-    /// - Parameter remoteConfiguration: The remote configuration, or `nil`.
+    /// The merge happens once, at `RUM.enable(with:)` time; live updates after initialization are out
+    /// of scope.
+    ///
+    /// - Parameter remoteConfiguration: The remote configuration to merge, or `nil` when none is
+    ///   available (leaving this configuration unchanged).
     mutating func apply(remoteConfiguration: RemoteConfiguration?) {
         apply(rum: remoteConfiguration?.rum)
 
-        // Distributed tracing rides on RUM's network instrumentation, so an explicit
-        // `rum.trackResources == false` (resource tracking disabled) also suppresses trace instrumentation.
         if remoteConfiguration?.rum?.trackResources != false {
             apply(trace: remoteConfiguration?.trace)
         }
     }
 
-    /// Overrides the supported behavioral parameters from the `rum` namespace.
+    /// Applies the `rum` namespace, overriding the supported behavioral parameters with their remote
+    /// values.
+    ///
+    /// Scalar and enum settings (sample rates, thresholds, tracking flags, vitals frequency) are
+    /// overridden directly. `trackResources` and `trackUserInteractions` have no direct in-code
+    /// equivalent — they are modeled as the presence of a tracking configuration / action predicate —
+    /// so they are toggled through the `override(_:with:)` overloads instead. Thresholds arrive in
+    /// milliseconds and are converted to seconds.
+    ///
+    /// - Parameter rum: The `rum` namespace, or `nil` to leave the configuration unchanged.
     private mutating func apply(rum: RemoteConfiguration.RUM?) {
         guard let rum else {
             return
         }
 
-        if let telemetrySampleRate = rum.telemetrySampleRate {
-            self.telemetrySampleRate = SampleRate(telemetrySampleRate)
-        }
-        if let trackAnonymousUser = rum.trackAnonymousUser {
-            self.trackAnonymousUser = trackAnonymousUser
-        }
-        if let trackBackgroundEvents = rum.trackBackgroundEvents {
-            self.trackBackgroundEvents = trackBackgroundEvents
-        }
-        if let trackFrustrations = rum.trackFrustrations {
-            self.trackFrustrations = trackFrustrations
-        }
-        if let longTaskThresholdMs = rum.longTaskThresholdMs {
-            self.longTaskThreshold = .ddFromMilliseconds(.ddWithNoOverflow(longTaskThresholdMs))
-        }
-        if let appHangThresholdMs = rum.appHangThresholdMs {
-            self.appHangThreshold = .ddFromMilliseconds(.ddWithNoOverflow(appHangThresholdMs))
-        }
-        if let trackSlowFrames = rum.trackSlowFrames {
-            self.trackSlowFrames = trackSlowFrames
-        }
-        if let trackWatchdogTerminations = rum.trackWatchdogTerminations {
-            self.trackWatchdogTerminations = trackWatchdogTerminations
-        }
-        if let vitalsUpdateFrequency = rum.vitalsUpdateFrequency {
-            self.vitalsUpdateFrequency = VitalsFrequency(vitalsUpdateFrequency)
-        }
-        // `trackResources` is modeled in-code as the presence of `urlSessionTracking`. Disabling
-        // turns off resource tracking; enabling installs a default configuration only when the
-        // developer did not provide one.
-        if let trackResources = rum.trackResources {
-            if !trackResources {
-                self.urlSessionTracking = nil
-            } else if self.urlSessionTracking == nil {
-                self.urlSessionTracking = .init()
-            }
-        }
-
+        override(\.telemetrySampleRate, with: rum.telemetrySampleRate.map { SampleRate($0) })
+        override(\.trackAnonymousUser, with: rum.trackAnonymousUser)
+        override(\.trackBackgroundEvents, with: rum.trackBackgroundEvents)
+        override(\.trackFrustrations, with: rum.trackFrustrations)
+        override(\.longTaskThreshold, with: rum.longTaskThresholdMs.map { .ddFromMilliseconds(.ddWithNoOverflow($0)) })
+        override(\.appHangThreshold, with: rum.appHangThresholdMs.map { .ddFromMilliseconds(.ddWithNoOverflow($0)) })
+        override(\.trackSlowFrames, with: rum.trackSlowFrames)
+        override(\.trackWatchdogTerminations, with: rum.trackWatchdogTerminations)
+        override(\.vitalsUpdateFrequency, with: rum.vitalsUpdateFrequency.map { VitalsFrequency($0) })
+        override(\.urlSessionTracking, with: rum.trackResources)
         #if !os(watchOS)
-        if let trackMemoryWarnings = rum.trackMemoryWarnings {
-            self.trackMemoryWarnings = trackMemoryWarnings
-        }
-
-        // `trackUserInteractions` is modeled in-code as the presence of action predicates. Disabling
-        // removes any action predicate; enabling installs the default UIKit actions predicate only
-        // when the developer did not provide any action predicate.
-        if let trackUserInteractions = rum.trackUserInteractions {
-            if !trackUserInteractions {
-                self.uiKitActionsPredicate = nil
-                self.swiftUIActionsPredicate = nil
-            } else if self.uiKitActionsPredicate == nil, self.swiftUIActionsPredicate == nil {
-                self.uiKitActionsPredicate = DefaultUIKitRUMActionsPredicate()
-            }
-        }
+        override(\.trackMemoryWarnings, with: rum.trackMemoryWarnings)
+        override(\.uiKitActionsPredicate, with: rum.trackUserInteractions)
+        override(\.swiftUIActionsPredicate, with: rum.trackUserInteractions)
         #endif
     }
 
-    /// Configures distributed tracing for the `trace` namespace's first-party hosts.
+    /// Applies the `trace` namespace, configuring distributed tracing for its first-party hosts.
     ///
-    /// As tracing is carried by RUM's network instrumentation, providing traced hosts also enables
-    /// that instrumentation (creating a default `urlSessionTracking` when the developer set none).
+    /// Trace propagation is carried by RUM's URLSession instrumentation, so configuring tracing also
+    /// enables that instrumentation: when the developer provided no `urlSessionTracking`, a default one
+    /// is created to hold the tracing configuration. An existing `urlSessionTracking` keeps its other
+    /// settings (e.g. resource attributes, header capture) — only its first-party hosts tracing is
+    /// replaced. A `trace` namespace without hosts describes nothing to instrument and is ignored.
+    ///
+    /// - Parameter trace: The `trace` namespace, or `nil` to leave the configuration unchanged.
     private mutating func apply(trace: RemoteConfiguration.Trace?) {
-        guard let trace, let tracedHosts = trace.tracedHosts, !tracedHosts.isEmpty else {
+        guard let firstPartyHostsTracing = trace.flatMap({ URLSessionTracking.FirstPartyHostsTracing($0) }) else {
             return
         }
 
-        let hosts = Set(tracedHosts)
-        let sampleRate = trace.sampleRate.map { SampleRate($0) } ?? .maxSampleRate
-        let traceControlInjection = trace.traceContextInjection.map { TraceContextInjection($0) } ?? .sampled
-
-        let firstPartyHostsTracing: URLSessionTracking.FirstPartyHostsTracing
-        if let tracingHeaderTypes = trace.tracingHeaderTypes, !tracingHeaderTypes.isEmpty {
-            let headerTypes = Set(tracingHeaderTypes.map { TracingHeaderType($0) })
-            firstPartyHostsTracing = .traceWithHeaders(
-                hostsWithHeaders: Dictionary(uniqueKeysWithValues: hosts.map { ($0, headerTypes) }),
-                sampleRate: sampleRate,
-                traceControlInjection: traceControlInjection
-            )
-        } else {
-            firstPartyHostsTracing = .trace(
-                hosts: hosts,
-                sampleRate: sampleRate,
-                traceControlInjection: traceControlInjection
-            )
-        }
-
-        var tracking = urlSessionTracking ?? .init()
+        var tracking = urlSessionTracking ?? URLSessionTracking()
         tracking.firstPartyHostsTracing = firstPartyHostsTracing
         urlSessionTracking = tracking
     }
+
+    /// Overrides the value at `keyPath` with `remoteValue` when it is present.
+    ///
+    /// The merge primitive for a setting that maps one-to-one onto a stored property: a present remote
+    /// value wins, an absent one (`nil`) leaves the in-code value untouched.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The configuration property to override.
+    ///   - remoteValue: The remote value to apply, or `nil` when the remote configuration omits it.
+    private mutating func override<Value>(_ keyPath: WritableKeyPath<Self, Value>, with remoteValue: Value?) {
+        if let remoteValue {
+            self[keyPath: keyPath] = remoteValue
+        }
+    }
+
+    /// Toggles resource tracking, which is modeled in-code as the presence of `urlSessionTracking`.
+    ///
+    /// - `true` keeps any developer-provided configuration, installing a default one only when none is
+    ///   set (so it never discards existing settings).
+    /// - `false` clears it, disabling resource tracking.
+    /// - `nil` leaves the current value untouched.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The `urlSessionTracking` property to toggle.
+    ///   - enabled: The remote `trackResources` flag, or `nil` when omitted.
+    private mutating func override(_ keyPath: WritableKeyPath<Self, URLSessionTracking?>, with enabled: Bool?) {
+        if let enabled {
+            self[keyPath: keyPath] = enabled
+                ? self[keyPath: keyPath] ?? URLSessionTracking()
+                : nil
+        }
+    }
+
+    #if !os(watchOS)
+    /// Toggles UIKit user-interaction tracking, which is modeled in-code as the presence of a UIKit
+    /// action predicate.
+    ///
+    /// - `true` keeps any developer-provided predicate, installing the default one only when none is
+    ///   set.
+    /// - `false` clears it, disabling UIKit action tracking.
+    /// - `nil` leaves the current value untouched.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The `uiKitActionsPredicate` property to toggle.
+    ///   - enabled: The remote `trackUserInteractions` flag, or `nil` when omitted.
+    private mutating func override(_ keyPath: WritableKeyPath<Self, UIKitRUMActionsPredicate?>, with enabled: Bool?) {
+        if let enabled {
+            self[keyPath: keyPath] = enabled
+                ? self[keyPath: keyPath] ?? DefaultUIKitRUMActionsPredicate()
+                : nil
+        }
+    }
+
+    /// Toggles SwiftUI user-interaction tracking, which is modeled in-code as the presence of a SwiftUI
+    /// action predicate.
+    ///
+    /// - `true` keeps any developer-provided predicate, installing the default one only when none is
+    ///   set.
+    /// - `false` clears it, disabling SwiftUI action tracking.
+    /// - `nil` leaves the current value untouched.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The `swiftUIActionsPredicate` property to toggle.
+    ///   - enabled: The remote `trackUserInteractions` flag, or `nil` when omitted.
+    private mutating func override(_ keyPath: WritableKeyPath<Self, SwiftUIRUMActionsPredicate?>, with enabled: Bool?) {
+        if let enabled {
+            self[keyPath: keyPath] = enabled
+                ? self[keyPath: keyPath] ?? DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true)
+                : nil
+        }
+    }
+    #endif
 }
 
 private extension RUM.Configuration.VitalsFrequency {
-    /// Maps a remote vitals update frequency onto the in-code `VitalsFrequency`.
-    /// `.never` disables vitals collection and therefore has no in-code equivalent (`nil`).
+    /// Creates the in-code vitals frequency matching a remote `vitalsUpdateFrequency`.
+    ///
+    /// - Parameter remote: The remote vitals update frequency.
+    /// - Returns: The matching `VitalsFrequency`, or `nil` for `.never` — which disables vitals
+    ///   collection and has no in-code equivalent.
     init?(_ remote: RemoteConfiguration.RUM.VitalsUpdateFrequency) {
         switch remote {
         case .frequent: self = .frequent
@@ -140,8 +172,45 @@ private extension RUM.Configuration.VitalsFrequency {
     }
 }
 
+private extension RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing {
+    /// Builds first-party hosts tracing configuration from a remote `trace` namespace.
+    ///
+    /// When header formats are provided they apply to every traced host (`.traceWithHeaders`);
+    /// otherwise the default trace headers are used (`.trace`). A missing sample rate defaults to
+    /// `.maxSampleRate` and a missing injection strategy to `.sampled`.
+    ///
+    /// - Parameter trace: The remote `trace` namespace.
+    /// - Returns: The tracing configuration, or `nil` when no hosts are provided (nothing to instrument).
+    init?(_ trace: RemoteConfiguration.Trace) {
+        guard let tracedHosts = trace.tracedHosts, !tracedHosts.isEmpty else {
+            return nil
+        }
+
+        let hosts = Set(tracedHosts)
+        let sampleRate = trace.sampleRate.map { SampleRate($0) } ?? .maxSampleRate
+        let traceControlInjection = trace.traceContextInjection.map { TraceContextInjection($0) } ?? .sampled
+
+        if let tracingHeaderTypes = trace.tracingHeaderTypes, !tracingHeaderTypes.isEmpty {
+            let headerTypes = Set(tracingHeaderTypes.map { TracingHeaderType($0) })
+            self = .traceWithHeaders(
+                hostsWithHeaders: Dictionary(uniqueKeysWithValues: hosts.map { ($0, headerTypes) }),
+                sampleRate: sampleRate,
+                traceControlInjection: traceControlInjection
+            )
+        } else {
+            self = .trace(
+                hosts: hosts,
+                sampleRate: sampleRate,
+                traceControlInjection: traceControlInjection
+            )
+        }
+    }
+}
+
 private extension TraceContextInjection {
     /// Maps a remote trace context injection strategy onto the in-code `TraceContextInjection`.
+    ///
+    /// - Parameter remote: The remote injection strategy.
     init(_ remote: RemoteConfiguration.Trace.TraceContextInjection) {
         switch remote {
         case .all: self = .all
@@ -152,6 +221,8 @@ private extension TraceContextInjection {
 
 private extension TracingHeaderType {
     /// Maps a remote tracing header format onto the in-code `TracingHeaderType`.
+    ///
+    /// - Parameter remote: The remote tracing header format.
     init(_ remote: RemoteConfiguration.Trace.TracingHeaderTypes) {
         switch remote {
         case .datadog: self = .datadog

--- a/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
@@ -69,35 +69,61 @@ extension RUM.Configuration {
     /// Trace propagation is carried by RUM's URLSession instrumentation, so configuring tracing also
     /// enables that instrumentation: when the developer provided no `urlSessionTracking`, a default one
     /// is created to hold the tracing configuration. An existing `urlSessionTracking` keeps its other
-    /// settings (e.g. resource attributes, header capture) — only its first-party hosts tracing is
-    /// replaced.
+    /// settings (e.g. resource attributes, header capture), and its first-party hosts tracing is merged
+    /// field by field — the remote hosts, sample rate, and injection strategy each replace the in-code
+    /// value only when present.
     ///
-    /// The host list drives the outcome: a non-empty list configures (or replaces) trace propagation,
+    /// The host list drives whether propagation exists: a non-empty list configures (or replaces) it,
     /// while an explicit empty list clears it — stopping header injection on an in-code
-    /// `urlSessionTracking` while leaving its other settings intact. When `tracedHosts` is omitted
-    /// (or the whole `trace` namespace is `nil`), nothing is described and the configuration is left
-    /// unchanged; likewise, an empty list is a no-op when no `urlSessionTracking` was configured in
-    /// code (there is nothing to clear).
+    /// `urlSessionTracking` while leaving its other settings intact. When `tracedHosts` is omitted, a
+    /// present sample rate / injection still updates existing propagation; an empty list is a no-op when
+    /// no `urlSessionTracking` was configured in code (there is nothing to clear).
     ///
     /// - Parameter trace: The `trace` namespace, or `nil` to leave the configuration unchanged.
     private mutating func apply(trace: RemoteConfiguration.Trace?) {
-        guard let trace, let tracedHosts = trace.tracedHosts else {
+        guard let trace else {
             return
         }
 
-        // A non-empty list configures propagation; an explicit empty list clears it.
-        let firstPartyHostsTracing = tracedHosts.isEmpty
-            ? nil
-            : URLSessionTracking.FirstPartyHostsTracing(trace)
+        // Resolve the tracing sample rate and injection strategy: a present remote value wins,
+        // otherwise the in-code value is kept, falling back to the module defaults when neither exists.
+        let existing = urlSessionTracking?.firstPartyHostsTracing
+        let sampleRate = trace.sampleRate.map { SampleRate($0) } ?? existing?.sampleRate ?? .maxSampleRate
+        let traceControlInjection = trace.traceContextInjection
+            .map { TraceContextInjection($0) } ?? existing?.traceControlInjection ?? .sampled
 
-        // An empty list has nothing to clear when no instrumentation was configured in code.
-        guard urlSessionTracking != nil || firstPartyHostsTracing != nil else {
-            return
+        switch trace.tracedHosts {
+        case .some(let tracedHosts) where !tracedHosts.isEmpty:
+            // A non-empty list configures (or replaces) propagation for the remote hosts.
+            var tracking = urlSessionTracking ?? URLSessionTracking()
+            tracking.firstPartyHostsTracing = URLSessionTracking.FirstPartyHostsTracing(
+                trace,
+                sampleRate: sampleRate,
+                traceControlInjection: traceControlInjection
+            )
+            urlSessionTracking = tracking
+
+        case .some:
+            // An explicit empty list clears propagation, keeping any other instrumentation settings;
+            // there is nothing to clear when no instrumentation was configured in code.
+            if var tracking = urlSessionTracking {
+                tracking.firstPartyHostsTracing = nil
+                urlSessionTracking = tracking
+            }
+
+        case .none:
+            // Hosts omitted: a present sample rate or injection strategy still updates existing
+            // propagation; without existing propagation there are no hosts to configure.
+            guard trace.sampleRate != nil || trace.traceContextInjection != nil,
+                  var tracking = urlSessionTracking,
+                  let firstPartyHostsTracing = tracking.firstPartyHostsTracing else {
+                return
+            }
+
+            tracking.firstPartyHostsTracing = firstPartyHostsTracing
+                .overriding(sampleRate: sampleRate, traceControlInjection: traceControlInjection)
+            urlSessionTracking = tracking
         }
-
-        var tracking = urlSessionTracking ?? URLSessionTracking()
-        tracking.firstPartyHostsTracing = firstPartyHostsTracing
-        urlSessionTracking = tracking
     }
 
     /// Overrides the value at `keyPath` with `remoteValue` when it is present.
@@ -190,22 +216,39 @@ private extension RUM.Configuration.VitalsFrequency {
 }
 
 private extension RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing {
-    /// Builds first-party hosts tracing configuration from a remote `trace` namespace.
+    /// The trace propagation sample rate carried by this configuration.
+    var sampleRate: SampleRate {
+        switch self {
+        case let .trace(_, sampleRate, _), let .traceWithHeaders(_, sampleRate, _):
+            return sampleRate
+        }
+    }
+
+    /// The trace context injection strategy carried by this configuration.
+    var traceControlInjection: TraceContextInjection {
+        switch self {
+        case let .trace(_, _, injection), let .traceWithHeaders(_, _, injection):
+            return injection
+        }
+    }
+
+    /// Builds first-party hosts tracing configuration for a remote `trace` namespace's hosts.
     ///
     /// When header formats are provided they apply to every traced host (`.traceWithHeaders`);
-    /// otherwise the default trace headers are used (`.trace`). A missing sample rate defaults to
-    /// `.maxSampleRate` and a missing injection strategy to `.sampled`.
+    /// otherwise the default trace headers are used (`.trace`). The sample rate and injection strategy
+    /// are resolved by the caller (remote value, else in-code value, else module default).
     ///
-    /// - Parameter trace: The remote `trace` namespace.
+    /// - Parameters:
+    ///   - trace: The remote `trace` namespace.
+    ///   - sampleRate: The resolved trace propagation sample rate.
+    ///   - traceControlInjection: The resolved trace context injection strategy.
     /// - Returns: The tracing configuration, or `nil` when no hosts are provided (nothing to instrument).
-    init?(_ trace: RemoteConfiguration.Trace) {
+    init?(_ trace: RemoteConfiguration.Trace, sampleRate: SampleRate, traceControlInjection: TraceContextInjection) {
         guard let tracedHosts = trace.tracedHosts, !tracedHosts.isEmpty else {
             return nil
         }
 
         let hosts = Set(tracedHosts)
-        let sampleRate = trace.sampleRate.map { SampleRate($0) } ?? .maxSampleRate
-        let traceControlInjection = trace.traceContextInjection.map { TraceContextInjection($0) } ?? .sampled
 
         if let tracingHeaderTypes = trace.tracingHeaderTypes, !tracingHeaderTypes.isEmpty {
             let headerTypes = Set(tracingHeaderTypes.map { TracingHeaderType($0) })
@@ -217,6 +260,27 @@ private extension RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing {
         } else {
             self = .trace(
                 hosts: hosts,
+                sampleRate: sampleRate,
+                traceControlInjection: traceControlInjection
+            )
+        }
+    }
+
+    /// Returns a copy overriding the sample rate and injection strategy while preserving the hosts and
+    /// any header formats.
+    ///
+    /// - Parameters:
+    ///   - sampleRate: The trace propagation sample rate to apply.
+    ///   - traceControlInjection: The trace context injection strategy to apply.
+    /// - Returns: A configuration with the same hosts (and header formats) but the given sample rate
+    ///   and injection strategy.
+    func overriding(sampleRate: SampleRate, traceControlInjection: TraceContextInjection) -> Self {
+        switch self {
+        case let .trace(hosts, _, _):
+            return .trace(hosts: hosts, sampleRate: sampleRate, traceControlInjection: traceControlInjection)
+        case let .traceWithHeaders(hostsWithHeaders, _, _):
+            return .traceWithHeaders(
+                hostsWithHeaders: hostsWithHeaders,
                 sampleRate: sampleRate,
                 traceControlInjection: traceControlInjection
             )

--- a/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
@@ -1,0 +1,183 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogInternal
+@testable import DatadogRUM
+
+class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
+    /// When there is no remote configuration (`nil`) or its namespaces carry no value, RUM must
+    /// behave exactly as configured in-code.
+    func testWhenNoRemoteValuesAreProvided_itLeavesConfigurationUnchanged() {
+        let baseline: RUM.Configuration = .mockRandom()
+
+        var withNilRemote = baseline
+        withNilRemote.apply(remoteConfiguration: nil)
+        DDAssertReflectionEqual(withNilRemote, baseline)
+
+        var withEmptyRemote = baseline
+        withEmptyRemote.apply(remoteConfiguration: .mockWith()) // every namespace absent
+        DDAssertReflectionEqual(withEmptyRemote, baseline)
+    }
+
+    /// A fully-populated remote `rum` namespace must override every mapped behavioral parameter,
+    /// regardless of the in-code baseline. Both the baseline and the remote are randomized and the
+    /// check repeated, so random enum/boolean values exercise every branch (e.g.
+    /// `vitalsUpdateFrequency == .never`, `trackResources == false`) over the run.
+    func testItOverridesEveryBehavioralParameterFromRemoteValues() throws {
+        for _ in 0..<100 {
+            // Given
+            let rum: RemoteConfiguration.RUM = .mockRandom()
+            var configuration: RUM.Configuration = .mockRandom()
+
+            // When
+            configuration.apply(remoteConfiguration: .mockWith(rum: rum))
+
+            // Then
+            XCTAssertEqual(configuration.telemetrySampleRate, SampleRate(try XCTUnwrap(rum.telemetrySampleRate)))
+            XCTAssertEqual(configuration.trackAnonymousUser, rum.trackAnonymousUser)
+            XCTAssertEqual(configuration.trackBackgroundEvents, rum.trackBackgroundEvents)
+            XCTAssertEqual(configuration.trackFrustrations, rum.trackFrustrations)
+            XCTAssertEqual(configuration.longTaskThreshold, .ddFromMilliseconds(.ddWithNoOverflow(try XCTUnwrap(rum.longTaskThresholdMs))))
+            XCTAssertEqual(configuration.appHangThreshold, .ddFromMilliseconds(.ddWithNoOverflow(try XCTUnwrap(rum.appHangThresholdMs))))
+            XCTAssertEqual(configuration.trackSlowFrames, rum.trackSlowFrames)
+            XCTAssertEqual(configuration.trackWatchdogTerminations, rum.trackWatchdogTerminations)
+            XCTAssertEqual(configuration.vitalsUpdateFrequency, expectedVitalsFrequency(try XCTUnwrap(rum.vitalsUpdateFrequency)))
+
+            // `trackResources` / `trackUserInteractions` are modeled as the presence of a tracking
+            // config / action predicate: enabling keeps whatever is set, disabling clears it. Either
+            // way, `presence == remote flag`.
+            XCTAssertEqual(configuration.urlSessionTracking != nil, try XCTUnwrap(rum.trackResources))
+            #if !os(watchOS)
+            XCTAssertEqual(configuration.trackMemoryWarnings, try XCTUnwrap(rum.trackMemoryWarnings))
+            XCTAssertEqual(configuration.uiKitActionsPredicate != nil, try XCTUnwrap(rum.trackUserInteractions))
+            #endif
+        }
+    }
+
+    /// `trackResources` / `trackUserInteractions` are modeled as the presence of a tracking config or
+    /// action predicate. When the remote enables them but the developer already provided one, the
+    /// in-code value must be preserved rather than replaced with a default.
+    func testWhenRemoteEnablesAlreadyConfiguredTracking_itPreservesInCodeValues() {
+        // Given
+        let customHost = "custom.example.com"
+        #if !os(watchOS)
+        let predicate = UIKitRUMActionsPredicateMock()
+        #endif
+
+        var configuration: RUM.Configuration = .mockWith { configuration in
+            configuration.urlSessionTracking = .init(firstPartyHostsTracing: .trace(hosts: [customHost]))
+            #if !os(watchOS)
+            configuration.uiKitActionsPredicate = predicate
+            #endif
+        }
+
+        // When
+        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(trackResources: true, trackUserInteractions: true)))
+
+        // Then
+        guard case let .trace(hosts, _, _) = configuration.urlSessionTracking?.firstPartyHostsTracing else {
+            return XCTFail("Expected in-code first-party hosts tracing to be preserved")
+        }
+        XCTAssertEqual(hosts, [customHost])
+        #if !os(watchOS)
+        XCTAssertIdentical(configuration.uiKitActionsPredicate as AnyObject, predicate)
+        #endif
+    }
+
+    // MARK: - Trace namespace (distributed tracing / network instrumentation)
+
+    /// The `trace` namespace must enable network instrumentation (even when none was configured
+    /// in-code) and set up distributed tracing for the given hosts. When header formats are provided,
+    /// they apply to every traced host.
+    func testWhenRemoteTraceProvidesHostsAndHeaderTypes_itConfiguresDistributedTracing() throws {
+        // Given no in-code network instrumentation
+        var configuration: RUM.Configuration = .mockWith { $0.urlSessionTracking = nil }
+        let remote: RemoteConfiguration = .mockWith(
+            trace: .init(
+                sampleRate: 55,
+                traceContextInjection: .all,
+                tracedHosts: ["api.example.com", "example.com"],
+                tracingHeaderTypes: [.datadog, .b3]
+            )
+        )
+
+        // When
+        configuration.apply(remoteConfiguration: remote)
+
+        // Then
+        guard case let .traceWithHeaders(hostsWithHeaders, sampleRate, injection) =
+            configuration.urlSessionTracking?.firstPartyHostsTracing else {
+            return XCTFail("Expected `.traceWithHeaders` first-party hosts tracing to be configured")
+        }
+        XCTAssertEqual(hostsWithHeaders, [
+            "api.example.com": [.datadog, .b3],
+            "example.com": [.datadog, .b3]
+        ])
+        XCTAssertEqual(sampleRate, 55)
+        XCTAssertEqual(injection, .all)
+    }
+
+    /// When the `trace` namespace provides hosts but no header formats, RUM falls back to the default
+    /// trace headers and the default sample rate / injection strategy.
+    func testWhenRemoteTraceProvidesHostsWithoutHeaderTypes_itUsesDefaultTraceHeaders() throws {
+        // Given no in-code network instrumentation
+        var configuration: RUM.Configuration = .mockWith { $0.urlSessionTracking = nil }
+        let remote: RemoteConfiguration = .mockWith(trace: .init(tracedHosts: ["example.com"]))
+
+        // When
+        configuration.apply(remoteConfiguration: remote)
+
+        // Then
+        guard case let .trace(hosts, sampleRate, injection) =
+            configuration.urlSessionTracking?.firstPartyHostsTracing else {
+            return XCTFail("Expected `.trace` first-party hosts tracing to be configured")
+        }
+        XCTAssertEqual(hosts, ["example.com"])
+        XCTAssertEqual(sampleRate, .maxSampleRate) // default when the remote omits `sampleRate`
+        XCTAssertEqual(injection, .sampled) // default when the remote omits `traceContextInjection`
+    }
+
+    /// A `trace` namespace without hosts has nothing to instrument and must leave the configuration's
+    /// network instrumentation untouched.
+    func testWhenRemoteTraceHasNoHosts_itLeavesNetworkInstrumentationUnchanged() {
+        var configuration: RUM.Configuration = .mockWith { $0.urlSessionTracking = nil }
+
+        configuration.apply(remoteConfiguration: .mockWith(trace: .init(sampleRate: 42, tracedHosts: nil)))
+
+        XCTAssertNil(configuration.urlSessionTracking)
+    }
+
+    /// An explicit `rum.trackResources == false` disables resource tracking regardless, so it must
+    /// suppress trace instrumentation even when the `trace` namespace provides hosts.
+    func testWhenRemoteTrackResourcesIsFalse_itSuppressesTraceInstrumentation() {
+        var configuration: RUM.Configuration = .mockWith { $0.urlSessionTracking = nil }
+
+        configuration.apply(
+            remoteConfiguration: .mockWith(
+                rum: .mockWith(trackResources: false),
+                trace: .init(tracedHosts: ["example.com"])
+            )
+        )
+
+        XCTAssertNil(configuration.urlSessionTracking)
+    }
+
+    // MARK: - Helpers
+
+    /// The independent oracle for the `vitalsUpdateFrequency` mapping (`.never` disables vitals).
+    private func expectedVitalsFrequency(
+        _ remote: RemoteConfiguration.RUM.VitalsUpdateFrequency
+    ) -> RUM.Configuration.VitalsFrequency? {
+        switch remote {
+        case .frequent: return .frequent
+        case .average: return .average
+        case .rare: return .rare
+        case .never: return nil
+        }
+    }
+}

--- a/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
@@ -252,6 +252,16 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
         XCTAssertNil(configuration.longTaskThreshold)
     }
 
+    /// A remote `vitalsUpdateFrequency == .never` disables vitals collection: `VitalsFrequency.init?`
+    /// maps `.never` to `nil`, which clears the in-code value even when vitals were enabled in code.
+    func testWhenRemoteVitalsUpdateFrequencyIsNever_itDisablesVitalsCollection() {
+        var configuration: RUM.Configuration = .mockWith { $0.vitalsUpdateFrequency = .average }
+
+        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(vitalsUpdateFrequency: .never)))
+
+        XCTAssertNil(configuration.vitalsUpdateFrequency)
+    }
+
     // MARK: - Helpers
 
     /// The independent oracle for the `vitalsUpdateFrequency` mapping (`.never` disables vitals).

--- a/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
@@ -152,6 +152,29 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
         XCTAssertNil(configuration.urlSessionTracking)
     }
 
+    /// An explicit empty host list means "stop propagating traces": it must clear the in-code
+    /// first-party hosts tracing while keeping the rest of the network instrumentation.
+    func testWhenRemoteTraceHasEmptyHosts_itClearsInCodeTracing() {
+        var configuration: RUM.Configuration = .mockWith {
+            $0.urlSessionTracking = .init(firstPartyHostsTracing: .trace(hosts: ["custom.example.com"]))
+        }
+
+        configuration.apply(remoteConfiguration: .mockWith(trace: .init(tracedHosts: [])))
+
+        XCTAssertNotNil(configuration.urlSessionTracking)
+        XCTAssertNil(configuration.urlSessionTracking?.firstPartyHostsTracing)
+    }
+
+    /// An explicit empty host list has nothing to clear when no network instrumentation was configured
+    /// in-code, so the configuration must stay untouched (no default instrumentation is installed).
+    func testWhenRemoteTraceHasEmptyHostsAndNoInCodeInstrumentation_itLeavesConfigurationUnchanged() {
+        var configuration: RUM.Configuration = .mockWith { $0.urlSessionTracking = nil }
+
+        configuration.apply(remoteConfiguration: .mockWith(trace: .init(tracedHosts: [])))
+
+        XCTAssertNil(configuration.urlSessionTracking)
+    }
+
     /// An explicit `rum.trackResources == false` disables resource tracking regardless, so it must
     /// suppress trace instrumentation even when the `trace` namespace provides hosts.
     func testWhenRemoteTrackResourcesIsFalse_itSuppressesTraceInstrumentation() {

--- a/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
@@ -175,6 +175,44 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
         XCTAssertNil(configuration.urlSessionTracking)
     }
 
+    /// When remote hosts are provided but the sample rate / injection strategy are omitted, the merge
+    /// must keep the in-code values for those fields rather than falling back to the module defaults.
+    func testWhenRemoteTraceProvidesHostsWithoutSampleRateOrInjection_itPreservesInCodeValues() {
+        var configuration: RUM.Configuration = .mockWith {
+            $0.urlSessionTracking = .init(
+                firstPartyHostsTracing: .trace(hosts: ["in-code.example.com"], sampleRate: 30, traceControlInjection: .all)
+            )
+        }
+
+        configuration.apply(remoteConfiguration: .mockWith(trace: .init(tracedHosts: ["remote.example.com"])))
+
+        guard case let .trace(hosts, sampleRate, injection) = configuration.urlSessionTracking?.firstPartyHostsTracing else {
+            return XCTFail("Expected `.trace` first-party hosts tracing to be configured")
+        }
+        XCTAssertEqual(hosts, ["remote.example.com"])
+        XCTAssertEqual(sampleRate, 30)
+        XCTAssertEqual(injection, .all)
+    }
+
+    /// When the remote omits hosts but provides a sample rate, the existing first-party hosts tracing
+    /// must have its propagation sample rate updated (its hosts and injection strategy are preserved).
+    func testWhenRemoteTraceProvidesOnlySampleRate_itUpdatesExistingTracingSampleRate() {
+        var configuration: RUM.Configuration = .mockWith {
+            $0.urlSessionTracking = .init(
+                firstPartyHostsTracing: .trace(hosts: ["in-code.example.com"], sampleRate: 20, traceControlInjection: .all)
+            )
+        }
+
+        configuration.apply(remoteConfiguration: .mockWith(trace: .mockWith(sampleRate: 0, tracedHosts: nil)))
+
+        guard case let .trace(hosts, sampleRate, injection) = configuration.urlSessionTracking?.firstPartyHostsTracing else {
+            return XCTFail("Expected `.trace` first-party hosts tracing to be configured")
+        }
+        XCTAssertEqual(hosts, ["in-code.example.com"])
+        XCTAssertEqual(sampleRate, 0)
+        XCTAssertEqual(injection, .all)
+    }
+
     /// An explicit `rum.trackResources == false` disables resource tracking regardless, so it must
     /// suppress trace instrumentation even when the `trace` namespace provides hosts.
     func testWhenRemoteTrackResourcesIsFalse_itSuppressesTraceInstrumentation() {

--- a/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
@@ -228,6 +228,30 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
         XCTAssertNil(configuration.urlSessionTracking)
     }
 
+    /// `appHangThresholdMs` follows "omit to disable" semantics: within a present `rum` namespace, an
+    /// omitted value clears the in-code `appHangThreshold`, disabling app-hang monitoring — even though
+    /// it was enabled in code.
+    func testWhenRemoteRUMOmitsAppHangThreshold_itDisablesAppHangMonitoring() {
+        var configuration: RUM.Configuration = .mockWith { $0.appHangThreshold = 0.25 }
+
+        // A present `rum` namespace that does not carry `appHangThresholdMs`.
+        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(appHangThresholdMs: nil)))
+
+        XCTAssertNil(configuration.appHangThreshold)
+    }
+
+    /// `longTaskThresholdMs` follows "omit to disable" semantics: within a present `rum` namespace, an
+    /// omitted value clears the in-code `longTaskThreshold`, disabling long-task tracking — even though
+    /// it was enabled in code.
+    func testWhenRemoteRUMOmitsLongTaskThreshold_itDisablesLongTaskTracking() {
+        var configuration: RUM.Configuration = .mockWith { $0.longTaskThreshold = 0.5 }
+
+        // A present `rum` namespace that does not carry `longTaskThresholdMs`.
+        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(longTaskThresholdMs: nil)))
+
+        XCTAssertNil(configuration.longTaskThreshold)
+    }
+
     // MARK: - Helpers
 
     /// The independent oracle for the `vitalsUpdateFrequency` mapping (`.never` disables vitals).

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -405,6 +405,84 @@ class RUMTests: XCTestCase {
         XCTAssertEqual(telemetryReceiver?.configurationExtraSampler.samplingRate, 20)
     }
 
+    // MARK: - Remote Configuration
+
+    func testWhenEnabled_itAppliesRemoteConfigurationOnTopOfInCodeConfiguration() throws {
+        // Given
+        config = RUM.Configuration(applicationID: .mockRandom())
+        config.trackBackgroundEvents = false
+        core.remoteConfiguration = RemoteConfiguration(
+            rum: .init(applicationId: .mockRandom(), trackBackgroundEvents: true)
+        )
+
+        // When
+        RUM.enable(with: config, in: core)
+
+        // Then
+        let monitor = try XCTUnwrap(RUMMonitor.shared(in: core) as? Monitor)
+        XCTAssertTrue(
+            monitor.scopes.dependencies.trackBackgroundEvents,
+            "Remote `trackBackgroundEvents` must override the in-code value at enable time"
+        )
+    }
+
+    func testWhenEnabledWithNoRemoteConfiguration_itUsesInCodeConfiguration() throws {
+        // Given
+        config = RUM.Configuration(applicationID: .mockRandom())
+        config.trackBackgroundEvents = true
+        core.remoteConfiguration = nil
+
+        // When
+        RUM.enable(with: config, in: core)
+
+        // Then
+        let monitor = try XCTUnwrap(RUMMonitor.shared(in: core) as? Monitor)
+        XCTAssertTrue(
+            monitor.scopes.dependencies.trackBackgroundEvents,
+            "Without remote configuration, RUM must behave exactly as configured in-code"
+        )
+    }
+
+    func testWhenEnabledWithRemoteTrackResources_itEnablesNetworkInstrumentation() throws {
+        // Given
+        config = RUM.Configuration(applicationID: .mockRandom())
+        config.urlSessionTracking = nil
+        core.remoteConfiguration = RemoteConfiguration(
+            rum: .init(applicationId: .mockRandom(), trackResources: true)
+        )
+
+        // When
+        RUM.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNotNil(
+            core.get(feature: NetworkInstrumentationFeature.self),
+            "Remote `trackResources` must enable `NetworkInstrumentationFeature` at enable time"
+        )
+    }
+
+    func testWhenEnabledWithRemoteTrace_itEnablesNetworkInstrumentation() throws {
+        // Given
+        config = RUM.Configuration(applicationID: .mockRandom())
+        config.urlSessionTracking = nil
+        core.remoteConfiguration = RemoteConfiguration(
+            trace: .init(tracedHosts: ["example.com"])
+        )
+
+        // When
+        RUM.enable(with: config, in: core)
+
+        // Then
+        let networkInstrumentation = try XCTUnwrap(
+            core.get(feature: NetworkInstrumentationFeature.self),
+            "Remote `trace` must enable `NetworkInstrumentationFeature` at enable time"
+        )
+        let urlSessionHandler = try XCTUnwrap(
+            networkInstrumentation.handlers.firstElement(of: URLSessionRUMResourcesHandler.self)
+        )
+        XCTAssertEqual(urlSessionHandler.distributedTracing?.firstPartyHosts.hosts, ["example.com"])
+    }
+
     // MARK: - Behaviour Tests
 
     func testWhenEnabled_itSetsRUMContextInCore() throws {

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RemoteConfigurationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RemoteConfigurationMocks.swift
@@ -15,7 +15,7 @@ extension RemoteConfiguration: AnyMockable, RandomMockable {
     public static func mockRandom() -> RemoteConfiguration {
         .init(
             profiling: .mockRandom(),
-            rum: nil,
+            rum: .mockRandom(),
             sessionReplay: nil,
             trace: nil
         )
@@ -60,5 +60,77 @@ extension RemoteConfiguration.Profiling: AnyMockable, RandomMockable {
             applicationLaunchSampleRate: applicationLaunchSampleRate,
             continuousSampleRate: continuousSampleRate
         )
+    }
+}
+
+extension RemoteConfiguration.RUM: AnyMockable, RandomMockable {
+    public static func mockAny() -> RemoteConfiguration.RUM {
+        mockWith()
+    }
+
+    /// Builds a `rum` namespace with **every** field populated with a random, non-`nil` value.
+    ///
+    /// Keeping all fields populated is what lets the exhaustiveness guard in
+    /// `RUMConfiguration_RemoteConfigurationTests` detect any newly generated schema field.
+    public static func mockRandom() -> RemoteConfiguration.RUM {
+        .init(
+            appHangThresholdMs: .mockRandom(min: 100, max: 5_000),
+            applicationId: .mockRandom(),
+            env: .mockRandom(),
+            longTaskThresholdMs: .mockRandom(min: 100, max: 5_000),
+            service: .mockRandom(),
+            telemetrySampleRate: .mockRandom(min: 0, max: 100),
+            trackAnonymousUser: .mockRandom(),
+            trackBackgroundEvents: .mockRandom(),
+            trackFrustrations: .mockRandom(),
+            trackMemoryWarnings: .mockRandom(),
+            trackResources: .mockRandom(),
+            trackSlowFrames: .mockRandom(),
+            trackUserInteractions: .mockRandom(),
+            trackWatchdogTerminations: .mockRandom(),
+            vitalsUpdateFrequency: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        appHangThresholdMs: Double? = nil,
+        applicationId: String = .mockAny(),
+        env: String? = nil,
+        longTaskThresholdMs: Double? = nil,
+        service: String? = nil,
+        telemetrySampleRate: Double? = nil,
+        trackAnonymousUser: Bool? = nil,
+        trackBackgroundEvents: Bool? = nil,
+        trackFrustrations: Bool? = nil,
+        trackMemoryWarnings: Bool? = nil,
+        trackResources: Bool? = nil,
+        trackSlowFrames: Bool? = nil,
+        trackUserInteractions: Bool? = nil,
+        trackWatchdogTerminations: Bool? = nil,
+        vitalsUpdateFrequency: RemoteConfiguration.RUM.VitalsUpdateFrequency? = nil
+    ) -> RemoteConfiguration.RUM {
+        .init(
+            appHangThresholdMs: appHangThresholdMs,
+            applicationId: applicationId,
+            env: env,
+            longTaskThresholdMs: longTaskThresholdMs,
+            service: service,
+            telemetrySampleRate: telemetrySampleRate,
+            trackAnonymousUser: trackAnonymousUser,
+            trackBackgroundEvents: trackBackgroundEvents,
+            trackFrustrations: trackFrustrations,
+            trackMemoryWarnings: trackMemoryWarnings,
+            trackResources: trackResources,
+            trackSlowFrames: trackSlowFrames,
+            trackUserInteractions: trackUserInteractions,
+            trackWatchdogTerminations: trackWatchdogTerminations,
+            vitalsUpdateFrequency: vitalsUpdateFrequency
+        )
+    }
+}
+
+extension RemoteConfiguration.RUM.VitalsUpdateFrequency: RandomMockable {
+    public static func mockRandom() -> RemoteConfiguration.RUM.VitalsUpdateFrequency {
+        [.frequent, .average, .rare, .never].randomElement()!
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RemoteConfigurationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RemoteConfigurationMocks.swift
@@ -134,3 +134,48 @@ extension RemoteConfiguration.RUM.VitalsUpdateFrequency: RandomMockable {
         [.frequent, .average, .rare, .never].randomElement()!
     }
 }
+
+extension RemoteConfiguration.Trace: AnyMockable, RandomMockable {
+    public static func mockAny() -> RemoteConfiguration.Trace {
+        mockWith()
+    }
+
+    /// Builds a `trace` namespace with **every** field populated with a random, non-`nil` value.
+    ///
+    /// Keeping all fields populated is what lets the exhaustiveness guard in
+    /// `TraceConfiguration_RemoteConfigurationTests` detect any newly generated schema field.
+    public static func mockRandom() -> RemoteConfiguration.Trace {
+        .init(
+            sampleRate: .mockRandom(min: 0, max: 100),
+            traceContextInjection: .mockRandom(),
+            tracedHosts: ["api.example.com", "example.com"],
+            tracingHeaderTypes: [.mockRandom()]
+        )
+    }
+
+    public static func mockWith(
+        sampleRate: Double? = nil,
+        traceContextInjection: RemoteConfiguration.Trace.TraceContextInjection? = nil,
+        tracedHosts: [String]? = nil,
+        tracingHeaderTypes: [RemoteConfiguration.Trace.TracingHeaderTypes]? = nil
+    ) -> RemoteConfiguration.Trace {
+        .init(
+            sampleRate: sampleRate,
+            traceContextInjection: traceContextInjection,
+            tracedHosts: tracedHosts,
+            tracingHeaderTypes: tracingHeaderTypes
+        )
+    }
+}
+
+extension RemoteConfiguration.Trace.TraceContextInjection: RandomMockable {
+    public static func mockRandom() -> RemoteConfiguration.Trace.TraceContextInjection {
+        [.all, .sampled].randomElement()!
+    }
+}
+
+extension RemoteConfiguration.Trace.TracingHeaderTypes: RandomMockable {
+    public static func mockRandom() -> RemoteConfiguration.Trace.TracingHeaderTypes {
+        [.datadog, .b3, .b3multi, .tracecontext].randomElement()!
+    }
+}


### PR DESCRIPTION
### What and why?

Part of the Mobile Remote Configuration RFC (RUM-16416). When `RUM.enable(with:)` is called, RUM now reads the remote configuration cached by Core and merges it on top of the developer's in-code `RUM.Configuration`.

Remote values take precedence for the supported parameters. If no remote configuration is available, RUM behaves exactly as today.

### How?

`RUM.Configuration.apply(remoteConfiguration:)` merges two namespaces at enable time:

- **`rum`** — overrides behavioral settings (sample rates, tracking flags, thresholds, vitals frequency).
- **`trace`** — sets up distributed tracing on the traced hosts, enabling RUM's network instrumentation.

The merge runs once at enablement; live updates are out of scope.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — N/A, targets `feature/remote-config`; CHANGELOG lands when the feature merges to `develop`
- [ ] Add Objective-C interface for public APIs — N/A, no new public API
- [ ] Run `make api-surface` when adding new APIs — N/A, no new public API

_Target branch: `feature/remote-config` (not `develop`), per RUM-16416._