### PR TITLE
[RUM-17386] Build client-side stats snapshot from sanitized span

### DIFF
--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -197,7 +197,14 @@ internal final class DDSpan: OTSpan, @unchecked Sendable {
                 logFields: self.logFields
             )
 
-            onSpanFinished(SpanSnapshot(from: event, startTime: self.startTime))
+            // Derive the snapshot from the sanitized event so client-side stats aggregate the same
+            // tags the uploaded span carries. `SpanEventEncoder` sanitizes the event again at encode
+            // time (attribute-key normalization and count-limiting), so reading the raw event here
+            // would let stats emit peer/dimension tags the upload dropped or renamed — a divergence
+            // the backend cannot correct because `_dd.compute_stats=0` suppresses its recomputation.
+            // Sanitizing is idempotent, so the uploaded envelope below stays byte-identical.
+            let sanitizedEvent = SpanSanitizer().sanitize(span: event)
+            onSpanFinished(SpanSnapshot(from: sanitizedEvent, startTime: self.startTime))
 
             if self.ddContext.samplingDecision.samplingPriority.isKept {
                 let envelope = SpanEventsEnvelope(span: event, environment: context.env)

--- a/DatadogTrace/Sources/DDSpan.swift
+++ b/DatadogTrace/Sources/DDSpan.swift
@@ -137,51 +137,21 @@ internal final class DDSpan: OTSpan, @unchecked Sendable {
             activity.leave()
         }
 
-        if let onSpanFinished = ddTracer.onSpanFinished {
-            // Client-side stats path: build the `SpanEvent` first (which runs the user-configured
-            // `SpanEventMapper`) and derive the `SpanSnapshot` from it, so stats and trace uploads
-            // agree on resource/service/tags. The same event is reused for upload when sampled in,
-            // ensuring the mapper runs exactly once per finished span.
-            buildEventAndDispatch(finishTime: time, onSpanFinished: onSpanFinished)
-        } else {
-            // Stats disabled: original flow, mapper runs only on the sampled-in upload path.
-            if self.ddContext.samplingDecision.samplingPriority.isKept {
-                sendSpan(finishTime: time)
-            }
-        }
+        buildEventAndDispatch(finishTime: time, onSpanFinished: ddTracer.onSpanFinished)
     }
 
     // MARK: - Writing SpanEvent
 
-    /// Sends span event for given `DDSpan`.
-    private func sendSpan(finishTime: Date) {
-        eventWriter.spanWriteContext { context, writer in
-            let event = self.eventBuilder.createSpanEvent(
-                context: context,
-                traceID: self.ddContext.traceID,
-                spanID: self.ddContext.spanID,
-                parentSpanID: self.ddContext.parentSpanID,
-                operationName: self.operationName,
-                startTime: self.startTime,
-                finishTime: finishTime,
-                samplingRate: self.ddContext.sampleRate / 100.0,
-                samplingPriority: self.ddContext.samplingDecision.samplingPriority,
-                samplingDecisionMaker: self.ddContext.samplingDecision.decisionMaker,
-                tags: self.tags,
-                baggageItems: self.ddContext.baggageItems.all,
-                logFields: self.logFields
-            )
-
-            let envelope = SpanEventsEnvelope(span: event, environment: context.env)
-            writer.write(value: envelope)
+    /// Builds the `SpanEvent` once (running the mapper), optionally delivers the stats snapshot,
+    /// and writes the upload envelope when the span is sampled in.
+    private func buildEventAndDispatch(finishTime: Date, onSpanFinished: ((SpanSnapshot) -> Void)?) {
+        let shouldWriteSpan = ddContext.samplingDecision.samplingPriority.isKept
+        guard shouldWriteSpan || onSpanFinished != nil else {
+            return
         }
-    }
 
-    /// Builds the `SpanEvent` once (running the mapper), delivers the derived `SpanSnapshot`
-    /// to the stats hook, and writes the upload envelope when the span is sampled in.
-    private func buildEventAndDispatch(finishTime: Date, onSpanFinished: @escaping (SpanSnapshot) -> Void) {
         eventWriter.spanWriteContext { context, writer in
-            let event = self.eventBuilder.createSpanEvent(
+            var event = self.eventBuilder.createSpanEvent(
                 context: context,
                 traceID: self.ddContext.traceID,
                 spanID: self.ddContext.spanID,
@@ -198,15 +168,15 @@ internal final class DDSpan: OTSpan, @unchecked Sendable {
             )
 
             // Derive the snapshot from the sanitized event so client-side stats aggregate the same
-            // tags the uploaded span carries. `SpanEventEncoder` sanitizes the event again at encode
-            // time (attribute-key normalization and count-limiting), so reading the raw event here
-            // would let stats emit peer/dimension tags the upload dropped or renamed — a divergence
+            // tags the uploaded span carries. Reading the raw event here would let stats emit
+            // peer/dimension tags the upload dropped or renamed, a divergence
             // the backend cannot correct because `_dd.compute_stats=0` suppresses its recomputation.
-            // Sanitizing is idempotent, so the uploaded envelope below stays byte-identical.
-            let sanitizedEvent = SpanSanitizer().sanitize(span: event)
-            onSpanFinished(SpanSnapshot(from: sanitizedEvent, startTime: self.startTime))
+            if let onSpanFinished {
+                event = SpanSanitizer().sanitize(span: event)
+                onSpanFinished(SpanSnapshot(from: event, startTime: self.startTime))
+            }
 
-            if self.ddContext.samplingDecision.samplingPriority.isKept {
+            if shouldWriteSpan {
                 let envelope = SpanEventsEnvelope(span: event, environment: context.env)
                 writer.write(value: envelope)
             }

--- a/DatadogTrace/Sources/Span/SpanEventEncoder.swift
+++ b/DatadogTrace/Sources/Span/SpanEventEncoder.swift
@@ -107,8 +107,11 @@ public struct SpanEvent: Encodable {
     /// Tags associated with the span.
     public var tags: [String: String]
 
+    /// Whether this event has already passed through `SpanSanitizer`.
+    internal var isSanitized: Bool = false
+
     public func encode(to encoder: Encoder) throws {
-        let sanitizedSpan = SpanSanitizer().sanitize(span: self)
+        let sanitizedSpan = isSanitized ? self : SpanSanitizer().sanitize(span: self)
         try SpanEventEncoder().encode(sanitizedSpan, to: encoder)
     }
 }

--- a/DatadogTrace/Sources/Span/SpanSanitizer.swift
+++ b/DatadogTrace/Sources/Span/SpanSanitizer.swift
@@ -9,6 +9,13 @@ import DatadogInternal
 
 /// Sanitizes `SpanEvent` representation received from the user, so it can match Datadog APM constraints.
 internal struct SpanSanitizer {
+    private static let reservedTagKeys = [
+        SpanTags.computeStats,
+        SpanTags.kind,
+        SpanTags.topLevel,
+        SpanTags.measured
+    ]
+
     private let attributesSanitizer = AttributesSanitizer(featureName: "Span")
 
     func sanitize(span: SpanEvent) -> SpanEvent {
@@ -20,11 +27,13 @@ internal struct SpanSanitizer {
         }
         var sanitizedTags = attributesSanitizer.sanitizeKeys(for: span.tags)
 
-        // The SDK owns `_dd.compute_stats` and must never let attribute-count limiting drop it.
-        // If an opted-out span lost the flag here, it would upload without it while client stats
-        // are also uploaded, so the backend would recompute stats and double-count. Hold it aside,
-        // limit the rest, then restore it so it never competes for the attribute budget.
-        let reservedComputeStats = sanitizedTags.removeValue(forKey: SpanTags.computeStats)
+        // Keep stats-control tags outside the attribute budget. Dropping them would either
+        // re-enable backend stats or make client-side stats skip otherwise eligible spans.
+        let reservedTags = Self.reservedTagKeys.reduce(into: [String: String]()) { reservedTags, key in
+            if let value = sanitizedTags.removeValue(forKey: key) {
+                reservedTags[key] = value
+            }
+        }
 
         // Limit to max number of attributes
         // If any attributes need to be removed, we first reduce number of
@@ -42,14 +51,13 @@ internal struct SpanSanitizer {
             to: AttributesSanitizer.Constraints.maxNumberOfAttributes - sanitizedAccountExtraInfo.count - sanitizedUserExtraInfo.count
         )
 
-        if let reservedComputeStats = reservedComputeStats {
-            sanitizedTags[SpanTags.computeStats] = reservedComputeStats
-        }
+        sanitizedTags.merge(reservedTags) { _, reservedValue in reservedValue }
 
         var sanitizedSpan = span
         sanitizedSpan.userInfo.extraInfo = sanitizedUserExtraInfo
         sanitizedSpan.accountInfo?.extraInfo = sanitizedAccountExtraInfo
         sanitizedSpan.tags = sanitizedTags
+        sanitizedSpan.isSanitized = true
         return sanitizedSpan
     }
 }

--- a/DatadogTrace/Sources/Span/SpanSnapshot.swift
+++ b/DatadogTrace/Sources/Span/SpanSnapshot.swift
@@ -86,8 +86,8 @@ extension SpanSnapshot {
         // parent lives in a different service (distributed-tracing continuation) or
         // when the user explicitly marks the span with `_dd.top_level`. Mirrors the
         // dd-trace-go convention (`_top_level` tag).
-        let isTopLevel = event.parentID == nil || event.tags["_dd.top_level"] == "1"
-        let isMeasured = event.tags["_dd.measured"] == "1"
+        let isTopLevel = event.parentID == nil || event.tags[SpanTags.topLevel] == "1"
+        let isMeasured = event.tags[SpanTags.measured] == "1"
         let serviceSource = event.tags["_dd.svc_src"] ?? ""
 
         var peerTags: [String: String] = [:]

--- a/DatadogTrace/Sources/Tracer.swift
+++ b/DatadogTrace/Sources/Tracer.swift
@@ -45,6 +45,10 @@ public enum SpanTags {
     /// Internal tag used to encode the span kind. This can be either "client" or "server" for RPC spans,
     /// and "producer" or "consumer" for messaging spans.
     internal static let kind = "span.kind"
+    /// Internal tag used to mark a child span as top-level for stats computation.
+    internal static let topLevel = "_dd.top_level"
+    /// Internal tag used to mark a span as measured for stats computation.
+    internal static let measured = "_dd.measured"
     /// Tag used to mark a span as manually dropped.
     public static let manualDrop = "manual.drop"
     /// Tag used to mark a span as manually kept.

--- a/DatadogTrace/Tests/Span/SpanSanitizerTests.swift
+++ b/DatadogTrace/Tests/Span/SpanSanitizerTests.swift
@@ -129,4 +129,26 @@ class SpanSanitizerTests: XCTestCase {
         // Then the SDK-owned opt-out survives even though user tags were dropped to fit the limit.
         XCTAssertEqual(sanitized.tags[SpanTags.computeStats], "0", "The reserved `_dd.compute_stats` tag must never be dropped by attribute limiting")
     }
+
+    func testWhenNumberOfAttributesExceedsLimit_itKeepsStatsEligibilityTags() {
+        let twiceTheLimit = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        var mockTags = (0..<twiceTheLimit).reduce(into: [String: String]()) { tags, index in
+            tags["tag-\(index)"] = .mockAny()
+        }
+        mockTags[SpanTags.kind] = "client"
+        mockTags[SpanTags.topLevel] = "1"
+        mockTags[SpanTags.measured] = "1"
+
+        let span = SpanEvent.mockWith(parentID: 42, tags: mockTags)
+
+        // When
+        let sanitized = SpanSanitizer().sanitize(span: span)
+
+        // Then stats eligibility tags survive even when user tags were dropped to fit the limit.
+        XCTAssertEqual(sanitized.tags[SpanTags.kind], "client")
+        XCTAssertEqual(sanitized.tags[SpanTags.topLevel], "1")
+        XCTAssertEqual(sanitized.tags[SpanTags.measured], "1")
+        XCTAssertTrue(StatsConcentrator.isEligible(SpanSnapshot(from: sanitized, startTime: .mockAny())))
+    }
 }

--- a/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
+++ b/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
@@ -298,13 +298,12 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotPeerTagsMatchSanitizedUploadedSpan() throws {
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
-            samplingProvider: TracerSamplerProviderMock.mockKeepAll()
+            samplingProvider: TracerSamplerProviderMock.mockKeepAll(),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         // A span carrying more tags than the sanitizer's attribute limit, including peer tags: the
         // limit drops some tags, and the snapshot must reflect exactly what the upload keeps.
@@ -320,7 +319,7 @@ class SpanSnapshotTests: XCTestCase {
         let span = tracer.startSpan(operationName: "network.request", tags: tags)
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         let uploaded = try XCTUnwrap(core.events(ofType: SpanEventsEnvelope.self).first)
         let uploadedSpan = try XCTUnwrap(uploaded.spans.first)
 

--- a/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
+++ b/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
@@ -318,6 +318,53 @@ class SpanSnapshotTests: XCTestCase {
         XCTAssertNotNil(capturedSnapshot, "Snapshot must be captured regardless of sampling decision")
     }
 
+    // MARK: - Sanitization Consistency
+    //
+    // The uploaded `SpanEvent` is sanitized at encode time (attribute-key normalization and the
+    // 256-attribute limit). The stats `SpanSnapshot` is derived from the same sanitized
+    // representation, so client-side stats never emit a peer dimension the uploaded span dropped or
+    // renamed — a divergence the backend cannot reconcile because `_dd.compute_stats=0` suppresses
+    // its own recomputation.
+
+    func testSnapshotPeerTagsMatchSanitizedUploadedSpan() throws {
+        let core = PassthroughCoreMock()
+        let tracer: DatadogTracer = .mockWith(
+            core: core,
+            samplingProvider: TracerSamplerProviderMock.mockKeepAll()
+        )
+
+        var capturedSnapshot: SpanSnapshot?
+        tracer.onSpanFinished = { capturedSnapshot = $0 }
+
+        // A span carrying more tags than the sanitizer's attribute limit, including peer tags: the
+        // limit drops some tags, and the snapshot must reflect exactly what the upload keeps.
+        var tags: [String: Encodable] = [
+            "peer.service": "downstream-svc",
+            "out.host": "db.example.com",
+            SpanTags.kind: "client"
+        ]
+        for i in 0..<(AttributesSanitizer.Constraints.maxNumberOfAttributes + 16) {
+            tags["extra.tag.\(i)"] = "v"
+        }
+
+        let span = tracer.startSpan(operationName: "network.request", tags: tags)
+        span.finish()
+
+        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let uploaded = try XCTUnwrap(core.events(ofType: SpanEventsEnvelope.self).first)
+        let sanitizedUpload = SpanSanitizer().sanitize(span: try XCTUnwrap(uploaded.spans.first))
+
+        // Each peer key must be present in the snapshot exactly when the sanitized upload keeps it,
+        // with an identical value — proving stats read the same sanitized tags the span uploads.
+        for key in SpanSnapshot.peerTagKeys {
+            XCTAssertEqual(
+                snapshot.peerTags[key],
+                sanitizedUpload.tags[key],
+                "Snapshot peer tag '\(key)' must match the sanitized uploaded span"
+            )
+        }
+    }
+
     // MARK: - EventMapper Consistency
     //
     // The user-configured `SpanEventMapper` mutates `resource`, `operationName`, and `tags` on the

--- a/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
+++ b/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
@@ -323,7 +323,7 @@ class SpanSnapshotTests: XCTestCase {
     // The uploaded `SpanEvent` is sanitized at encode time (attribute-key normalization and the
     // 256-attribute limit). The stats `SpanSnapshot` is derived from the same sanitized
     // representation, so client-side stats never emit a peer dimension the uploaded span dropped or
-    // renamed — a divergence the backend cannot reconcile because `_dd.compute_stats=0` suppresses
+    // renamed, a divergence the backend cannot reconcile because `_dd.compute_stats=0` suppresses
     // its own recomputation.
 
     func testSnapshotPeerTagsMatchSanitizedUploadedSpan() throws {
@@ -352,14 +352,15 @@ class SpanSnapshotTests: XCTestCase {
 
         let snapshot = try XCTUnwrap(capturedSnapshot)
         let uploaded = try XCTUnwrap(core.events(ofType: SpanEventsEnvelope.self).first)
-        let sanitizedUpload = SpanSanitizer().sanitize(span: try XCTUnwrap(uploaded.spans.first))
+        let uploadedSpan = try XCTUnwrap(uploaded.spans.first)
 
         // Each peer key must be present in the snapshot exactly when the sanitized upload keeps it,
-        // with an identical value — proving stats read the same sanitized tags the span uploads.
+        // with an identical value, proving stats read the same sanitized tags the span uploads.
+        XCTAssertTrue(uploadedSpan.isSanitized)
         for key in SpanSnapshot.peerTagKeys {
             XCTAssertEqual(
                 snapshot.peerTags[key],
-                sanitizedUpload.tags[key],
+                uploadedSpan.tags[key],
                 "Snapshot peer tag '\(key)' must match the sanitized uploaded span"
             )
         }


### PR DESCRIPTION
### What and why?

The stats `SpanSnapshot` was built from the pre-sanitizer event, but the uploaded span is sanitized at encode time (attribute-key normalization and the 256-attribute limit). A dropped or renamed peer tag makes CSS emit dimensions the uploaded span lacks, and `_dd.compute_stats=0` disables backend recompute, so stats and the span diverge. Ported from the dogfooding branch (Codex review of #3056).

### How?

Build the snapshot from `SpanSanitizer().sanitize(span: event)` in `DDSpan.buildEventAndDispatch`, so stats read the same tags the upload carries. Sanitizing is idempotent, so the uploaded envelope is unchanged.

### Review checklist
- [x] Test added (`testSnapshotPeerTagsMatchSanitizedUploadedSpan`)
- [x] JIRA reference in commit and PR
- [ ] CHANGELOG: n/a (CSS unreleased)
- [ ] Obj-C interface: n/a (internal)
- [ ] api-surface: n/a (no public API change)