### PR TITLE
RUM-17206 Capture cf-cache-status and x-vercel-cache by default

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -35,8 +35,7 @@ internal struct HeaderProcessor {
         "server-timing",
         "x-cache",
         "cf-cache-status",
-        "x-vercel-cache",
-        "x-served-by"
+        "x-vercel-cache"
     ]
 
     /// iOS-managed headers that are always omitted from request capture.

--- a/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/HeaderCapture/HeaderProcessor.swift
@@ -33,7 +33,10 @@ internal struct HeaderProcessor {
         "expires",
         "vary",
         "server-timing",
-        "x-cache"
+        "x-cache",
+        "cf-cache-status",
+        "x-vercel-cache",
+        "x-served-by"
     ]
 
     /// iOS-managed headers that are always omitted from request capture.

--- a/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
@@ -68,13 +68,16 @@ class HeaderProcessorTests: XCTestCase {
                 "vary": "Accept-Encoding",
                 "server-timing": "db;dur=53",
                 "x-cache": "HIT",
+                "cf-cache-status": "HIT",
+                "x-vercel-cache": "HIT",
+                "x-served-by": "cache-cdg-1234",
                 "x-custom-header": "should-not-appear",
                 "set-cookie": "session=abc"
             ]
         )
 
         // Then
-        XCTAssertEqual(result.response.count, 10)
+        XCTAssertEqual(result.response.count, 13)
         XCTAssertEqual(result.response["cache-control"], "max-age=3600")
         XCTAssertEqual(result.response["etag"], "\"abc123\"")
         XCTAssertEqual(result.response["age"], "120")
@@ -85,6 +88,9 @@ class HeaderProcessorTests: XCTestCase {
         XCTAssertEqual(result.response["vary"], "Accept-Encoding")
         XCTAssertEqual(result.response["server-timing"], "db;dur=53")
         XCTAssertEqual(result.response["x-cache"], "HIT")
+        XCTAssertEqual(result.response["cf-cache-status"], "HIT")
+        XCTAssertEqual(result.response["x-vercel-cache"], "HIT")
+        XCTAssertEqual(result.response["x-served-by"], "cache-cdg-1234")
         XCTAssertNil(result.response["x-custom-header"])
         XCTAssertNil(result.response["set-cookie"])
     }

--- a/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/HeaderCapture/HeaderProcessorTests.swift
@@ -70,14 +70,13 @@ class HeaderProcessorTests: XCTestCase {
                 "x-cache": "HIT",
                 "cf-cache-status": "HIT",
                 "x-vercel-cache": "HIT",
-                "x-served-by": "cache-cdg-1234",
                 "x-custom-header": "should-not-appear",
                 "set-cookie": "session=abc"
             ]
         )
 
         // Then
-        XCTAssertEqual(result.response.count, 13)
+        XCTAssertEqual(result.response.count, 12)
         XCTAssertEqual(result.response["cache-control"], "max-age=3600")
         XCTAssertEqual(result.response["etag"], "\"abc123\"")
         XCTAssertEqual(result.response["age"], "120")
@@ -90,7 +89,6 @@ class HeaderProcessorTests: XCTestCase {
         XCTAssertEqual(result.response["x-cache"], "HIT")
         XCTAssertEqual(result.response["cf-cache-status"], "HIT")
         XCTAssertEqual(result.response["x-vercel-cache"], "HIT")
-        XCTAssertEqual(result.response["x-served-by"], "cache-cdg-1234")
         XCTAssertNil(result.response["x-custom-header"])
         XCTAssertNil(result.response["set-cookie"])
     }


### PR DESCRIPTION
### What and why?

Adds `cf-cache-status` and `x-vercel-cache` to the default-captured response headers, so the RUM backend's shared-cache detection can flag CDN hits from Cloudflare and Vercel (`x-cache` is already captured).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs