### PR TITLE
Fix dogfood.sh: restore missing commit SHA argument to commit-headless push

### DIFF
--- a/tools/dogfooding/dogfood.sh
+++ b/tools/dogfooding/dogfood.sh
@@ -96,7 +96,8 @@ push_repo() {
             -T "DataDog/$REPO_NAME" \
             --branch "$DOGFOODING_BRANCH_NAME" \
             --head-sha "$BASE_SHA" \
-            --create-branch
+            --create-branch \
+            "$(git rev-parse HEAD)"
     fi
     cd -
 }


### PR DESCRIPTION
### What and why?

The Shopist dogfooding CI job fails with `commit-headless: error: no commits present on standard input`. `commit-headless push` needs the commit SHA to push as a positional argument, not just `--head-sha` (which is the base SHA).

### How?

Restore the trailing `"$(git rev-parse HEAD)"` argument to the `commit-headless push` call in `push_repo()`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs