### PR TITLE
RUM-17207 Forward local_cache_hit signal on RUM resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [FEATURE] Add support for UK1 Datadog Site. See [#3087][]
 - [FIX] onSessionStart is now called only after sampling information used by WebView Tracking is in place, avoiding missing traces in early requests. See [#3104][]
 - [FIX] Fix crash when defining `onSessionStart` in RUM configuration in Swift 6 projects. See [#3106][]
+- [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
 
 # 3.14.0 / 15-07-2026
 
@@ -1204,6 +1205,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3087]: https://github.com/DataDog/dd-sdk-ios/pull/3087
 [#3104]: https://github.com/DataDog/dd-sdk-ios/pull/3104
 [#3106]: https://github.com/DataDog/dd-sdk-ios/pull/3106
+[#3074]: https://github.com/DataDog/dd-sdk-ios/pull/3074
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -179,6 +179,11 @@ public struct CrossPlatformAttributes {
     /// Used in RUM resources to transport response headers through the RUM command pipeline.
     /// Expects `[String: String]` value containing header keys and values.
     public static let responseHeaders = "_dd.response_headers"
+
+    /// Indicates the resource was served from the device's local cache, captured from native URLSession interception.
+    /// Only ever sent as `true`. Absence means "not a local cache hit".
+    /// Expects `Bool` value.
+    public static let localCacheHit = "_dd.local_cache_hit"
 }
 
 /// HTTP header names used to pass GraphQL metadata from the application to the SDK.

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -180,8 +180,7 @@ public struct CrossPlatformAttributes {
     /// Expects `[String: String]` value containing header keys and values.
     public static let responseHeaders = "_dd.response_headers"
 
-    /// Indicates the resource was served from the device's local cache, captured from native URLSession interception.
-    /// Only ever sent as `true`. Absence means "not a local cache hit".
+    /// Indicates whether the resource was served from the device's local cache, captured from native URLSession interception.
     /// Expects `Bool` value.
     public static let localCacheHit = "_dd.local_cache_hit"
 }

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -1651,6 +1651,9 @@ public struct RUMErrorEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public let configuration: Configuration?
 
+        /// Mapping of source file URLs to their debug IDs for source map deobfuscation
+        public let debugIds: [DebugIds]?
+
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
@@ -1678,6 +1681,7 @@ public struct RUMErrorEvent: RUMDataModel {
         public enum CodingKeys: String, CodingKey {
             case browserSdkVersion = "browser_sdk_version"
             case configuration = "configuration"
+            case debugIds = "debug_ids"
             case formatVersion = "format_version"
             case parentSpanId = "parent_span_id"
             case profiling = "profiling"
@@ -1693,6 +1697,7 @@ public struct RUMErrorEvent: RUMDataModel {
         /// - Parameters:
         ///   - browserSdkVersion: Browser SDK version
         ///   - configuration: Subset of the SDK configuration options in use during its execution
+        ///   - debugIds: Mapping of source file URLs to their debug IDs for source map deobfuscation
         ///   - parentSpanId: parent span identifier in decimal format
         ///   - profiling: Profiling context
         ///   - rulePsr: trace sample rate in decimal format
@@ -1703,6 +1708,7 @@ public struct RUMErrorEvent: RUMDataModel {
         public init(
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
+            debugIds: [DebugIds]? = nil,
             parentSpanId: String? = nil,
             profiling: DDProfiling? = nil,
             rulePsr: Double? = nil,
@@ -1713,6 +1719,7 @@ public struct RUMErrorEvent: RUMDataModel {
         ) {
             self.browserSdkVersion = browserSdkVersion
             self.configuration = configuration
+            self.debugIds = debugIds
             self.parentSpanId = parentSpanId
             self.profiling = profiling
             self.rulePsr = rulePsr
@@ -1760,6 +1767,33 @@ public struct RUMErrorEvent: RUMDataModel {
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
+            }
+        }
+
+        /// Association between a source file URL and its debug ID
+        public struct DebugIds: Codable {
+            /// Debug ID (UUID) for the source file
+            public let id: String
+
+            /// URL of the source file
+            public let url: String
+
+            public enum CodingKeys: String, CodingKey {
+                case id = "id"
+                case url = "url"
+            }
+
+            /// Association between a source file URL and its debug ID
+            ///
+            /// - Parameters:
+            ///   - id: Debug ID (UUID) for the source file
+            ///   - url: URL of the source file
+            public init(
+                id: String,
+                url: String
+            ) {
+                self.id = id
+                self.url = url
             }
         }
 
@@ -3079,6 +3113,9 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public let configuration: Configuration?
 
+        /// Mapping of source file URLs to their debug IDs for source map deobfuscation
+        public let debugIds: [DebugIds]?
+
         /// Whether the long task should be discarded or indexed
         public let discarded: Bool?
 
@@ -3097,6 +3134,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         public enum CodingKeys: String, CodingKey {
             case browserSdkVersion = "browser_sdk_version"
             case configuration = "configuration"
+            case debugIds = "debug_ids"
             case discarded = "discarded"
             case formatVersion = "format_version"
             case profiling = "profiling"
@@ -3109,6 +3147,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// - Parameters:
         ///   - browserSdkVersion: Browser SDK version
         ///   - configuration: Subset of the SDK configuration options in use during its execution
+        ///   - debugIds: Mapping of source file URLs to their debug IDs for source map deobfuscation
         ///   - discarded: Whether the long task should be discarded or indexed
         ///   - profiling: Profiling context
         ///   - sdkName: SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
@@ -3116,6 +3155,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         public init(
             browserSdkVersion: String? = nil,
             configuration: Configuration? = nil,
+            debugIds: [DebugIds]? = nil,
             discarded: Bool? = nil,
             profiling: DDProfiling? = nil,
             sdkName: String? = nil,
@@ -3123,6 +3163,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         ) {
             self.browserSdkVersion = browserSdkVersion
             self.configuration = configuration
+            self.debugIds = debugIds
             self.discarded = discarded
             self.profiling = profiling
             self.sdkName = sdkName
@@ -3167,6 +3208,33 @@ public struct RUMLongTaskEvent: RUMDataModel {
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
+            }
+        }
+
+        /// Association between a source file URL and its debug ID
+        public struct DebugIds: Codable {
+            /// Debug ID (UUID) for the source file
+            public let id: String
+
+            /// URL of the source file
+            public let url: String
+
+            public enum CodingKeys: String, CodingKey {
+                case id = "id"
+                case url = "url"
+            }
+
+            /// Association between a source file URL and its debug ID
+            ///
+            /// - Parameters:
+            ///   - id: Debug ID (UUID) for the source file
+            ///   - url: URL of the source file
+            public init(
+                id: String,
+                url: String
+            ) {
+                self.id = id
+                self.url = url
             }
         }
 
@@ -4224,6 +4292,9 @@ public struct RUMResourceEvent: RUMDataModel {
         /// UUID of the resource
         public let id: String?
 
+        /// Whether the resource was served from the device's local cache
+        public let localCacheHit: Bool?
+
         /// HTTP method of the resource
         public let method: RUMMethod?
 
@@ -4277,6 +4348,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case firstByte = "first_byte"
             case graphql = "graphql"
             case id = "id"
+            case localCacheHit = "local_cache_hit"
             case method = "method"
             case `protocol` = "protocol"
             case provider = "provider"
@@ -4306,6 +4378,7 @@ public struct RUMResourceEvent: RUMDataModel {
         ///   - firstByte: First Byte phase properties
         ///   - graphql: GraphQL request parameters
         ///   - id: UUID of the resource
+        ///   - localCacheHit: Whether the resource was served from the device's local cache
         ///   - method: HTTP method of the resource
         ///   - `protocol`: Network protocol used to fetch the resource (e.g., 'http/1.1', 'h2')
         ///   - provider: The provider for this resource
@@ -4331,6 +4404,7 @@ public struct RUMResourceEvent: RUMDataModel {
             firstByte: FirstByte? = nil,
             graphql: RUMGraphql? = nil,
             id: String? = nil,
+            localCacheHit: Bool? = nil,
             method: RUMMethod? = nil,
             `protocol`: String? = nil,
             provider: Provider? = nil,
@@ -4356,6 +4430,7 @@ public struct RUMResourceEvent: RUMDataModel {
             self.firstByte = firstByte
             self.graphql = graphql
             self.id = id
+            self.localCacheHit = localCacheHit
             self.method = method
             self.`protocol` = `protocol`
             self.provider = provider
@@ -5452,6 +5527,9 @@ public struct RUMViewEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// The id of the remote configuration applied to the SDK, if any
+            public let remoteConfigurationId: String?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -5466,6 +5544,7 @@ public struct RUMViewEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case remoteConfigurationId = "remote_configuration_id"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
@@ -5476,18 +5555,21 @@ public struct RUMViewEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - remoteConfigurationId: The id of the remote configuration applied to the SDK, if any
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - startSessionReplayRecordingManually: Whether session replay recording configured to start manually
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                remoteConfigurationId: String? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 startSessionReplayRecordingManually: Bool? = nil,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.remoteConfigurationId = remoteConfigurationId
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.startSessionReplayRecordingManually = startSessionReplayRecordingManually
@@ -7513,6 +7595,9 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         /// Browser SDK version
         public let browserSdkVersion: String?
 
+        /// Additional information of the reported Cumulative Layout Shift
+        public let cls: CLS?
+
         /// Subset of the SDK configuration options in use during its execution
         public let configuration: Configuration?
 
@@ -7522,6 +7607,15 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
+        /// List of the page states during the view
+        public let pageStates: [PageStates]?
+
+        /// Profiling context
+        public let profiling: DDProfiling?
+
+        /// Debug metadata for Replay Sessions
+        public let replayStats: ReplayStats?
+
         /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         public let sdkName: String?
 
@@ -7530,9 +7624,13 @@ public struct RUMViewUpdateEvent: RUMDataModel {
 
         public enum CodingKeys: String, CodingKey {
             case browserSdkVersion = "browser_sdk_version"
+            case cls = "cls"
             case configuration = "configuration"
             case documentVersion = "document_version"
             case formatVersion = "format_version"
+            case pageStates = "page_states"
+            case profiling = "profiling"
+            case replayStats = "replay_stats"
             case sdkName = "sdk_name"
             case session = "session"
         }
@@ -7541,22 +7639,54 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         ///
         /// - Parameters:
         ///   - browserSdkVersion: Browser SDK version
+        ///   - cls: Additional information of the reported Cumulative Layout Shift
         ///   - configuration: Subset of the SDK configuration options in use during its execution
         ///   - documentVersion: Version of the update of the view event
+        ///   - pageStates: List of the page states during the view
+        ///   - profiling: Profiling context
+        ///   - replayStats: Debug metadata for Replay Sessions
         ///   - sdkName: SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
         ///   - session: Session-related internal properties
         public init(
             browserSdkVersion: String? = nil,
+            cls: CLS? = nil,
             configuration: Configuration? = nil,
             documentVersion: Int64,
+            pageStates: [PageStates]? = nil,
+            profiling: DDProfiling? = nil,
+            replayStats: ReplayStats? = nil,
             sdkName: String? = nil,
             session: Session? = nil
         ) {
             self.browserSdkVersion = browserSdkVersion
+            self.cls = cls
             self.configuration = configuration
             self.documentVersion = documentVersion
+            self.pageStates = pageStates
+            self.profiling = profiling
+            self.replayStats = replayStats
             self.sdkName = sdkName
             self.session = session
+        }
+
+        /// Additional information of the reported Cumulative Layout Shift
+        public struct CLS: Codable {
+            /// Pixel ratio of the device where the layout shift was reported
+            public let devicePixelRatio: Double?
+
+            public enum CodingKeys: String, CodingKey {
+                case devicePixelRatio = "device_pixel_ratio"
+            }
+
+            /// Additional information of the reported Cumulative Layout Shift
+            ///
+            /// - Parameters:
+            ///   - devicePixelRatio: Pixel ratio of the device where the layout shift was reported
+            public init(
+                devicePixelRatio: Double? = nil
+            ) {
+                self.devicePixelRatio = devicePixelRatio
+            }
         }
 
         /// Subset of the SDK configuration options in use during its execution
@@ -7564,19 +7694,27 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// The id of the remote configuration applied to the SDK, if any
+            public let remoteConfigurationId: String?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
             /// The percentage of sessions tracked
             public let sessionSampleRate: Double
 
+            /// Whether session replay recording configured to start manually
+            public let startSessionReplayRecordingManually: Bool?
+
             /// The percentage of sessions with traced resources
             public let traceSampleRate: Double?
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case remoteConfigurationId = "remote_configuration_id"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
+                case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
                 case traceSampleRate = "trace_sample_rate"
             }
 
@@ -7584,19 +7722,95 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - remoteConfigurationId: The id of the remote configuration applied to the SDK, if any
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
+            ///   - startSessionReplayRecordingManually: Whether session replay recording configured to start manually
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                remoteConfigurationId: String? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
+                startSessionReplayRecordingManually: Bool? = nil,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.remoteConfigurationId = remoteConfigurationId
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
+                self.startSessionReplayRecordingManually = startSessionReplayRecordingManually
                 self.traceSampleRate = traceSampleRate
+            }
+        }
+
+        /// Properties of the page state
+        public struct PageStates: Codable {
+            /// Duration in ns between start of the view and start of the page state
+            public let start: Int64
+
+            /// Page state name
+            public let state: State
+
+            public enum CodingKeys: String, CodingKey {
+                case start = "start"
+                case state = "state"
+            }
+
+            /// Properties of the page state
+            ///
+            /// - Parameters:
+            ///   - start: Duration in ns between start of the view and start of the page state
+            ///   - state: Page state name
+            public init(
+                start: Int64,
+                state: State
+            ) {
+                self.start = start
+                self.state = state
+            }
+
+            /// Page state name
+            public enum State: String, Codable {
+                case active = "active"
+                case passive = "passive"
+                case hidden = "hidden"
+                case frozen = "frozen"
+                case terminated = "terminated"
+            }
+        }
+
+        /// Debug metadata for Replay Sessions
+        public struct ReplayStats: Codable {
+            /// The number of records produced during this view lifetime
+            public let recordsCount: Int64?
+
+            /// The number of segments sent during this view lifetime
+            public let segmentsCount: Int64?
+
+            /// The total size in bytes of the segments sent during this view lifetime
+            public let segmentsTotalRawSize: Int64?
+
+            public enum CodingKeys: String, CodingKey {
+                case recordsCount = "records_count"
+                case segmentsCount = "segments_count"
+                case segmentsTotalRawSize = "segments_total_raw_size"
+            }
+
+            /// Debug metadata for Replay Sessions
+            ///
+            /// - Parameters:
+            ///   - recordsCount: The number of records produced during this view lifetime
+            ///   - segmentsCount: The number of segments sent during this view lifetime
+            ///   - segmentsTotalRawSize: The total size in bytes of the segments sent during this view lifetime
+            public init(
+                recordsCount: Int64? = nil,
+                segmentsCount: Int64? = nil,
+                segmentsTotalRawSize: Int64? = nil
+            ) {
+                self.recordsCount = recordsCount
+                self.segmentsCount = segmentsCount
+                self.segmentsTotalRawSize = segmentsTotalRawSize
             }
         }
 
@@ -11542,6 +11756,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// The upload frequency of batches (in milliseconds)
             public let batchUploadFrequency: Int64?
 
+            /// Whether the beta partial view updates feature is enabled
+            public var betaEnableViewUpdates: Bool?
+
             /// Whether the beta encode cookie options is enabled
             public var betaEncodeCookieOptions: Bool?
 
@@ -11815,6 +12032,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case batchProcessingLevel = "batch_processing_level"
                 case batchSize = "batch_size"
                 case batchUploadFrequency = "batch_upload_frequency"
+                case betaEnableViewUpdates = "beta_enable_view_updates"
                 case betaEncodeCookieOptions = "beta_encode_cookie_options"
                 case compressIntakeRequests = "compress_intake_requests"
                 case dartVersion = "dart_version"
@@ -11916,6 +12134,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - batchProcessingLevel: Maximum number of batches processed sequentially without a delay
             ///   - batchSize: The window duration for batches sent by the SDK (in milliseconds)
             ///   - batchUploadFrequency: The upload frequency of batches (in milliseconds)
+            ///   - betaEnableViewUpdates: Whether the beta partial view updates feature is enabled
             ///   - betaEncodeCookieOptions: Whether the beta encode cookie options is enabled
             ///   - compressIntakeRequests: Whether intake requests are compressed
             ///   - dartVersion: The version of Dart used in a Flutter application
@@ -12013,6 +12232,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 batchProcessingLevel: Int64? = nil,
                 batchSize: Int64? = nil,
                 batchUploadFrequency: Int64? = nil,
+                betaEnableViewUpdates: Bool? = nil,
                 betaEncodeCookieOptions: Bool? = nil,
                 compressIntakeRequests: Bool? = nil,
                 dartVersion: String? = nil,
@@ -12110,6 +12330,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.batchProcessingLevel = batchProcessingLevel
                 self.batchSize = batchSize
                 self.batchUploadFrequency = batchUploadFrequency
+                self.betaEnableViewUpdates = betaEnableViewUpdates
                 self.betaEncodeCookieOptions = betaEncodeCookieOptions
                 self.compressIntakeRequests = compressIntakeRequests
                 self.dartVersion = dartVersion
@@ -14057,4 +14278,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/2e1fe49897be86e72c0c2f0c2ae052c0d5f826eb
+// Generated from https://github.com/DataDog/rum-events-format/tree/543596f0d831ca9ee014cbae23ef4138eb2e0cb7

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -311,7 +311,17 @@ extension ResourceMetrics {
         // * if `200 OK` was preceded by `301` redirection, it will contain 2 transactions.
         let mainTransaction = transactions.last
         let redirectionTransactions = transactions.dropLast()
-        let isLocalCacheHit = taskMetrics.transactionMetrics.last?.resourceFetchType == .localCache
+        let isLocalCacheHit: Bool?
+        switch taskMetrics.transactionMetrics.last?.resourceFetchType {
+        case .some(.localCache):
+            isLocalCacheHit = true
+        case .some(.unknown), .none:
+            // `.unknown` means the fetch manner wasn't determined by `URLSession` - keep it as unknown
+            // rather than asserting a measured cache miss.
+            isLocalCacheHit = nil
+        default:
+            isLocalCacheHit = false
+        }
 
         var redirection: DateInterval? = nil
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -315,13 +315,14 @@ extension ResourceMetrics {
         switch taskMetrics.transactionMetrics.last?.resourceFetchType {
         case .some(.localCache):
             isLocalCacheHit = true
-        case .some(.networkLoad):
+        case .some(.networkLoad), .some(.serverPush):
             isLocalCacheHit = false
         case .some(.unknown), .none:
             // `.unknown` means the fetch manner wasn't determined by `URLSession` - keep it as unknown
             // rather than asserting a measured cache miss.
             isLocalCacheHit = nil
         default:
+            // Any fetch type not yet known to this SDK - keep as unknown rather than guessing.
             isLocalCacheHit = nil
         }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -315,12 +315,14 @@ extension ResourceMetrics {
         switch taskMetrics.transactionMetrics.last?.resourceFetchType {
         case .some(.localCache):
             isLocalCacheHit = true
+        case .some(.networkLoad):
+            isLocalCacheHit = false
         case .some(.unknown), .none:
             // `.unknown` means the fetch manner wasn't determined by `URLSession` - keep it as unknown
             // rather than asserting a measured cache miss.
             isLocalCacheHit = nil
         default:
-            isLocalCacheHit = false
+            isLocalCacheHit = nil
         }
 
         var redirection: DateInterval? = nil

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -267,7 +267,8 @@ public struct ResourceMetrics {
     public let requestBodySize: (encoded: Int64, decoded: Int64)?
 
     /// Indicates whether the resource was served from the device's local cache.
-    public let isLocalCacheHit: Bool
+    /// `nil` when this signal isn't known, e.g. metrics reported without real `URLSessionTaskMetrics`.
+    public let isLocalCacheHit: Bool?
 
     public init(
         fetch: DateInterval,
@@ -279,7 +280,7 @@ public struct ResourceMetrics {
         download: DateInterval?,
         responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
         requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
-        isLocalCacheHit: Bool = false
+        isLocalCacheHit: Bool? = nil
     ) {
         self.fetch = fetch
         self.redirection = redirection

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -266,7 +266,7 @@ public struct ResourceMetrics {
     /// - `decoded`: Size before encoding (original content size).
     public let requestBodySize: (encoded: Int64, decoded: Int64)?
 
-    /// Tells if the resource was served from the device's local cache.
+    /// Indicates whether the resource was served from the device's local cache.
     public let isLocalCacheHit: Bool
 
     public init(

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -266,6 +266,9 @@ public struct ResourceMetrics {
     /// - `decoded`: Size before encoding (original content size).
     public let requestBodySize: (encoded: Int64, decoded: Int64)?
 
+    /// Tells if the resource was served from the device's local cache.
+    public let isLocalCacheHit: Bool
+
     public init(
         fetch: DateInterval,
         redirection: DateInterval?,
@@ -275,7 +278,8 @@ public struct ResourceMetrics {
         firstByte: DateInterval?,
         download: DateInterval?,
         responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
-        requestBodySize: (encoded: Int64, decoded: Int64)? = nil
+        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
+        isLocalCacheHit: Bool = false
     ) {
         self.fetch = fetch
         self.redirection = redirection
@@ -286,6 +290,7 @@ public struct ResourceMetrics {
         self.download = download
         self.responseBodySize = responseBodySize
         self.requestBodySize = requestBodySize
+        self.isLocalCacheHit = isLocalCacheHit
     }
 }
 
@@ -305,6 +310,7 @@ extension ResourceMetrics {
         // * if `200 OK` was preceded by `301` redirection, it will contain 2 transactions.
         let mainTransaction = transactions.last
         let redirectionTransactions = transactions.dropLast()
+        let isLocalCacheHit = taskMetrics.transactionMetrics.last?.resourceFetchType == .localCache
 
         var redirection: DateInterval? = nil
 
@@ -376,7 +382,8 @@ extension ResourceMetrics {
             firstByte: firstByte,
             download: download,
             responseBodySize: responseBodySize,
-            requestBodySize: requestBodySize
+            requestBodySize: requestBodySize,
+            isLocalCacheHit: isLocalCacheHit
         )
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -375,4 +375,32 @@ class ResourceMetricsTests: XCTestCase {
         )
         XCTAssertEqual(resourceMetrics.isLocalCacheHit, true)
     }
+
+    func testWhenTaskFetchTypeIsUnknown_thenLocalCacheHitIsNil() {
+        guard #available(iOS 13, tvOS 13, *) else {
+            return
+        }
+
+        let taskInterval = DateInterval(
+            start: .mockDecember15th2019At10AMUTC(),
+            end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 5)
+        )
+        // Apple documents `.unknown` as "the fetch manner was not determined" -
+        // it must not be reported as a measured cache miss.
+        let taskTransaction: URLSessionTaskTransactionMetrics = .mockBySpreadingDetailsBetween(
+            start: taskInterval.start,
+            end: taskInterval.end,
+            resourceFetchType: .unknown
+        )
+
+        // When
+        let taskMetrics: URLSessionTaskMetrics = .mockWith(
+            taskInterval: taskInterval,
+            transactionMetrics: [taskTransaction]
+        )
+
+        // Then
+        let resourceMetrics = ResourceMetrics(taskMetrics: taskMetrics)
+        XCTAssertNil(resourceMetrics.isLocalCacheHit)
+    }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -376,57 +376,39 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.isLocalCacheHit, true)
     }
 
-    func testWhenTaskFetchTypeIsUnknown_thenLocalCacheHitIsNil() {
+    func testWhenTaskFetchTypeVaries_thenLocalCacheHitReflectsOnlyKnownSignals() {
         guard #available(iOS 13, tvOS 13, *) else {
             return
         }
 
-        let taskInterval = DateInterval(
-            start: .mockDecember15th2019At10AMUTC(),
-            end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 5)
-        )
-        // Apple documents `.unknown` as "the fetch manner was not determined" -
+        // `.unknown` is documented by Apple as "the fetch manner was not determined" -
         // it must not be reported as a measured cache miss.
-        let taskTransaction: URLSessionTaskTransactionMetrics = .mockBySpreadingDetailsBetween(
-            start: taskInterval.start,
-            end: taskInterval.end,
-            resourceFetchType: .unknown
-        )
+        let cases: [(fetchType: URLSessionTaskMetrics.ResourceFetchType, expected: Bool?)] = [
+            (.localCache, true),
+            (.networkLoad, false),
+            (.serverPush, false),
+            (.unknown, nil)
+        ]
 
-        // When
-        let taskMetrics: URLSessionTaskMetrics = .mockWith(
-            taskInterval: taskInterval,
-            transactionMetrics: [taskTransaction]
-        )
+        for testCase in cases {
+            XCTContext.runActivity(named: "\(testCase.fetchType)") { _ in
+                let taskInterval = DateInterval(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 5)
+                )
+                let taskTransaction: URLSessionTaskTransactionMetrics = .mockBySpreadingDetailsBetween(
+                    start: taskInterval.start,
+                    end: taskInterval.end,
+                    resourceFetchType: testCase.fetchType
+                )
+                let taskMetrics: URLSessionTaskMetrics = .mockWith(
+                    taskInterval: taskInterval,
+                    transactionMetrics: [taskTransaction]
+                )
 
-        // Then
-        let resourceMetrics = ResourceMetrics(taskMetrics: taskMetrics)
-        XCTAssertNil(resourceMetrics.isLocalCacheHit)
-    }
-
-    func testWhenTaskFetchTypeIsNetworkLoad_thenLocalCacheHitIsFalse() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
+                let resourceMetrics = ResourceMetrics(taskMetrics: taskMetrics)
+                XCTAssertEqual(resourceMetrics.isLocalCacheHit, testCase.expected)
+            }
         }
-
-        let taskInterval = DateInterval(
-            start: .mockDecember15th2019At10AMUTC(),
-            end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 5)
-        )
-        let taskTransaction: URLSessionTaskTransactionMetrics = .mockBySpreadingDetailsBetween(
-            start: taskInterval.start,
-            end: taskInterval.end,
-            resourceFetchType: .networkLoad
-        )
-
-        // When
-        let taskMetrics: URLSessionTaskMetrics = .mockWith(
-            taskInterval: taskInterval,
-            transactionMetrics: [taskTransaction]
-        )
-
-        // Then
-        let resourceMetrics = ResourceMetrics(taskMetrics: taskMetrics)
-        XCTAssertEqual(resourceMetrics.isLocalCacheHit, false)
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -403,4 +403,30 @@ class ResourceMetricsTests: XCTestCase {
         let resourceMetrics = ResourceMetrics(taskMetrics: taskMetrics)
         XCTAssertNil(resourceMetrics.isLocalCacheHit)
     }
+
+    func testWhenTaskFetchTypeIsNetworkLoad_thenLocalCacheHitIsFalse() {
+        guard #available(iOS 13, tvOS 13, *) else {
+            return
+        }
+
+        let taskInterval = DateInterval(
+            start: .mockDecember15th2019At10AMUTC(),
+            end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 5)
+        )
+        let taskTransaction: URLSessionTaskTransactionMetrics = .mockBySpreadingDetailsBetween(
+            start: taskInterval.start,
+            end: taskInterval.end,
+            resourceFetchType: .networkLoad
+        )
+
+        // When
+        let taskMetrics: URLSessionTaskMetrics = .mockWith(
+            taskInterval: taskInterval,
+            transactionMetrics: [taskTransaction]
+        )
+
+        // Then
+        let resourceMetrics = ResourceMetrics(taskMetrics: taskMetrics)
+        XCTAssertEqual(resourceMetrics.isLocalCacheHit, false)
+    }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -249,7 +249,7 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.responseBodySize?.decoded, taskTransaction.countOfResponseBodyBytesAfterDecoding)
         XCTAssertEqual(resourceMetrics.requestBodySize?.decoded, taskTransaction.countOfRequestBodyBytesBeforeEncoding)
         XCTAssertEqual(resourceMetrics.requestBodySize?.encoded, taskTransaction.countOfRequestBodyBytesSent)
-        XCTAssertFalse(resourceMetrics.isLocalCacheHit)
+        XCTAssertEqual(resourceMetrics.isLocalCacheHit, false)
     }
 
     func testWhenTaskMakesMultipleFetchesFromNetwork_thenAllMetricsAreCollected() {
@@ -373,6 +373,6 @@ class ResourceMetricsTests: XCTestCase {
             resourceMetrics.requestBodySize,
             "`requestBodySize` should not be tracked for cache transactions."
         )
-        XCTAssertTrue(resourceMetrics.isLocalCacheHit)
+        XCTAssertEqual(resourceMetrics.isLocalCacheHit, true)
     }
 }

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -249,6 +249,7 @@ class ResourceMetricsTests: XCTestCase {
         XCTAssertEqual(resourceMetrics.responseBodySize?.decoded, taskTransaction.countOfResponseBodyBytesAfterDecoding)
         XCTAssertEqual(resourceMetrics.requestBodySize?.decoded, taskTransaction.countOfRequestBodyBytesBeforeEncoding)
         XCTAssertEqual(resourceMetrics.requestBodySize?.encoded, taskTransaction.countOfRequestBodyBytesSent)
+        XCTAssertFalse(resourceMetrics.isLocalCacheHit)
     }
 
     func testWhenTaskMakesMultipleFetchesFromNetwork_thenAllMetricsAreCollected() {
@@ -372,5 +373,6 @@ class ResourceMetricsTests: XCTestCase {
             resourceMetrics.requestBodySize,
             "`requestBodySize` should not be tracked for cache transactions."
         )
+        XCTAssertTrue(resourceMetrics.isLocalCacheHit)
     }
 }

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -1413,6 +1413,10 @@ public class objc_RUMErrorEventDD: NSObject {
         root.swiftModel.dd.configuration != nil ? objc_RUMErrorEventDDConfiguration(root: root) : nil
     }
 
+    public var debugIds: [objc_RUMErrorEventDDDebugIds]? {
+        root.swiftModel.dd.debugIds?.map { objc_RUMErrorEventDDDebugIds(swiftModel: $0) }
+    }
+
     public var formatVersion: NSNumber {
         root.swiftModel.dd.formatVersion as NSNumber
     }
@@ -1470,6 +1474,26 @@ public class objc_RUMErrorEventDDConfiguration: NSObject {
 
     public var traceSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.traceSampleRate as NSNumber?
+    }
+}
+
+@objc(DDRUMErrorEventDDDebugIds)
+@objcMembers
+@_spi(objc)
+public class objc_RUMErrorEventDDDebugIds: NSObject {
+    internal var swiftModel: RUMErrorEvent.DD.DebugIds
+    internal var root: objc_RUMErrorEventDDDebugIds { self }
+
+    internal init(swiftModel: RUMErrorEvent.DD.DebugIds) {
+        self.swiftModel = swiftModel
+    }
+
+    public var id: String {
+        root.swiftModel.id
+    }
+
+    public var url: String {
+        root.swiftModel.url
     }
 }
 
@@ -3326,6 +3350,10 @@ public class objc_RUMLongTaskEventDD: NSObject {
         root.swiftModel.dd.configuration != nil ? objc_RUMLongTaskEventDDConfiguration(root: root) : nil
     }
 
+    public var debugIds: [objc_RUMLongTaskEventDDDebugIds]? {
+        root.swiftModel.dd.debugIds?.map { objc_RUMLongTaskEventDDDebugIds(swiftModel: $0) }
+    }
+
     public var discarded: NSNumber? {
         root.swiftModel.dd.discarded as NSNumber?
     }
@@ -3371,6 +3399,26 @@ public class objc_RUMLongTaskEventDDConfiguration: NSObject {
 
     public var traceSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.traceSampleRate as NSNumber?
+    }
+}
+
+@objc(DDRUMLongTaskEventDDDebugIds)
+@objcMembers
+@_spi(objc)
+public class objc_RUMLongTaskEventDDDebugIds: NSObject {
+    internal var swiftModel: RUMLongTaskEvent.DD.DebugIds
+    internal var root: objc_RUMLongTaskEventDDDebugIds { self }
+
+    internal init(swiftModel: RUMLongTaskEvent.DD.DebugIds) {
+        self.swiftModel = swiftModel
+    }
+
+    public var id: String {
+        root.swiftModel.id
+    }
+
+    public var url: String {
+        root.swiftModel.url
     }
 }
 
@@ -5305,6 +5353,10 @@ public class objc_RUMResourceEventResource: NSObject {
         root.swiftModel.resource.id
     }
 
+    public var localCacheHit: NSNumber? {
+        root.swiftModel.resource.localCacheHit as NSNumber?
+    }
+
     public var method: objc_RUMResourceEventResourceRUMMethod {
         .init(swift: root.swiftModel.resource.method)
     }
@@ -6343,6 +6395,10 @@ public class objc_RUMViewEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var remoteConfigurationId: String? {
+        root.swiftModel.dd.configuration!.remoteConfigurationId
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -8432,6 +8488,10 @@ public class objc_RUMViewUpdateEventDD: NSObject {
         root.swiftModel.dd.browserSdkVersion
     }
 
+    public var cls: objc_RUMViewUpdateEventDDCLS? {
+        root.swiftModel.dd.cls != nil ? objc_RUMViewUpdateEventDDCLS(root: root) : nil
+    }
+
     public var configuration: objc_RUMViewUpdateEventDDConfiguration? {
         root.swiftModel.dd.configuration != nil ? objc_RUMViewUpdateEventDDConfiguration(root: root) : nil
     }
@@ -8444,12 +8504,39 @@ public class objc_RUMViewUpdateEventDD: NSObject {
         root.swiftModel.dd.formatVersion as NSNumber
     }
 
+    public var pageStates: [objc_RUMViewUpdateEventDDPageStates]? {
+        root.swiftModel.dd.pageStates?.map { objc_RUMViewUpdateEventDDPageStates(swiftModel: $0) }
+    }
+
+    public var profiling: objc_RUMViewUpdateEventDDProfiling? {
+        root.swiftModel.dd.profiling != nil ? objc_RUMViewUpdateEventDDProfiling(root: root) : nil
+    }
+
+    public var replayStats: objc_RUMViewUpdateEventDDReplayStats? {
+        root.swiftModel.dd.replayStats != nil ? objc_RUMViewUpdateEventDDReplayStats(root: root) : nil
+    }
+
     public var sdkName: String? {
         root.swiftModel.dd.sdkName
     }
 
     public var session: objc_RUMViewUpdateEventDDSession? {
         root.swiftModel.dd.session != nil ? objc_RUMViewUpdateEventDDSession(root: root) : nil
+    }
+}
+
+@objc(DDRUMViewUpdateEventDDCLS)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventDDCLS: NSObject {
+    internal let root: objc_RUMViewUpdateEvent
+
+    internal init(root: objc_RUMViewUpdateEvent) {
+        self.root = root
+    }
+
+    public var devicePixelRatio: NSNumber? {
+        root.swiftModel.dd.cls!.devicePixelRatio as NSNumber?
     }
 }
 
@@ -8467,6 +8554,10 @@ public class objc_RUMViewUpdateEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var remoteConfigurationId: String? {
+        root.swiftModel.dd.configuration!.remoteConfigurationId
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -8475,8 +8566,207 @@ public class objc_RUMViewUpdateEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.sessionSampleRate as NSNumber
     }
 
+    public var startSessionReplayRecordingManually: NSNumber? {
+        root.swiftModel.dd.configuration!.startSessionReplayRecordingManually as NSNumber?
+    }
+
     public var traceSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.traceSampleRate as NSNumber?
+    }
+}
+
+@objc(DDRUMViewUpdateEventDDPageStates)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventDDPageStates: NSObject {
+    internal var swiftModel: RUMViewUpdateEvent.DD.PageStates
+    internal var root: objc_RUMViewUpdateEventDDPageStates { self }
+
+    internal init(swiftModel: RUMViewUpdateEvent.DD.PageStates) {
+        self.swiftModel = swiftModel
+    }
+
+    public var start: NSNumber {
+        root.swiftModel.start as NSNumber
+    }
+
+    public var state: objc_RUMViewUpdateEventDDPageStatesState {
+        .init(swift: root.swiftModel.state)
+    }
+}
+
+@objc(DDRUMViewUpdateEventDDPageStatesState)
+@_spi(objc)
+public enum objc_RUMViewUpdateEventDDPageStatesState: Int {
+    internal init(swift: RUMViewUpdateEvent.DD.PageStates.State) {
+        switch swift {
+        case .active: self = .active
+        case .passive: self = .passive
+        case .hidden: self = .hidden
+        case .frozen: self = .frozen
+        case .terminated: self = .terminated
+        }
+    }
+
+    internal var toSwift: RUMViewUpdateEvent.DD.PageStates.State {
+        switch self {
+        case .active: return .active
+        case .passive: return .passive
+        case .hidden: return .hidden
+        case .frozen: return .frozen
+        case .terminated: return .terminated
+        }
+    }
+
+    case active
+    case passive
+    case hidden
+    case frozen
+    case terminated
+}
+
+@objc(DDRUMViewUpdateEventDDProfiling)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventDDProfiling: NSObject {
+    internal let root: objc_RUMViewUpdateEvent
+
+    internal init(root: objc_RUMViewUpdateEvent) {
+        self.root = root
+    }
+
+    public var errorReason: objc_RUMViewUpdateEventDDProfilingErrorReason {
+        .init(swift: root.swiftModel.dd.profiling!.errorReason)
+    }
+
+    public var quotaReason: objc_RUMViewUpdateEventDDProfilingQuotaReason {
+        .init(swift: root.swiftModel.dd.profiling!.quotaReason)
+    }
+
+    public var status: objc_RUMViewUpdateEventDDProfilingStatus {
+        .init(swift: root.swiftModel.dd.profiling!.status)
+    }
+}
+
+@objc(DDRUMViewUpdateEventDDProfilingErrorReason)
+@_spi(objc)
+public enum objc_RUMViewUpdateEventDDProfilingErrorReason: Int {
+    internal init(swift: DDProfiling.ErrorReason?) {
+        switch swift {
+        case nil: self = .none
+        case .notSupportedByBrowser?: self = .notSupportedByBrowser
+        case .failedToLazyLoad?: self = .failedToLazyLoad
+        case .missingDocumentPolicyHeader?: self = .missingDocumentPolicyHeader
+        case .unexpectedException?: self = .unexpectedException
+        }
+    }
+
+    internal var toSwift: DDProfiling.ErrorReason? {
+        switch self {
+        case .none: return nil
+        case .notSupportedByBrowser: return .notSupportedByBrowser
+        case .failedToLazyLoad: return .failedToLazyLoad
+        case .missingDocumentPolicyHeader: return .missingDocumentPolicyHeader
+        case .unexpectedException: return .unexpectedException
+        }
+    }
+
+    case none
+    case notSupportedByBrowser
+    case failedToLazyLoad
+    case missingDocumentPolicyHeader
+    case unexpectedException
+}
+
+@objc(DDRUMViewUpdateEventDDProfilingQuotaReason)
+@_spi(objc)
+public enum objc_RUMViewUpdateEventDDProfilingQuotaReason: Int {
+    internal init(swift: DDProfiling.QuotaReason?) {
+        switch swift {
+        case nil: self = .none
+        case .quotaOk?: self = .quotaOk
+        case .quotaExceeded?: self = .quotaExceeded
+        case .orgDisabled?: self = .orgDisabled
+        case .backendUnavailable?: self = .backendUnavailable
+        case .undefined?: self = .undefined
+        case .timeout?: self = .timeout
+        case .apiError?: self = .apiError
+        }
+    }
+
+    internal var toSwift: DDProfiling.QuotaReason? {
+        switch self {
+        case .none: return nil
+        case .quotaOk: return .quotaOk
+        case .quotaExceeded: return .quotaExceeded
+        case .orgDisabled: return .orgDisabled
+        case .backendUnavailable: return .backendUnavailable
+        case .undefined: return .undefined
+        case .timeout: return .timeout
+        case .apiError: return .apiError
+        }
+    }
+
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+}
+
+@objc(DDRUMViewUpdateEventDDProfilingStatus)
+@_spi(objc)
+public enum objc_RUMViewUpdateEventDDProfilingStatus: Int {
+    internal init(swift: DDProfiling.Status?) {
+        switch swift {
+        case nil: self = .none
+        case .starting?: self = .starting
+        case .running?: self = .running
+        case .stopped?: self = .stopped
+        case .error?: self = .error
+        }
+    }
+
+    internal var toSwift: DDProfiling.Status? {
+        switch self {
+        case .none: return nil
+        case .starting: return .starting
+        case .running: return .running
+        case .stopped: return .stopped
+        case .error: return .error
+        }
+    }
+
+    case none
+    case starting
+    case running
+    case stopped
+    case error
+}
+
+@objc(DDRUMViewUpdateEventDDReplayStats)
+@objcMembers
+@_spi(objc)
+public class objc_RUMViewUpdateEventDDReplayStats: NSObject {
+    internal let root: objc_RUMViewUpdateEvent
+
+    internal init(root: objc_RUMViewUpdateEvent) {
+        self.root = root
+    }
+
+    public var recordsCount: NSNumber? {
+        root.swiftModel.dd.replayStats!.recordsCount as NSNumber?
+    }
+
+    public var segmentsCount: NSNumber? {
+        root.swiftModel.dd.replayStats!.segmentsCount as NSNumber?
+    }
+
+    public var segmentsTotalRawSize: NSNumber? {
+        root.swiftModel.dd.replayStats!.segmentsTotalRawSize as NSNumber?
     }
 }
 
@@ -13910,6 +14200,11 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
         root.swiftModel.telemetry.configuration.batchUploadFrequency as NSNumber?
     }
 
+    public var betaEnableViewUpdates: NSNumber? {
+        set { root.swiftModel.telemetry.configuration.betaEnableViewUpdates = newValue?.boolValue }
+        get { root.swiftModel.telemetry.configuration.betaEnableViewUpdates as NSNumber? }
+    }
+
     public var betaEncodeCookieOptions: NSNumber? {
         set { root.swiftModel.telemetry.configuration.betaEncodeCookieOptions = newValue?.boolValue }
         get { root.swiftModel.telemetry.configuration.betaEncodeCookieOptions as NSNumber? }
@@ -15300,4 +15595,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/2e1fe49897be86e72c0c2f0c2ae052c0d5f826eb
+// Generated from https://github.com/DataDog/rum-events-format/tree/543596f0d831ca9ee014cbae23ef4138eb2e0cb7

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -178,6 +178,10 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
             }
         }
 
+        if interception.metrics?.isLocalCacheHit == true {
+            combinedAttributes[CrossPlatformAttributes.localCacheHit] = true
+        }
+
         if let resourceMetrics = interception.metrics {
             subscriber.process(
                 command: RUMAddResourceMetricsCommand(

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -207,6 +207,8 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
         }
 
         if let error = interception.completion?.error {
+            var errorAttributes = combinedAttributes
+            errorAttributes.removeValue(forKey: CrossPlatformAttributes.localCacheHit)
             subscriber.process(
                 command: RUMStopResourceWithErrorCommand(
                     resourceKey: interception.identifier.uuidString,
@@ -215,7 +217,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
                     source: .network,
                     httpStatusCode: interception.completion?.httpResponse?.statusCode,
                     globalAttributes: [:],
-                    attributes: combinedAttributes
+                    attributes: errorAttributes
                 )
             )
         }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -291,6 +291,8 @@ internal class RUMResourceScope: RUMScope {
 
     private func sendErrorEvent(on command: RUMStopResourceWithErrorCommand, context: DatadogContext, writer: Writer) {
         let errorFingerprint: String? = attributes.removeValue(forKey: RUM.Attributes.errorFingerprint)?.dd.decode()
+        // Never leak the internal cache-hit marker into arbitrary error context.
+        attributes.removeValue(forKey: CrossPlatformAttributes.localCacheHit)
         let timeSinceAppStart = command.time.timeIntervalSince(context.launchInfo.processLaunchDate).dd.toInt64Milliseconds
 
         // Trace context from cross-platform attributes or spanContext fallback

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -129,7 +129,7 @@ internal class RUMResourceScope: RUMScope {
         // Extract captured HTTP headers
         let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.requestHeaders)?.dd.decode()
         let responseHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.responseHeaders)?.dd.decode()
-        let localCacheHit: Bool? = attributes.removeValue(forKey: CrossPlatformAttributes.localCacheHit)?.dd.decode()
+        let localCacheHit: Bool? = attributes.removeValue(forKey: CrossPlatformAttributes.localCacheHit)?.dd.decode() ?? resourceMetrics?.isLocalCacheHit
 
         // Metrics values take precedence over other values.
         if let metrics = resourceMetrics {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -129,6 +129,7 @@ internal class RUMResourceScope: RUMScope {
         // Extract captured HTTP headers
         let requestHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.requestHeaders)?.dd.decode()
         let responseHeaders: [String: String]? = attributes.removeValue(forKey: CrossPlatformAttributes.responseHeaders)?.dd.decode()
+        let localCacheHit: Bool? = attributes.removeValue(forKey: CrossPlatformAttributes.localCacheHit)?.dd.decode()
 
         // Metrics values take precedence over other values.
         if let metrics = resourceMetrics {
@@ -230,6 +231,7 @@ internal class RUMResourceScope: RUMScope {
                 },
                 graphql: graphql,
                 id: resourceUUID.toRUMDataFormat,
+                localCacheHit: localCacheHit,
                 method: resourceHTTPMethod,
                 protocol: nil,
                 provider: resourceEventProvider,

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -728,6 +728,32 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertNil(resourceStopCommand.httpStatusCode)
     }
 
+    func testGivenTaskInterceptionWithLocalCacheHitMetricsAndError_whenInterceptionCompletes_itOmitsLocalCacheHitAttributeFromErrorCommand() throws {
+        let receiveCommands = expectation(description: "Receive 2 RUM commands")
+        receiveCommands.expectedFulfillmentCount = 2
+        var commandsReceived: [RUMCommand] = []
+        commandSubscriber.onCommandReceived = { command in
+            commandsReceived.append(command)
+            receiveCommands.fulfill()
+        }
+
+        // Given
+        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random(), trackingMode: .mockRandom())
+        let taskError = NSError(domain: "domain", code: 123, userInfo: [NSLocalizedDescriptionKey: "network error"])
+        let resourceMetrics = ResourceMetrics.mockWith(isLocalCacheHit: true)
+        taskInterception.register(metrics: resourceMetrics)
+        taskInterception.register(response: nil, error: taskError)
+
+        // When
+        handler.interceptionDidComplete(interception: taskInterception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let resourceStopCommand = try XCTUnwrap(commandsReceived[1] as? RUMStopResourceWithErrorCommand)
+        XCTAssertNil(resourceStopCommand.attributes[CrossPlatformAttributes.localCacheHit])
+    }
+
     // MARK: - RUM Resource Attributes Provider
 
     func testGivenRUMAttributesProviderRegistered_whenInterceptionCompletesWithResponse_itAddsCustomRUMAttributes() throws {

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -635,6 +635,60 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertNotEqual(resourceStopCommand.size, taskInterception.metrics?.responseBodySize?.decoded, "Should not use metrics.responseBodySize?.decoded when it is 0")
     }
 
+    func testGivenTaskInterceptionWithLocalCacheHitMetrics_whenInterceptionCompletes_itSetsLocalCacheHitAttribute() throws {
+        let receiveCommand = expectation(description: "Receive RUMStopResourceCommand")
+        var stopResourceCommand: RUMStopResourceCommand?
+        commandSubscriber.onCommandReceived = { command in
+            if let command = command as? RUMStopResourceCommand {
+                stopResourceCommand = command
+                receiveCommand.fulfill()
+            }
+        }
+
+        // Given
+        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random(), trackingMode: .registeredDelegate)
+        let resourceMetrics = ResourceMetrics.mockWith(isLocalCacheHit: true)
+        taskInterception.register(metrics: resourceMetrics)
+        let response: HTTPURLResponse = .mockResponseWith(statusCode: 200)
+        taskInterception.register(response: response, error: nil)
+
+        // When
+        handler.interceptionDidComplete(interception: taskInterception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
+        XCTAssertEqual(attributes[CrossPlatformAttributes.localCacheHit] as? Bool, true)
+    }
+
+    func testGivenTaskInterceptionWithoutLocalCacheHitMetrics_whenInterceptionCompletes_itOmitsLocalCacheHitAttribute() throws {
+        let receiveCommand = expectation(description: "Receive RUMStopResourceCommand")
+        var stopResourceCommand: RUMStopResourceCommand?
+        commandSubscriber.onCommandReceived = { command in
+            if let command = command as? RUMStopResourceCommand {
+                stopResourceCommand = command
+                receiveCommand.fulfill()
+            }
+        }
+
+        // Given
+        let taskInterception = URLSessionTaskInterception(request: .mockAny(), isFirstParty: .random(), trackingMode: .registeredDelegate)
+        let resourceMetrics = ResourceMetrics.mockWith(isLocalCacheHit: false)
+        taskInterception.register(metrics: resourceMetrics)
+        let response: HTTPURLResponse = .mockResponseWith(statusCode: 200)
+        taskInterception.register(response: response, error: nil)
+
+        // When
+        handler.interceptionDidComplete(interception: taskInterception)
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let attributes = try XCTUnwrap(stopResourceCommand?.attributes)
+        XCTAssertNil(attributes[CrossPlatformAttributes.localCacheHit])
+    }
+
     func testGivenTaskInterceptionWithMetricsAndError_whenInterceptionCompletes_itStopsRUMResourceWithErrorAndMetrics() throws {
         let receiveCommands = expectation(description: "Receive 2 RUM commands")
         receiveCommands.expectedFulfillmentCount = 2

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1939,6 +1939,47 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(event.resource.localCacheHit)
     }
 
+    func testWhenResourceMetricsIndicateLocalCacheHitAndStopCommandHasNoAttribute_itPopulatesResourceLocalCacheHit() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/api/data",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/data",
+            httpMethod: .get
+        )
+
+        let metricsCommand = RUMAddResourceMetricsCommand(
+            resourceKey: "/api/data",
+            time: .mockDecember15th2019At10AMUTC(),
+            attributes: [:],
+            metrics: .mockWith(isLocalCacheHit: true)
+        )
+
+        // When
+        XCTAssertTrue(scope.process(command: metricsCommand, context: context, writer: writer))
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceKey: "/api/data",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    attributes: [:],
+                    kind: .xhr,
+                    httpStatusCode: 200,
+                    size: nil
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
+        XCTAssertEqual(event.resource.localCacheHit, true)
+    }
+
     func testWhenStopCommandContainsRequestHeadersAndBodySizeMetrics_itPopulatesBoth() throws {
         // Given
         let scope = RUMResourceScope.mockWith(

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1980,6 +1980,49 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.resource.localCacheHit, true)
     }
 
+    func testWhenResourceMetricsHaveNoCacheSignalAndStopCommandHasNoAttribute_itLeavesResourceLocalCacheHitNil() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/api/data",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/data",
+            httpMethod: .get
+        )
+
+        // Mirrors metrics reported via the cross-platform `addResourceMetrics(at:fetch:...)` API,
+        // which has no notion of cache status at all.
+        let metricsCommand = RUMAddResourceMetricsCommand(
+            resourceKey: "/api/data",
+            time: .mockDecember15th2019At10AMUTC(),
+            attributes: [:],
+            metrics: .mockWith(isLocalCacheHit: nil)
+        )
+
+        // When
+        XCTAssertTrue(scope.process(command: metricsCommand, context: context, writer: writer))
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceKey: "/api/data",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    attributes: [:],
+                    kind: .xhr,
+                    httpStatusCode: 200,
+                    size: nil
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
+        XCTAssertNil(event.resource.localCacheHit)
+    }
+
     func testWhenStopCommandContainsRequestHeadersAndBodySizeMetrics_itPopulatesBoth() throws {
         // Given
         let scope = RUMResourceScope.mockWith(

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1873,6 +1873,72 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(headers.headersInfo["etag"], "\"abc\"")
     }
 
+    func testWhenStopCommandContainsLocalCacheHit_itPopulatesResourceLocalCacheHit() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/api/data",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/data",
+            httpMethod: .get
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceKey: "/api/data",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    attributes: [
+                        CrossPlatformAttributes.localCacheHit: true
+                    ],
+                    kind: .xhr,
+                    httpStatusCode: 200,
+                    size: nil
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
+        XCTAssertEqual(event.resource.localCacheHit, true)
+    }
+
+    func testWhenStopCommandDoesNotContainLocalCacheHit_itLeavesResourceLocalCacheHitNil() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/api/data",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://api.example.com/data",
+            httpMethod: .get
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceKey: "/api/data",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1),
+                    attributes: [:],
+                    kind: .xhr,
+                    httpStatusCode: 200,
+                    size: nil
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMResourceEvent.self).first)
+        XCTAssertNil(event.resource.localCacheHit)
+    }
+
     func testWhenStopCommandContainsRequestHeadersAndBodySizeMetrics_itPopulatesBoth() throws {
         // Given
         let scope = RUMResourceScope.mockWith(

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -2023,6 +2023,42 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(event.resource.localCacheHit)
     }
 
+    func testWhenStopWithErrorCommandContainsLocalCacheHit_itDoesNotLeakItIntoErrorContext() throws {
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            parent: provider,
+            dependencies: dependencies,
+            resourceKey: "/resource/1",
+            startTime: .mockDecember15th2019At10AMUTC(),
+            url: "https://foo.com/resource/1",
+            httpMethod: .post
+        )
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceKey: "/resource/1",
+                    time: .mockDecember15th2019At10AMUTC(addingTimeInterval: 2),
+                    error: ErrorMock("network issue explanation"),
+                    source: .network,
+                    httpStatusCode: 500,
+                    globalAttributes: [:],
+                    attributes: [
+                        "foo": "bar",
+                        CrossPlatformAttributes.localCacheHit: true
+                    ]
+                ),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(writer.events(ofType: RUMErrorEvent.self).first)
+        XCTAssertEqual(event.context?.contextInfo as? [String: String], ["foo": "bar"])
+    }
+
     func testWhenStopCommandContainsRequestHeadersAndBodySizeMetrics_itPopulatesBoth() throws {
         // Given
         let scope = RUMResourceScope.mockWith(

--- a/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
@@ -223,7 +223,8 @@ extension ResourceMetrics: AnyMockable {
         firstByte: DateInterval? = nil,
         download: DateInterval? = nil,
         responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
-        requestBodySize: (encoded: Int64, decoded: Int64)? = nil
+        requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
+        isLocalCacheHit: Bool = false
     ) -> Self {
         return .init(
             fetch: fetch,
@@ -234,7 +235,8 @@ extension ResourceMetrics: AnyMockable {
             firstByte: firstByte,
             download: download,
             responseBodySize: responseBodySize,
-            requestBodySize: requestBodySize
+            requestBodySize: requestBodySize,
+            isLocalCacheHit: isLocalCacheHit
         )
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/NetworkInstrumentationMocks.swift
@@ -224,7 +224,7 @@ extension ResourceMetrics: AnyMockable {
         download: DateInterval? = nil,
         responseBodySize: (encoded: Int64, decoded: Int64)? = nil,
         requestBodySize: (encoded: Int64, decoded: Int64)? = nil,
-        isLocalCacheHit: Bool = false
+        isLocalCacheHit: Bool? = nil
     ) -> Self {
         return .init(
             fetch: fetch,

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -652,6 +652,7 @@ public class objc_RUMErrorEvent: NSObject
 public class objc_RUMErrorEventDD: NSObject
     public var browserSdkVersion: String?
     public var configuration: objc_RUMErrorEventDDConfiguration?
+    public var debugIds: [objc_RUMErrorEventDDDebugIds]?
     public var formatVersion: NSNumber
     public var parentSpanId: String?
     public var profiling: objc_RUMErrorEventDDProfiling?
@@ -665,6 +666,9 @@ public class objc_RUMErrorEventDDConfiguration: NSObject
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
+public class objc_RUMErrorEventDDDebugIds: NSObject
+    public var id: String
+    public var url: String
 public class objc_RUMErrorEventDDProfiling: NSObject
     public var errorReason: objc_RUMErrorEventDDProfilingErrorReason
     public var quotaReason: objc_RUMErrorEventDDProfilingQuotaReason
@@ -1035,6 +1039,7 @@ public class objc_RUMLongTaskEvent: NSObject
 public class objc_RUMLongTaskEventDD: NSObject
     public var browserSdkVersion: String?
     public var configuration: objc_RUMLongTaskEventDDConfiguration?
+    public var debugIds: [objc_RUMLongTaskEventDDDebugIds]?
     public var discarded: NSNumber?
     public var formatVersion: NSNumber
     public var profiling: objc_RUMLongTaskEventDDProfiling?
@@ -1045,6 +1050,9 @@ public class objc_RUMLongTaskEventDDConfiguration: NSObject
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
+public class objc_RUMLongTaskEventDDDebugIds: NSObject
+    public var id: String
+    public var url: String
 public class objc_RUMLongTaskEventDDProfiling: NSObject
     public var errorReason: objc_RUMLongTaskEventDDProfilingErrorReason
     public var quotaReason: objc_RUMLongTaskEventDDProfilingQuotaReason
@@ -1426,6 +1434,7 @@ public class objc_RUMResourceEventResource: NSObject
     public var firstByte: objc_RUMResourceEventResourceFirstByte?
     public var graphql: objc_RUMResourceEventResourceRUMGraphql?
     public var id: String?
+    public var localCacheHit: NSNumber?
     public var method: objc_RUMResourceEventResourceRUMMethod
     public var `protocol`: String?
     public var provider: objc_RUMResourceEventResourceProvider?
@@ -1631,6 +1640,7 @@ public class objc_RUMViewEventDDCLS: NSObject
     public var devicePixelRatio: NSNumber?
 public class objc_RUMViewEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var remoteConfigurationId: String?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var startSessionReplayRecordingManually: NSNumber?
@@ -2044,16 +2054,62 @@ public class objc_RUMViewUpdateEvent: NSObject
     public var view: objc_RUMViewUpdateEventView
 public class objc_RUMViewUpdateEventDD: NSObject
     public var browserSdkVersion: String?
+    public var cls: objc_RUMViewUpdateEventDDCLS?
     public var configuration: objc_RUMViewUpdateEventDDConfiguration?
     public var documentVersion: NSNumber
     public var formatVersion: NSNumber
+    public var pageStates: [objc_RUMViewUpdateEventDDPageStates]?
+    public var profiling: objc_RUMViewUpdateEventDDProfiling?
+    public var replayStats: objc_RUMViewUpdateEventDDReplayStats?
     public var sdkName: String?
     public var session: objc_RUMViewUpdateEventDDSession?
+public class objc_RUMViewUpdateEventDDCLS: NSObject
+    public var devicePixelRatio: NSNumber?
 public class objc_RUMViewUpdateEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var remoteConfigurationId: String?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
+    public var startSessionReplayRecordingManually: NSNumber?
     public var traceSampleRate: NSNumber?
+public class objc_RUMViewUpdateEventDDPageStates: NSObject
+    public var start: NSNumber
+    public var state: objc_RUMViewUpdateEventDDPageStatesState
+public enum objc_RUMViewUpdateEventDDPageStatesState: Int
+    case active
+    case passive
+    case hidden
+    case frozen
+    case terminated
+public class objc_RUMViewUpdateEventDDProfiling: NSObject
+    public var errorReason: objc_RUMViewUpdateEventDDProfilingErrorReason
+    public var quotaReason: objc_RUMViewUpdateEventDDProfilingQuotaReason
+    public var status: objc_RUMViewUpdateEventDDProfilingStatus
+public enum objc_RUMViewUpdateEventDDProfilingErrorReason: Int
+    case none
+    case notSupportedByBrowser
+    case failedToLazyLoad
+    case missingDocumentPolicyHeader
+    case unexpectedException
+public enum objc_RUMViewUpdateEventDDProfilingQuotaReason: Int
+    case none
+    case quotaOk
+    case quotaExceeded
+    case orgDisabled
+    case backendUnavailable
+    case undefined
+    case timeout
+    case apiError
+public enum objc_RUMViewUpdateEventDDProfilingStatus: Int
+    case none
+    case starting
+    case running
+    case stopped
+    case error
+public class objc_RUMViewUpdateEventDDReplayStats: NSObject
+    public var recordsCount: NSNumber?
+    public var segmentsCount: NSNumber?
+    public var segmentsTotalRawSize: NSNumber?
 public class objc_RUMViewUpdateEventDDSession: NSObject
     public var plan: objc_RUMViewUpdateEventDDSessionPlan
     public var sessionPrecondition: objc_RUMViewUpdateEventDDSessionRUMSessionPrecondition
@@ -3128,6 +3184,7 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject
     public var batchProcessingLevel: NSNumber?
     public var batchSize: NSNumber?
     public var batchUploadFrequency: NSNumber?
+    public var betaEnableViewUpdates: NSNumber?
     public var betaEncodeCookieOptions: NSNumber?
     public var compressIntakeRequests: NSNumber?
     public var dartVersion: String?


### PR DESCRIPTION
### What and why?

Forwards a `local_cache_hit` boolean on RUM resource events, derived from `URLSessionTaskTransactionMetrics.resourceFetchType == .localCache`.

The backend already accepts `resource.local_cache_hit` to compute `cache_status`/`cache_reason`. No SDK currently sends it; browsers rely on a zero byte transfer size heuristic instead.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs, see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs