### PR TITLE
[RUM-17195] Apply remote configuration to Session Replay module at enablement

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -869,6 +869,8 @@
 		D2023AA02FFE64CE00A80981 /* ProfilingConfiguration+RemoteConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A9F2FFE64CE00A80981 /* ProfilingConfiguration+RemoteConfigurationTests.swift */; };
 		D2023A872FFBE06800A80981 /* RUMConfiguration+RemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A862FFBE06800A80981 /* RUMConfiguration+RemoteConfiguration.swift */; };
 		D2023A892FFBE09C00A80981 /* RUMConfiguration+RemoteConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A882FFBE09C00A80981 /* RUMConfiguration+RemoteConfigurationTests.swift */; };
+		D2023A8D2FFE588C00A80981 /* SessionReplayConfiguration+RemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A8C2FFE588C00A80981 /* SessionReplayConfiguration+RemoteConfiguration.swift */; };
+		D2023A942FFE59C500A80981 /* SessionReplayConfiguration+RemoteConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2023A932FFE59C500A80981 /* SessionReplayConfiguration+RemoteConfigurationTests.swift */; };
 		D2056C212BBFE05A0085BC76 /* WireframesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2056C202BBFE05A0085BC76 /* WireframesBuilderTests.swift */; };
 		D20605A3287464F40047275C /* ContextValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A2287464F40047275C /* ContextValuePublisher.swift */; };
 		D20605A6287476230047275C /* ServerOffsetPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605A5287476230047275C /* ServerOffsetPublisher.swift */; };
@@ -2804,6 +2806,8 @@
 		D2023A9F2FFE64CE00A80981 /* ProfilingConfiguration+RemoteConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfilingConfiguration+RemoteConfigurationTests.swift"; sourceTree = "<group>"; };
 		D2023A862FFBE06800A80981 /* RUMConfiguration+RemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMConfiguration+RemoteConfiguration.swift"; sourceTree = "<group>"; };
 		D2023A882FFBE09C00A80981 /* RUMConfiguration+RemoteConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMConfiguration+RemoteConfigurationTests.swift"; sourceTree = "<group>"; };
+		D2023A8C2FFE588C00A80981 /* SessionReplayConfiguration+RemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionReplayConfiguration+RemoteConfiguration.swift"; sourceTree = "<group>"; };
+		D2023A932FFE59C500A80981 /* SessionReplayConfiguration+RemoteConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionReplayConfiguration+RemoteConfigurationTests.swift"; sourceTree = "<group>"; };
 		D2056C202BBFE05A0085BC76 /* WireframesBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireframesBuilderTests.swift; sourceTree = "<group>"; };
 		D20605A2287464F40047275C /* ContextValuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextValuePublisher.swift; sourceTree = "<group>"; };
 		D20605A5287476230047275C /* ServerOffsetPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerOffsetPublisher.swift; sourceTree = "<group>"; };
@@ -4039,6 +4043,8 @@
 				61054E132A6EE10A00AAA894 /* Utilities */,
 				A7B932F62B1F6A0A00AE6477 /* Models */,
 				61054E032A6EE10A00AAA894 /* Writers */,
+				D2023A8C2FFE588C00A80981 /* SessionReplayConfiguration+RemoteConfiguration.swift */,
+				D2023A902FFE598200A80981 /* Tests */,
 			);
 			name = DatadogSessionReplay;
 			path = ../DatadogSessionReplay/Sources;
@@ -4061,6 +4067,7 @@
 				61054F3D2A6EE1B900AAA894 /* SessionReplayConfigurationTests.swift */,
 				D2A434AD2A8E426C0028E329 /* DDSessionReplayTests.swift */,
 				96E863752C9C7E800023BF78 /* DDSessionReplayOverridesTests.swift */,
+				D2023A932FFE59C500A80981 /* SessionReplayConfiguration+RemoteConfigurationTests.swift */,
 			);
 			name = DatadogSessionReplayTests;
 			path = ../DatadogSessionReplay/Tests;
@@ -6100,6 +6107,13 @@
 				5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */,
 			);
 			path = LayerTreeRecorder;
+			sourceTree = "<group>";
+		};
+		D2023A902FFE598200A80981 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		D207317D29A5226A00ECBF94 /* DatadogLogs */ = {
@@ -8396,6 +8410,7 @@
 				61054E802A6EE10A00AAA894 /* UIPickerViewRecorder.swift in Sources */,
 				61054E612A6EE10A00AAA894 /* SRCompression.swift in Sources */,
 				B73450212F9F200100000001 /* LayerRecording.swift in Sources */,
+				D2023A8D2FFE588C00A80981 /* SessionReplayConfiguration+RemoteConfiguration.swift in Sources */,
 				5BB771B42FE9848900C95960 /* WKWebView+SessionReplay.swift in Sources */,
 				5BF2BC772FC4D8E0000E999C /* LayerProvider.swift in Sources */,
 				5B1877CB2FDC4737005AC2CE /* UIImage+Redaction.swift in Sources */,
@@ -8582,6 +8597,7 @@
 				5B69166F2F3B89060074A909 /* TestTimerScheduler.swift in Sources */,
 				61054FAF2A6EE1BA00AAA894 /* ViewTreeRecordingContextTests.swift in Sources */,
 				61054FB92A6EE1BA00AAA894 /* UINavigationBarRecorderTests.swift in Sources */,
+				D2023A942FFE59C500A80981 /* SessionReplayConfiguration+RemoteConfigurationTests.swift in Sources */,
 				61054FA62A6EE1BA00AAA894 /* SnapshotProcessorTests.swift in Sources */,
 				61054FB72A6EE1BA00AAA894 /* UISegmentRecorderTests.swift in Sources */,
 				5B74483C2EFAEFC3003E622C /* CALayerObserverMock.swift in Sources */,

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -81,6 +81,13 @@ public enum SessionReplay {
             )
         }
 
+        // Merge remote configuration on top of the in-code configuration. Remote values take
+        // precedence for supported behavioral parameters; if no remote configuration is available,
+        // the in-code configuration is used unchanged. Applied before the sample-rate guard so a
+        // remote `sampleRate` can enable or disable recording.
+        var configuration = configuration
+        configuration.apply(remoteConfiguration: core.remoteConfiguration)
+
         guard configuration.replaySampleRate > 0 else {
             return
         }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration+RemoteConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration+RemoteConfiguration.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
+#if os(iOS)
 import Foundation
 import DatadogInternal
 
@@ -96,3 +97,5 @@ private extension TouchPrivacyLevel {
         }
     }
 }
+
+#endif

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration+RemoteConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration+RemoteConfiguration.swift
@@ -1,0 +1,98 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+extension SessionReplay.Configuration {
+    /// Merges the remote configuration on top of this in-code configuration.
+    ///
+    /// The `sessionReplay` namespace overrides the supported behavioral parameters: sample rate, the
+    /// three privacy levels, and whether recording starts immediately. Remote values take precedence,
+    /// while any parameter the remote configuration omits keeps its in-code value; passing `nil` (no
+    /// remote configuration was fetched) therefore leaves the configuration entirely unchanged.
+    ///
+    /// The merge happens once, at `SessionReplay.enable(with:)` time; live updates after initialization
+    /// are out of scope.
+    ///
+    /// - Parameter remoteConfiguration: The remote configuration to merge, or `nil` when none is
+    ///   available (leaving this configuration unchanged).
+    mutating func apply(remoteConfiguration: RemoteConfiguration?) {
+        apply(sessionReplay: remoteConfiguration?.sessionReplay)
+    }
+
+    /// Applies the `sessionReplay` namespace, overriding the supported behavioral parameters with their
+    /// remote values.
+    ///
+    /// Scalar and enum settings are overridden directly; the privacy enums are translated from their
+    /// remote representation to the in-code one. A missing field leaves the in-code value untouched.
+    ///
+    /// - Parameter sessionReplay: The `sessionReplay` namespace, or `nil` to leave the configuration
+    ///   unchanged.
+    private mutating func apply(sessionReplay: RemoteConfiguration.SessionReplay?) {
+        guard let sessionReplay else {
+            return
+        }
+
+        override(\.replaySampleRate, with: sessionReplay.sampleRate.map { SampleRate($0) })
+        override(\.startRecordingImmediately, with: sessionReplay.startRecordingImmediately)
+        override(\.textAndInputPrivacyLevel, with: sessionReplay.textAndInputPrivacy.map { TextAndInputPrivacyLevel($0) })
+        override(\.imagePrivacyLevel, with: sessionReplay.imagePrivacy.map { ImagePrivacyLevel($0) })
+        override(\.touchPrivacyLevel, with: sessionReplay.touchPrivacy.map { TouchPrivacyLevel($0) })
+    }
+
+    /// Overrides the value at `keyPath` with `remoteValue` when it is present.
+    ///
+    /// The merge primitive for a setting that maps one-to-one onto a stored property: a present remote
+    /// value wins, an absent one (`nil`) leaves the in-code value untouched.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The configuration property to override.
+    ///   - remoteValue: The remote value to apply, or `nil` when the remote configuration omits it.
+    private mutating func override<Value>(_ keyPath: WritableKeyPath<Self, Value>, with remoteValue: Value?) {
+        if let remoteValue {
+            self[keyPath: keyPath] = remoteValue
+        }
+    }
+}
+
+private extension TextAndInputPrivacyLevel {
+    /// Maps a remote text-and-input privacy level onto the in-code `TextAndInputPrivacyLevel`.
+    ///
+    /// - Parameter remote: The remote text-and-input privacy level.
+    init(_ remote: RemoteConfiguration.SessionReplay.TextAndInputPrivacy) {
+        switch remote {
+        case .maskSensitiveInputs: self = .maskSensitiveInputs
+        case .maskAllInputs: self = .maskAllInputs
+        case .maskAll: self = .maskAll
+        }
+    }
+}
+
+private extension ImagePrivacyLevel {
+    /// Maps a remote image privacy level onto the in-code `ImagePrivacyLevel`.
+    ///
+    /// - Parameter remote: The remote image privacy level.
+    init(_ remote: RemoteConfiguration.SessionReplay.ImagePrivacy) {
+        switch remote {
+        case .maskNone: self = .maskNone
+        case .maskNonBundledOnly: self = .maskNonBundledOnly
+        case .maskAll: self = .maskAll
+        }
+    }
+}
+
+private extension TouchPrivacyLevel {
+    /// Maps a remote touch privacy level onto the in-code `TouchPrivacyLevel`.
+    ///
+    /// - Parameter remote: The remote touch privacy level.
+    init(_ remote: RemoteConfiguration.SessionReplay.TouchPrivacy) {
+        switch remote {
+        case .show: self = .show
+        case .hide: self = .hide
+        }
+    }
+}

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration+RemoteConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration+RemoteConfiguration.swift
@@ -69,6 +69,7 @@ private extension TextAndInputPrivacyLevel {
         case .maskSensitiveInputs: self = .maskSensitiveInputs
         case .maskAllInputs: self = .maskAllInputs
         case .maskAll: self = .maskAll
+        @unknown default: self = .maskAll
         }
     }
 }
@@ -82,6 +83,7 @@ private extension ImagePrivacyLevel {
         case .maskNone: self = .maskNone
         case .maskNonBundledOnly: self = .maskNonBundledOnly
         case .maskAll: self = .maskAll
+        @unknown default: self = .maskAll
         }
     }
 }
@@ -94,6 +96,7 @@ private extension TouchPrivacyLevel {
         switch remote {
         case .show: self = .show
         case .hide: self = .hide
+        @unknown default: self = .hide
         }
     }
 }

--- a/DatadogSessionReplay/Tests/SessionReplayConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfiguration+RemoteConfigurationTests.swift
@@ -1,0 +1,120 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import XCTest
+import TestUtilities
+@testable import DatadogInternal
+@testable import DatadogSessionReplay
+
+class SessionReplayConfiguration_RemoteConfigurationTests: XCTestCase {
+    /// When there is no remote configuration (`nil`) or its `sessionReplay` namespace is absent,
+    /// Session Replay must behave exactly as configured in-code.
+    func testWhenNoRemoteValuesAreProvided_itLeavesConfigurationUnchanged() {
+        let baseline = SessionReplay.Configuration(
+            replaySampleRate: 42,
+            textAndInputPrivacyLevel: .maskSensitiveInputs,
+            imagePrivacyLevel: .maskNone,
+            touchPrivacyLevel: .show,
+            startRecordingImmediately: false
+        )
+
+        var withNilRemote = baseline
+        withNilRemote.apply(remoteConfiguration: nil)
+        DDAssertReflectionEqual(withNilRemote, baseline)
+
+        var withEmptyRemote = baseline
+        withEmptyRemote.apply(remoteConfiguration: .mockWith()) // every namespace absent
+        DDAssertReflectionEqual(withEmptyRemote, baseline)
+
+        var withEmptyNamespace = baseline
+        withEmptyNamespace.apply(remoteConfiguration: .mockWith(sessionReplay: .mockWith())) // all fields absent
+        DDAssertReflectionEqual(withEmptyNamespace, baseline)
+    }
+
+    /// A fully-populated remote `sessionReplay` namespace must override every mapped behavioral
+    /// parameter, regardless of the in-code baseline. Both the baseline and the remote are randomized
+    /// and the check repeated, so random enum/boolean values exercise every branch over the run.
+    func testItOverridesEveryBehavioralParameterFromRemoteValues() throws {
+        for _ in 0..<100 {
+            // Given
+            let sessionReplay: RemoteConfiguration.SessionReplay = .mockRandom()
+            var configuration = SessionReplay.Configuration(
+                replaySampleRate: .mockRandom(min: 0, max: 100),
+                textAndInputPrivacyLevel: [.maskSensitiveInputs, .maskAllInputs, .maskAll].randomElement()!,
+                imagePrivacyLevel: [.maskNone, .maskNonBundledOnly, .maskAll].randomElement()!,
+                touchPrivacyLevel: [.show, .hide].randomElement()!,
+                startRecordingImmediately: .mockRandom()
+            )
+
+            // When
+            configuration.apply(remoteConfiguration: .mockWith(sessionReplay: sessionReplay))
+
+            // Then
+            XCTAssertEqual(configuration.replaySampleRate, SampleRate(try XCTUnwrap(sessionReplay.sampleRate)))
+            XCTAssertEqual(configuration.startRecordingImmediately, try XCTUnwrap(sessionReplay.startRecordingImmediately))
+            XCTAssertEqual(configuration.textAndInputPrivacyLevel, expectedTextAndInputPrivacy(try XCTUnwrap(sessionReplay.textAndInputPrivacy)))
+            XCTAssertEqual(configuration.imagePrivacyLevel, expectedImagePrivacy(try XCTUnwrap(sessionReplay.imagePrivacy)))
+            XCTAssertEqual(configuration.touchPrivacyLevel, expectedTouchPrivacy(try XCTUnwrap(sessionReplay.touchPrivacy)))
+        }
+    }
+
+    /// A parameter the remote configuration omits must keep its in-code value while the present ones
+    /// are overridden.
+    func testWhenRemoteProvidesSomeValues_itKeepsInCodeValuesForTheOthers() {
+        // Given
+        var configuration = SessionReplay.Configuration(
+            replaySampleRate: 10,
+            textAndInputPrivacyLevel: .maskSensitiveInputs,
+            imagePrivacyLevel: .maskNone,
+            touchPrivacyLevel: .show,
+            startRecordingImmediately: true
+        )
+
+        // When — only `sampleRate` and `touchPrivacy` are provided remotely
+        configuration.apply(remoteConfiguration: .mockWith(sessionReplay: .mockWith(sampleRate: 90, touchPrivacy: .hide)))
+
+        // Then — provided values overridden
+        XCTAssertEqual(configuration.replaySampleRate, 90)
+        XCTAssertEqual(configuration.touchPrivacyLevel, .hide)
+        // Then — omitted values preserved
+        XCTAssertEqual(configuration.textAndInputPrivacyLevel, .maskSensitiveInputs)
+        XCTAssertEqual(configuration.imagePrivacyLevel, .maskNone)
+        XCTAssertTrue(configuration.startRecordingImmediately)
+    }
+
+    // MARK: - Helpers
+
+    private func expectedTextAndInputPrivacy(
+        _ remote: RemoteConfiguration.SessionReplay.TextAndInputPrivacy
+    ) -> TextAndInputPrivacyLevel {
+        switch remote {
+        case .maskSensitiveInputs: return .maskSensitiveInputs
+        case .maskAllInputs: return .maskAllInputs
+        case .maskAll: return .maskAll
+        }
+    }
+
+    private func expectedImagePrivacy(
+        _ remote: RemoteConfiguration.SessionReplay.ImagePrivacy
+    ) -> ImagePrivacyLevel {
+        switch remote {
+        case .maskNone: return .maskNone
+        case .maskNonBundledOnly: return .maskNonBundledOnly
+        case .maskAll: return .maskAll
+        }
+    }
+
+    private func expectedTouchPrivacy(
+        _ remote: RemoteConfiguration.SessionReplay.TouchPrivacy
+    ) -> TouchPrivacyLevel {
+        switch remote {
+        case .show: return .show
+        case .hide: return .hide
+        }
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -39,6 +39,53 @@ class SessionReplayTests: XCTestCase {
         XCTAssertNotNil(core.get(feature: ResourcesFeature.self))
     }
 
+    // MARK: - Remote Configuration
+
+    func testWhenEnabledWithRemoteSampleRate_itOverridesInCodeSampleRateAtEnableTime() {
+        // Given — in-code sample rate is 0 (would not record), remote enables it
+        config = SessionReplay.Configuration(replaySampleRate: 0)
+        core.remoteConfiguration = .mockWith(sessionReplay: .mockWith(sampleRate: 100))
+
+        // When
+        SessionReplay.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNotNil(
+            core.get(feature: SessionReplayFeature.self),
+            "Remote `sampleRate` must override the in-code value at enable time, enabling recording"
+        )
+    }
+
+    func testWhenEnabledWithRemoteSampleRateZero_itDisablesRecordingAtEnableTime() {
+        // Given — in-code sample rate records, remote disables it
+        config = SessionReplay.Configuration(replaySampleRate: 100)
+        core.remoteConfiguration = .mockWith(sessionReplay: .mockWith(sampleRate: 0))
+
+        // When
+        SessionReplay.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNil(
+            core.get(feature: SessionReplayFeature.self),
+            "Remote `sampleRate` of 0 must override the in-code value at enable time, disabling recording"
+        )
+    }
+
+    func testWhenEnabledWithNoRemoteConfiguration_itUsesInCodeConfiguration() {
+        // Given
+        config = SessionReplay.Configuration(replaySampleRate: 100)
+        core.remoteConfiguration = nil
+
+        // When
+        SessionReplay.enable(with: config, in: core)
+
+        // Then
+        XCTAssertNotNil(
+            core.get(feature: SessionReplayFeature.self),
+            "Without remote configuration, Session Replay must behave exactly as configured in-code"
+        )
+    }
+
     func testWhenEnabledInNOPCore_itPrintsError() {
         let printFunction = PrintFunctionSpy()
         consolePrint = printFunction.print

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -71,6 +71,32 @@ class SessionReplayTests: XCTestCase {
         )
     }
 
+    func testWhenEnabledWithRemoteConfiguration_itInjectsConfigurationAtEnableTime() throws {
+        // Given in-code values that all differ from the remote ones
+        config = SessionReplay.Configuration(
+            replaySampleRate: 10,
+            textAndInputPrivacyLevel: .maskSensitiveInputs,
+            imagePrivacyLevel: .maskNone,
+            touchPrivacyLevel: .show
+        )
+        core.remoteConfiguration = .mockWith(sessionReplay: .mockWith(
+            imagePrivacy: .maskAll,
+            sampleRate: 90,
+            textAndInputPrivacy: .maskAllInputs,
+            touchPrivacy: .hide
+        ))
+
+        // When
+        SessionReplay.enable(with: config, in: core)
+
+        // Then the merged remote values are injected into the recording coordinator at enable time
+        let sr = try XCTUnwrap(core.get(feature: SessionReplayFeature.self))
+        XCTAssertEqual(sr.recordingCoordinator.replaySampleRate, 90)
+        XCTAssertEqual(sr.recordingCoordinator.textAndInputPrivacy, .maskAllInputs)
+        XCTAssertEqual(sr.recordingCoordinator.imagePrivacy, .maskAll)
+        XCTAssertEqual(sr.recordingCoordinator.touchPrivacy, .hide)
+    }
+
     func testWhenEnabledWithNoRemoteConfiguration_itUsesInCodeConfiguration() {
         // Given
         config = SessionReplay.Configuration(replaySampleRate: 100)

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RemoteConfigurationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RemoteConfigurationMocks.swift
@@ -16,7 +16,7 @@ extension RemoteConfiguration: AnyMockable, RandomMockable {
         .init(
             profiling: .mockRandom(),
             rum: .mockRandom(),
-            sessionReplay: nil,
+            sessionReplay: .mockRandom(),
             trace: nil
         )
     }
@@ -177,5 +177,59 @@ extension RemoteConfiguration.Trace.TraceContextInjection: RandomMockable {
 extension RemoteConfiguration.Trace.TracingHeaderTypes: RandomMockable {
     public static func mockRandom() -> RemoteConfiguration.Trace.TracingHeaderTypes {
         [.datadog, .b3, .b3multi, .tracecontext].randomElement()!
+    }
+}
+
+extension RemoteConfiguration.SessionReplay: AnyMockable, RandomMockable {
+    public static func mockAny() -> RemoteConfiguration.SessionReplay {
+        mockWith()
+    }
+
+    /// Builds a `sessionReplay` namespace with **every** field populated with a random, non-`nil` value.
+    ///
+    /// Keeping all fields populated is what lets the exhaustiveness guard in
+    /// `SessionReplayConfiguration_RemoteConfigurationTests` detect any newly generated schema field.
+    public static func mockRandom() -> RemoteConfiguration.SessionReplay {
+        .init(
+            imagePrivacy: .mockRandom(),
+            sampleRate: .mockRandom(min: 0, max: 100),
+            startRecordingImmediately: .mockRandom(),
+            textAndInputPrivacy: .mockRandom(),
+            touchPrivacy: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        imagePrivacy: RemoteConfiguration.SessionReplay.ImagePrivacy? = nil,
+        sampleRate: Double? = nil,
+        startRecordingImmediately: Bool? = nil,
+        textAndInputPrivacy: RemoteConfiguration.SessionReplay.TextAndInputPrivacy? = nil,
+        touchPrivacy: RemoteConfiguration.SessionReplay.TouchPrivacy? = nil
+    ) -> RemoteConfiguration.SessionReplay {
+        .init(
+            imagePrivacy: imagePrivacy,
+            sampleRate: sampleRate,
+            startRecordingImmediately: startRecordingImmediately,
+            textAndInputPrivacy: textAndInputPrivacy,
+            touchPrivacy: touchPrivacy
+        )
+    }
+}
+
+extension RemoteConfiguration.SessionReplay.ImagePrivacy: RandomMockable {
+    public static func mockRandom() -> RemoteConfiguration.SessionReplay.ImagePrivacy {
+        [.maskNone, .maskNonBundledOnly, .maskAll].randomElement()!
+    }
+}
+
+extension RemoteConfiguration.SessionReplay.TextAndInputPrivacy: RandomMockable {
+    public static func mockRandom() -> RemoteConfiguration.SessionReplay.TextAndInputPrivacy {
+        [.maskSensitiveInputs, .maskAllInputs, .maskAll].randomElement()!
+    }
+}
+
+extension RemoteConfiguration.SessionReplay.TouchPrivacy: RandomMockable {
+    public static func mockRandom() -> RemoteConfiguration.SessionReplay.TouchPrivacy {
+        [.show, .hide].randomElement()!
     }
 }


### PR DESCRIPTION
### What and why?

Part of the Mobile Remote Configuration RFC (RUM-17195). When `SessionReplay.enable(with:)` is called, Session Replay now reads the remote configuration cached by Core and merges it on top of the developer's in-code `SessionReplay.Configuration`.

Remote values take precedence for the supported parameters. If no remote configuration is available, Session Replay behaves exactly as today.

### How?

`SessionReplay.Configuration.apply(remoteConfiguration:)` merges the **`sessionReplay`** namespace at enable time:

- **`sampleRate`** — the replay sample rate, applied before the sample-rate guard so it can enable or disable recording.
- **privacy levels** — text-and-input, image, and touch privacy.
- **`startRecordingImmediately`** — automatic vs. manual recording start.

The merge runs once at enablement; live updates are out of scope.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — N/A, targets `feature/remote-config`; CHANGELOG lands when the feature merges to `develop`
- [ ] Add Objective-C interface for public APIs — N/A, no new public API
- [ ] Run `make api-surface` when adding new APIs — N/A, no new public API

_Target branch: `feature/remote-config` (not `develop`), per RUM-17195._