### PR TITLE
chore: Use `--datadog-ci` for release publish jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -479,7 +479,7 @@ Publish GH Asset:
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - ./tools/runner-setup.sh --datadog-ci --xcode "$DEFAULT_XCODE"
     - make env-check
     - make clean
     - make release-publish-github
@@ -492,7 +492,7 @@ Publish CP podspecs (internal):
   before_script:
     - *export_MAKE_release_params
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - ./tools/runner-setup.sh --datadog-ci --xcode "$DEFAULT_XCODE"
     - make env-check
     - make clean
     - make release-publish-internal-podspecs
@@ -506,7 +506,7 @@ Publish CP podspecs (internal):
     - *export_MAKE_release_params
   needs: ["Build Artifacts", "Publish CP podspecs (internal)"]
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - ./tools/runner-setup.sh --datadog-ci --xcode "$DEFAULT_XCODE"
     - make env-check
     - make clean
     - make release-publish-podspec PODSPEC_NAME="$PODSPEC_NAME"


### PR DESCRIPTION
### What and why?

This PR updates the release publish jobs to install `datadog-ci` during runner setup.
The affected pipeline was failing because the publish jobs require `datadog-ci`, but the CI runner setup did not install it:
```
datadog-ci:
Error datadog-ci is not installed but it is required for development. Install it and try again.
```
[Failing pipeline example.](https://gitlab.ddbuild.io/DataDog/dd-sdk-ios/-/jobs/1862876455)

### How?

Pass `--datadog-ci` to `./tools/runner-setup.sh` in the GitLab release publish jobs before running the existing environment checks and publish commands.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
