### PR TITLE
[RUM-16945] Harden stats flush window math and test assertions

### DIFF
--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -286,12 +286,30 @@ internal final class StatsConcentrator: @unchecked Sendable {
                 return []
             }
 
-            let cutoff = force ? Int64.max : Int64(now) - Int64(bufferLen) * Int64(bucketDuration)
+            // A bucket is complete once it is older than the retention window ending at `now`, i.e.
+            // when `ts <= now - window`. Comparisons stay in the `UInt64` domain: a pathological span
+            // whose start time saturated to `UInt64.max` could produce a bucket key above `Int64.max`,
+            // and casting that to `Int64` would trap and crash the host app.
+            //
+            // When `now < window`, `now - window` would be negative, so no bucket is old enough yet and
+            // nothing (short of a forced flush) is eligible. Clamping the cutoff to `0` instead would
+            // wrongly flush a bucket sitting exactly at `ts == 0`, so guard that case explicitly rather
+            // than relying on a clamped cutoff.
+            let window = UInt64(bufferLen) * bucketDuration
+            let isFlushable: (UInt64) -> Bool
+            if force {
+                isFlushable = { _ in true }
+            } else if now >= window {
+                let cutoff = now - window
+                isFlushable = { $0 <= cutoff }
+            } else {
+                isFlushable = { _ in false }
+            }
             var flushed: [ExportedBucket] = []
             var keysToRemove: [UInt64] = []
 
             for (ts, bucket) in buckets {
-                if Int64(ts) > cutoff {
+                if !isFlushable(ts) {
                     continue
                 }
                 keysToRemove.append(ts)

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -195,8 +195,23 @@ internal final class StatsConcentrator: @unchecked Sendable {
         "server.address"
     ]
 
+    /// Length of each aggregation window, in nanoseconds. A finished span is placed in the bucket
+    /// whose start is its end time rounded down to a multiple of this value, so all spans completing
+    /// within the same window aggregate together. Defaults to `defaultBucketDuration` (10s), matching
+    /// the backend's stats granularity.
     private let bucketDuration: Nanoseconds
+
+    /// How many recent bucket windows to retain before a window becomes eligible for flush. With the
+    /// default of `2`, the current and immediately preceding windows are held back so late-arriving
+    /// spans can still land in their window; only windows older than that are exported. This trades a
+    /// small flush delay for fewer partially-filled buckets. Matches Go's `defaultBufferLen`.
     private let bufferLen: Int
+
+    /// Span attribute keys whose values are promoted to peer tags and folded into the aggregation key
+    /// for client/producer/consumer spans (e.g. `peer.service`, `db.instance`). These act as extra
+    /// stats dimensions, so the set must match the backend's configured peer tags: an over- or
+    /// under-broad set would split or merge groups differently than the backend expects. Defaults to
+    /// `defaultPeerTagKeys`.
     private let peerTagKeys: [String]
 
     /// Serial queue protecting `buckets` and `oldestTs`.
@@ -218,6 +233,20 @@ internal final class StatsConcentrator: @unchecked Sendable {
     /// otherwise leave the backend with no stats and no client bucket for that window.
     private var currentConsent: TrackingConsent
 
+    /// Creates a concentrator.
+    ///
+    /// Bucketing and flushing are driven by the `now` value passed to each `add`/`flush` call rather
+    /// than by wall-clock reads, which keeps the type deterministic and testable; `now` here only
+    /// seeds the initial `oldestTs`.
+    ///
+    /// - Parameters:
+    ///   - now: Current time in nanoseconds, used to seed `oldestTs` (the earliest window that still
+    ///     accepts spans).
+    ///   - initialConsent: Tracking consent at creation. `.granted`/`.pending` record, `.notGranted`
+    ///     drops. Defaults to `.pending` (record-but-hold) — see `currentConsent`.
+    ///   - bucketDuration: See `bucketDuration`. Defaults to `defaultBucketDuration`.
+    ///   - bufferLen: See `bufferLen`. Defaults to `defaultBufferLen`.
+    ///   - peerTagKeys: See `peerTagKeys`. Defaults to `defaultPeerTagKeys`.
     init(
         now: Nanoseconds,
         initialConsent: TrackingConsent = .pending,

--- a/DatadogTrace/Tests/StatsConcentratorTests.swift
+++ b/DatadogTrace/Tests/StatsConcentratorTests.swift
@@ -102,7 +102,7 @@ class StatsConcentratorTests: XCTestCase {
         XCTAssertTrue(buckets.isEmpty)
     }
 
-    func testSingleSpanProducesOneGroupInOneBucket() {
+    func testSingleSpanProducesOneGroupInOneBucket() throws {
         let concentrator = makeConcentrator(now: 0)
 
         let snapshot = SpanSnapshot.mockWith(
@@ -118,10 +118,10 @@ class StatsConcentratorTests: XCTestCase {
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
 
         XCTAssertEqual(buckets.count, 1)
-        let bucket = buckets[0]
+        let bucket = try XCTUnwrap(buckets.first)
         XCTAssertEqual(bucket.stats.count, 1)
 
-        let stats = bucket.stats[0]
+        let stats = try XCTUnwrap(bucket.stats.first)
         XCTAssertEqual(stats.service, "web")
         XCTAssertEqual(stats.name, "http.request")
         XCTAssertEqual(stats.resource, "GET /api")
@@ -130,7 +130,7 @@ class StatsConcentratorTests: XCTestCase {
         XCTAssertEqual(stats.topLevelHits, 1)
     }
 
-    func testMultipleSpansWithSameKeyAggregateIntoOneGroup() {
+    func testMultipleSpansWithSameKeyAggregateIntoOneGroup() throws {
         let concentrator = makeConcentrator(now: 0)
 
         for i in 0..<5 {
@@ -149,7 +149,7 @@ class StatsConcentratorTests: XCTestCase {
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
         XCTAssertEqual(buckets.count, 1)
 
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
         XCTAssertEqual(stats.hits, 5)
         XCTAssertEqual(stats.topLevelHits, 5)
     }
@@ -176,10 +176,10 @@ class StatsConcentratorTests: XCTestCase {
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
         XCTAssertEqual(buckets.count, 1)
-        XCTAssertEqual(buckets[0].stats.count, 2)
+        XCTAssertEqual(buckets.first?.stats.count, 2)
     }
 
-    func testErrorSpansIncrementErrorCount() {
+    func testErrorSpansIncrementErrorCount() throws {
         let concentrator = makeConcentrator(now: 0)
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -197,12 +197,12 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
         XCTAssertEqual(stats.hits, 2)
         XCTAssertEqual(stats.errors, 1)
     }
 
-    func testDurationIsAccumulatedAcrossSpans() {
+    func testDurationIsAccumulatedAcrossSpans() throws {
         let concentrator = makeConcentrator(now: 0)
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -218,11 +218,11 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
         XCTAssertEqual(stats.duration, 10_000_000_000)
     }
 
-    func testNonTopLevelSpanDoesNotIncrementTopLevelHits() {
+    func testNonTopLevelSpanDoesNotIncrementTopLevelHits() throws {
         let concentrator = makeConcentrator(now: 0)
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -234,7 +234,7 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
         XCTAssertEqual(stats.hits, 1)
         XCTAssertEqual(stats.topLevelHits, 0)
     }
@@ -263,8 +263,8 @@ class StatsConcentratorTests: XCTestCase {
         XCTAssertEqual(buckets.count, 2)
 
         let sortedBuckets = buckets.sorted { $0.start < $1.start }
-        XCTAssertEqual(sortedBuckets[0].start, 0)
-        XCTAssertEqual(sortedBuckets[1].start, 10_000_000_000)
+        XCTAssertEqual(sortedBuckets.first?.start, 0)
+        XCTAssertEqual(sortedBuckets.last?.start, 10_000_000_000)
     }
 
     func testBucketAlignment() {
@@ -311,12 +311,12 @@ class StatsConcentratorTests: XCTestCase {
         // Bucket 20s (ts=20 > 5) stays.
         let midBuckets = concentrator.flush(now: 25_000_000_000, force: false)
         XCTAssertEqual(midBuckets.count, 1)
-        XCTAssertEqual(midBuckets[0].start, 0)
+        XCTAssertEqual(midBuckets.first?.start, 0)
 
         // At t=45s, cutoff = 45 - 20 = 25. Bucket 20s (ts=20 <= 25) is flushed.
         let lateBuckets = concentrator.flush(now: 45_000_000_000, force: false)
         XCTAssertEqual(lateBuckets.count, 1)
-        XCTAssertEqual(lateBuckets[0].start, 20_000_000_000)
+        XCTAssertEqual(lateBuckets.first?.start, 20_000_000_000)
     }
 
     func testForceFlushReturnsAllBuckets() {
@@ -402,7 +402,7 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertEqual(buckets[0].stats.count, 2)
+        XCTAssertEqual(buckets.first?.stats.count, 2)
     }
 
     func testDifferentHTTPStatusCodesProduceSeparateGroups() {
@@ -424,10 +424,10 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertEqual(buckets[0].stats.count, 2)
+        XCTAssertEqual(buckets.first?.stats.count, 2)
     }
 
-    func testIsTraceRootDerivedFromParentSpanID() {
+    func testIsTraceRootDerivedFromParentSpanID() throws {
         let concentrator = makeConcentrator(now: 0)
 
         // Root span (no parent)
@@ -448,17 +448,18 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertEqual(buckets[0].stats.count, 2)
+        let stats = try XCTUnwrap(buckets.first).stats
+        XCTAssertEqual(stats.count, 2)
 
-        let root = buckets[0].stats.first { $0.isTraceRoot == .true }
-        let child = buckets[0].stats.first { $0.isTraceRoot == .false }
+        let root = stats.first { $0.isTraceRoot == .true }
+        let child = stats.first { $0.isTraceRoot == .false }
         XCTAssertNotNil(root)
         XCTAssertNotNil(child)
     }
 
     // MARK: - Peer Tags
 
-    func testPeerTagsIncludedForClientSpanKind() {
+    func testPeerTagsIncludedForClientSpanKind() throws {
         let concentrator = makeConcentrator(now: 0, peerTagKeys: ["peer.service", "out.host"])
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -471,13 +472,13 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
         XCTAssertEqual(stats.peerTags.count, 2)
         XCTAssertTrue(stats.peerTags.contains("peer.service:downstream-svc"))
         XCTAssertTrue(stats.peerTags.contains("out.host:db.example.com"))
     }
 
-    func testPeerTagsNotIncludedForServerSpanKind() {
+    func testPeerTagsNotIncludedForServerSpanKind() throws {
         let concentrator = makeConcentrator(now: 0, peerTagKeys: ["peer.service"])
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -490,11 +491,11 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
         XCTAssertTrue(stats.peerTags.isEmpty)
     }
 
-    func testPeerTagsIncludedForProducerSpanKind() {
+    func testPeerTagsIncludedForProducerSpanKind() throws {
         let concentrator = makeConcentrator(now: 0, peerTagKeys: ["peer.service"])
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -507,7 +508,7 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
         XCTAssertTrue(stats.peerTags.contains("peer.service:msg-queue"))
     }
 
@@ -556,12 +557,12 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertEqual(buckets[0].duration, bucketDuration)
+        XCTAssertEqual(buckets.first?.duration, bucketDuration)
     }
 
     // MARK: - Latency Sketches
 
-    func testOkSpanPopulatesOkSummaryNotErrorSummary() {
+    func testOkSpanPopulatesOkSummaryNotErrorSummary() throws {
         let concentrator = makeConcentrator(now: 0)
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -572,7 +573,7 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
 
         // An empty DDSketch encodes only the mapping field (11 bytes); a sketch
         // that has recorded at least one value also encodes a positive store.
@@ -583,7 +584,7 @@ class StatsConcentratorTests: XCTestCase {
         XCTAssertEqual(stats.errorSummary, emptySketchBytes)
     }
 
-    func testErrorSpanPopulatesErrorSummaryNotOkSummary() {
+    func testErrorSpanPopulatesErrorSummaryNotOkSummary() throws {
         let concentrator = makeConcentrator(now: 0)
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -594,14 +595,14 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
 
         let emptySketchBytes = DDSketch.makeForStats().toProtoBytes()
         XCTAssertEqual(stats.okSummary, emptySketchBytes)
         XCTAssertGreaterThan(stats.errorSummary.count, emptySketchBytes.count)
     }
 
-    func testMixedOkAndErrorSpans_populateBothSummaries() {
+    func testMixedOkAndErrorSpans_populateBothSummaries() throws {
         let concentrator = makeConcentrator(now: 0)
 
         // Two ok spans + one error span, all into the same aggregation group.
@@ -622,7 +623,7 @@ class StatsConcentratorTests: XCTestCase {
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
         XCTAssertEqual(buckets.count, 1)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
 
         XCTAssertEqual(stats.hits, 3)
         XCTAssertEqual(stats.errors, 1)
@@ -653,7 +654,7 @@ class StatsConcentratorTests: XCTestCase {
     /// exactly what a `DDSketch` built independently from the same input produces.
     /// Catches any future regression where the wiring stops feeding the sketch the
     /// raw `Double(duration)` we expect.
-    func testOkSummaryBytesMatchIndependentlyBuiltSketch() {
+    func testOkSummaryBytesMatchIndependentlyBuiltSketch() throws {
         let concentrator = makeConcentrator(now: 0)
         let durations: [Nanoseconds] = [100_000_000, 250_000_000, 1_000_000_000, 2_500_000_000]
 
@@ -672,13 +673,13 @@ class StatsConcentratorTests: XCTestCase {
         }
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        let stats = buckets[0].stats[0]
+        let stats = try XCTUnwrap(buckets.first?.stats.first)
         XCTAssertEqual(stats.okSummary, reference.toProtoBytes())
     }
 
     /// Two spans with different resources land in two distinct aggregation groups.
     /// Each group's sketch must reflect only its own span's duration, not the other's.
-    func testDistinctAggregationKeysGetIndependentSketches() {
+    func testDistinctAggregationKeysGetIndependentSketches() throws {
         let concentrator = makeConcentrator(now: 0)
 
         concentrator.add(SpanSnapshot.mockWith(
@@ -703,7 +704,7 @@ class StatsConcentratorTests: XCTestCase {
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
         XCTAssertEqual(buckets.count, 1)
-        let allStats = buckets[0].stats
+        let allStats = try XCTUnwrap(buckets.first).stats
         XCTAssertEqual(allStats.count, 2)
 
         let statsByResource = Dictionary(uniqueKeysWithValues: allStats.map { ($0.resource, $0) })
@@ -752,7 +753,7 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertEqual(buckets[0].stats[0].serviceSource, "m")
+        XCTAssertEqual(buckets.first?.stats.first?.serviceSource, "m")
     }
 
     // MARK: - Synthetics
@@ -767,7 +768,7 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertFalse(buckets[0].stats[0].synthetics)
+        XCTAssertEqual(buckets.first?.stats.first?.synthetics, false)
     }
 
     // MARK: - Span Type Passthrough
@@ -783,7 +784,7 @@ class StatsConcentratorTests: XCTestCase {
         ))
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertEqual(buckets[0].stats[0].type, "http")
+        XCTAssertEqual(buckets.first?.stats.first?.type, "http")
     }
 
     // MARK: - Consent
@@ -839,7 +840,7 @@ class StatsConcentratorTests: XCTestCase {
 
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
         XCTAssertEqual(buckets.count, 1)
-        XCTAssertEqual(buckets[0].stats[0].hits, 1)
+        XCTAssertEqual(buckets.first?.stats.first?.hits, 1)
     }
 
     func testWhenConsentIsGrantedAfterNotGranted_itResumesAggregating() {


### PR DESCRIPTION
### What and why?

The `StatsConcentrator` flush cutoff casts timestamps to `Int64`, which traps and crashes the host app for a pathological span whose bucket key saturates near `UInt64.max`. This ports the safer cutoff math from the dogfooding branch (#3056) and hardens the test assertions so a failing expectation can't abort the whole test bundle.

### How?

- Compute the flush cutoff entirely in the `UInt64` domain, guarding the `now < window` case explicitly so no bucket is flushed before the retention window elapses.
- Replace direct indexing (`buckets[0]`, `stats[0]`) in `StatsConcentratorTests` with `first`/`XCTUnwrap`, so a failure reports cleanly instead of an `Index out of range` crash.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — n/a (CSS unreleased)
- [ ] Add Objective-C interface for public APIs — n/a (internal)
- [ ] Run `make api-surface` when adding new APIs — n/a (no API change)