### PR TITLE
FIX: revert client-side truncation of log attribute values

### DIFF
--- a/DatadogInternal/Sources/Attributes/AttributesSanitizer.swift
+++ b/DatadogInternal/Sources/Attributes/AttributesSanitizer.swift
@@ -15,12 +15,6 @@ public struct AttributesSanitizer {
         /// Maximum number of attributes in log.
         /// If this number is exceeded, extra attributes will be ignored.
         public static let maxNumberOfAttributes: Int = 256
-        /// Maximum length of a string attribute value, measured in UTF-16 code units (Swift `String.utf16.count`).
-        /// Values exceeding this will be truncated. This matches the backend hard limit — the backend measures
-        /// length using Java's `String.length()`, which counts UTF-16 code units. For ASCII and most accented
-        /// characters this is equivalent to Swift's `String.count`, but emoji may differ
-        /// (e.g. 👩🏻 = 1 grapheme cluster but 4 UTF-16 code units).
-        public static let maxAttributeValueLength: Int = 25_600
     }
 
     let featureName: String
@@ -69,34 +63,6 @@ public struct AttributesSanitizer {
             }
         }
         return sanitized
-    }
-
-    // MARK: - Attribute values sanitization
-
-    /// Truncates string attribute values exceeding `Constraints.maxAttributeValueLength`.
-    public func sanitizeValues(for attributes: [String: Encodable]) -> [String: Encodable] {
-        return Dictionary(uniqueKeysWithValues: attributes.map { key, value in
-            guard let string = value.dd.decode(String.self),
-                  string.utf16.count > Constraints.maxAttributeValueLength else {
-                return (key, value)
-            }
-            DD.logger.warn(
-                """
-                \(featureName) attribute '\(key)' value was truncated from \(string.utf16.count) to \
-                \(Constraints.maxAttributeValueLength) UTF-16 code units to match Datadog constraints.
-                """
-            )
-            var utf16Count = 0
-            let truncated = string.prefix(while: { char in
-                let newCount = utf16Count + char.utf16.count
-                guard newCount <= Constraints.maxAttributeValueLength else {
-                    return false
-                }
-                utf16Count = newCount
-                return true
-            })
-            return (key, String(truncated))
-        })
     }
 
     // MARK: - Attributes count limitting

--- a/DatadogLogs/Sources/Log/LogEventSanitizer.swift
+++ b/DatadogLogs/Sources/Log/LogEventSanitizer.swift
@@ -54,7 +54,6 @@ internal struct LogEventSanitizer {
         userAttributes = removeInvalidAttributes(userAttributes)
         userAttributes = removeReservedAttributes(userAttributes)
         userAttributes = attributesSanitizer.sanitizeKeys(for: userAttributes)
-        userAttributes = attributesSanitizer.sanitizeValues(for: userAttributes)  // truncate at 25,600 chars
         let userAttributesLimit = AttributesSanitizer.Constraints.maxNumberOfAttributes - (rawAttributes.internalAttributes?.count ?? 0)
         userAttributes = attributesSanitizer.limitNumberOf(attributes: userAttributes, to: userAttributesLimit)
 

--- a/DatadogLogs/Tests/Log/LogSanitizerTests.swift
+++ b/DatadogLogs/Tests/Log/LogSanitizerTests.swift
@@ -175,59 +175,6 @@ class LogSanitizerTests: XCTestCase {
         }
     }
 
-    func testWhenAttributeValueExceedsCharacterLimit_itIsTruncated() {
-        let longValue = String(repeating: "a", count: 25_601)
-        let log = LogEvent.mockWith(
-            attributes: .mockWith(userAttributes: ["key": longValue])
-        )
-
-        let sanitized = LogEventSanitizer().sanitize(log: log)
-
-        let value = sanitized.attributes.userAttributes["key"] as? String
-        XCTAssertEqual(value?.count, 25_600)
-    }
-
-    func testWhenNSStringAttributeValueExceedsCharacterLimit_itIsTruncated() {
-        let longValue = AnyEncodable(NSString(string: String(repeating: "a", count: 25_601)))
-        let log = LogEvent.mockWith(
-            attributes: .mockWith(userAttributes: ["key": longValue])
-        )
-
-        let sanitized = LogEventSanitizer().sanitize(log: log)
-
-        let value = sanitized.attributes.userAttributes["key"] as? String
-        XCTAssertEqual(value?.count, 25_600)
-    }
-
-    func testWhenAttributeValueWithEmojiExceedsUTF16Limit_itIsTruncated() {
-        // "😀" is 1 grapheme cluster but 2 UTF-16 code units.
-        // 25,599 ASCII chars + "😀" = 25,600 grapheme clusters (at limit) but 25,601 UTF-16 units (over limit).
-        // The emoji should be dropped so the result stays within the UTF-16 limit.
-        let longValue = String(repeating: "a", count: 25_599) + "😀"
-        let log = LogEvent.mockWith(
-            attributes: .mockWith(userAttributes: ["key": longValue])
-        )
-
-        let sanitized = LogEventSanitizer().sanitize(log: log)
-
-        let value = sanitized.attributes.userAttributes["key"] as? String
-        XCTAssertEqual(value?.utf16.count, 25_599)
-        XCTAssertEqual(value, String(repeating: "a", count: 25_599))
-    }
-
-    func testWhenAttributeValueIsWithinLimit_itIsNotModified() {
-        let value = String(repeating: "a", count: 25_600)
-        let log = LogEvent.mockWith(
-            attributes: .mockWith(userAttributes: ["key": value])
-        )
-
-        let sanitized = LogEventSanitizer().sanitize(log: log)
-
-        let result = sanitized.attributes.userAttributes["key"] as? String
-        XCTAssertEqual(result?.count, 25_600)
-        XCTAssertEqual(result, value)
-    }
-
     // MARK: - Tags sanitization
 
     func testWhenTagHasUpperCasedCharacters_itGetsLowerCased() {


### PR DESCRIPTION
### What and why?

Reverts the client-side truncation of Log string attribute values at 25,600 characters, added in #2832 (RUM-744).

That truncation assumed the backend discards attribute values beyond 25,600 characters, so truncating client-side was framed as saving bandwidth. Backend has since confirmed this assumption is wrong: the 25,600-char limit is an indexing limit only — the attribute is stored as-is, never truncated server-side. Truncating on the SDK side was silently corrupting data that is perfectly valid at the storage layer (it just wouldn't be searchable past that length — a very different outcome than losing the data).

RUM and Trace are unaffected — this truncation was only ever wired into LogEventSanitizer, never into RUMEventSanitizer or SpanSanitizer.

### How?

- Removed AttributesSanitizer.Constraints.maxAttributeValueLength and the sanitizeValues(for:) method entirely
- Removed the sanitizeValues() call from LogEventSanitizer.sanitize(attributes:)
- Removed the 4 tests covering the truncation behavior in LogSanitizerTests.swift
- No changes to maxNumberOfAttributes (128→256) or batch size limits from #2832 — those were confirmed independently and are out of scope for this revert

### Review checklist
- [X] Feature or bugfix MUST have appropriate tests (unit, integration)
- [X] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
