### PR TITLE
RUM-14250: Add profiling context to RUM view events

### DIFF
--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -565,6 +565,7 @@ extension RUMViewScope {
 
         // Retrieve Session Replay config if any
         let sessionReplayConfig = context.additionalContext(ofType: SessionReplayCoreContext.Configuration.self)
+        let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
 
         let viewEvent = RUMViewEvent(
             dd: .init(
@@ -578,6 +579,7 @@ extension RUMViewScope {
                 ),
                 documentVersion: version.toInt64,
                 pageStates: nil,
+                profiling: profiling,
                 replayStats: .init(
                     recordsCount: context.recordsCountByViewID[viewUUID.toRUMDataFormat],
                     segmentsCount: nil,

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -332,6 +332,52 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.os?.build, "os-build")
     }
 
+    func testWhenViewIsStartedAndStoppedWithProfilingContext_itSendsViewUpdateEventsWithProfiling() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let quotaReason: DDProfiling.QuotaReason = .mockRandom()
+        var context = self.context
+        context.set(additionalContext: ProfilingContext(status: .running, quotaReason: quotaReason))
+
+        let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
+            parent: parent,
+            dependencies: .mockAny(),
+            identity: .mockViewIdentifier(),
+            path: "UIViewController",
+            name: "ViewName",
+            customTimings: [:],
+            startTime: currentTime,
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: INVMetricMock(),
+            viewIndexInSession: .mockAny()
+        )
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
+                context: context,
+                writer: writer
+            )
+        )
+
+        currentTime.addTimeInterval(2)
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
+                context: context,
+                writer: writer
+            )
+        )
+
+        let viewEvents = writer.events(ofType: RUMViewEvent.self)
+        XCTAssertEqual(viewEvents.count, 2)
+        viewEvents.forEach { viewEvent in
+            XCTAssertEqual(viewEvent.dd.profiling?.status, .running)
+            XCTAssertEqual(viewEvent.dd.profiling?.quotaReason, quotaReason)
+            XCTAssertNil(viewEvent.dd.profiling?.errorReason)
+        }
+    }
+
     func testWhenViewIsStopped_itMakesAttributesImmutable() throws {
         // Given
         var currentTime: Date = .mockDecember15th2019At10AMUTC()


### PR DESCRIPTION
### What and why?

This PR adds profiling context to RUM view events, following the same strategy used for other RUM events (operations, long tasks, app hangs).

### How?

It reads `ProfilingContext` when building `RUMViewEvent` and passes its profiling info into `RUMViewEvent.DD`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
