### PR TITLE
[RUM-16945] Revert clearAllData in-memory stats clearing on dogfooding

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -253,10 +253,6 @@ internal final class DatadogCore {
     func clearAllData() {
         allStorages.forEach { $0.clearAllData() }
         allDataStores.forEach { $0.clearAllData() }
-        // Storages and data stores only cover on-disk data. Features that buffer not-yet-uploaded
-        // data in memory clear it here so `clearAllData()` removes all unsent data, not just the
-        // part the core can see.
-        features.values.forEach { ($0 as? InMemoryDataClearing)?.clearInMemoryData() }
     }
 
     /// Adds a message receiver to the bus.

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -22,16 +22,6 @@ private struct FeatureMock: DatadogRemoteFeature {
     var performanceOverride: PerformancePresetOverride? = nil
 }
 
-private final class InMemoryClearingFeatureMock: DatadogFeature, InMemoryDataClearing {
-    static let name: String = "in-memory-clearing-mock"
-    var messageReceiver: FeatureMessageReceiver = FeatureMessageReceiverMock()
-
-    private(set) var clearInMemoryDataCallCount = 0
-    func clearInMemoryData() {
-        clearInMemoryDataCallCount += 1
-    }
-}
-
 class DatadogCoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
@@ -629,32 +619,6 @@ class DatadogCoreTests: XCTestCase {
             .map { $0.data.utf8String }
 
         XCTAssertEqual(uploadedEvents, [#"{"event":"test"}"#])
-    }
-
-    func testWhenClearingAllData_itClearsInMemoryDataOfConformingFeatures() throws {
-        // Given
-        let core = DatadogCore(
-            directory: temporaryCoreDirectory,
-            dateProvider: SystemDateProvider(),
-            initialConsent: .granted,
-            performance: .mockRandom(),
-            httpClient: HTTPClientMock(),
-            encryption: nil,
-            contextProvider: .mockAny(),
-            applicationVersion: .mockAny(),
-            maxBatchesPerUpload: .mockRandom(min: 1, max: 100),
-            backgroundTasksEnabled: .mockAny()
-        )
-        defer { core.flushAndTearDown() }
-
-        let feature = InMemoryClearingFeatureMock()
-        try core.register(feature: feature)
-
-        // When
-        core.clearAllData()
-
-        // Then
-        XCTAssertEqual(feature.clearInMemoryDataCallCount, 1)
     }
 
     func testItClearsAnonymousIdentifier() {

--- a/DatadogInternal/Sources/DatadogFeature.swift
+++ b/DatadogInternal/Sources/DatadogFeature.swift
@@ -18,17 +18,6 @@ public protocol DatadogFeature {
     var messageReceiver: FeatureMessageReceiver { get }
 }
 
-/// A Feature that buffers not-yet-uploaded data in memory, outside its `FeatureStorage`.
-///
-/// The core clears each Feature's on-disk storage and data store directly when the app calls
-/// `Datadog.clearAllData()`. Features holding unsent data in memory (buffers the core cannot see)
-/// conform to this protocol so that data is discarded too, upholding the promise that
-/// `clearAllData()` removes all not-yet-uploaded data.
-public protocol InMemoryDataClearing {
-    /// Discards all not-yet-uploaded data buffered in memory.
-    func clearInMemoryData()
-}
-
 /// A Datadog Feature with remote data store.
 public protocol DatadogRemoteFeature: DatadogFeature {
     /// The URL request builder for uploading data.

--- a/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
+++ b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift
@@ -101,15 +101,6 @@ extension ClientStatsFeature: Flushable {
     }
 }
 
-extension ClientStatsFeature: InMemoryDataClearing {
-    /// Drops the buckets buffered in the concentrator when the app clears unsent data. The
-    /// feature's on-disk storage is cleared by the core; this covers the in-memory aggregation
-    /// buffer that the core cannot reach.
-    func clearInMemoryData() {
-        concentrator.clearBuffer()
-    }
-}
-
 /// Forwards tracking-consent changes from the message bus to the `StatsConcentrator`.
 ///
 /// Holds the concentrator weakly: it is owned by `ClientStatsFeature`, while the bus owns this

--- a/DatadogTrace/Sources/Feature/StatsConcentrator.swift
+++ b/DatadogTrace/Sources/Feature/StatsConcentrator.swift
@@ -398,20 +398,6 @@ internal final class StatsConcentrator: @unchecked Sendable {
         }
     }
 
-    // MARK: - Clear
-
-    /// Discards all buckets buffered in memory.
-    ///
-    /// Called when the app clears its not-yet-uploaded data via `Datadog.clearAllData()`. Runs on
-    /// the serial queue so the clear is ordered with any in-flight `add` and `flush`, mirroring the
-    /// consent-revoke clear: spans aggregated before the call are dropped, while spans recorded
-    /// afterwards accumulate normally.
-    func clearBuffer() {
-        queue.async { [self] in
-            buckets.removeAll()
-        }
-    }
-
     // MARK: - Eligibility
 
     /// A span is eligible for stats if it is top-level, measured, or has a

--- a/DatadogTrace/Tests/ClientStatsFeatureTests.swift
+++ b/DatadogTrace/Tests/ClientStatsFeatureTests.swift
@@ -94,22 +94,6 @@ class ClientStatsFeatureTests: XCTestCase {
         XCTAssertFalse(receiver.receive(message: .payload("irrelevant"), from: core))
     }
 
-    // MARK: - Clear In-Memory Data
-
-    func testWhenClearInMemoryDataCalled_itDiscardsBufferedStats() throws {
-        // Given: a registered feature with a span buffered in its concentrator.
-        config.statsComputationEnabled = true
-        Trace.enable(with: config, in: core)
-        let stats = try XCTUnwrap(core.get(feature: ClientStatsFeature.self))
-        stats.concentrator.add(.mockWith(startTime: 0, duration: 2_000_000_000, isTopLevel: true))
-
-        // When: the app clears unsent data, routed to the feature via InMemoryDataClearing.
-        (stats as InMemoryDataClearing).clearInMemoryData()
-
-        // Then: the buffered span is dropped and a forced flush finds nothing.
-        XCTAssertTrue(stats.concentrator.flush(now: 100_000_000_000, force: true).isEmpty)
-    }
-
     // MARK: - Request Builder
 
     func testWhenStatsComputationEnabled_thenRequestBuilderUsesStatsEndpoint() throws {

--- a/DatadogTrace/Tests/StatsConcentratorTests.swift
+++ b/DatadogTrace/Tests/StatsConcentratorTests.swift
@@ -852,30 +852,4 @@ class StatsConcentratorTests: XCTestCase {
         let buckets = concentrator.flush(now: 100_000_000_000, force: true)
         XCTAssertEqual(buckets.count, 1)
     }
-
-    // MARK: - Clear Buffer
-
-    func testWhenBufferIsCleared_itDiscardsBufferedData() {
-        let concentrator = makeConcentrator(now: 0, initialConsent: .granted)
-        concentrator.add(makeEligibleSnapshot())
-
-        concentrator.clearBuffer()
-
-        // Even a forced flush must find nothing: the buffered span was dropped, not merely held.
-        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertTrue(buckets.isEmpty)
-    }
-
-    func testWhenBufferIsCleared_itKeepsAggregatingSpansRecordedAfterwards() {
-        let concentrator = makeConcentrator(now: 0, initialConsent: .granted)
-        concentrator.add(makeEligibleSnapshot())
-
-        // Clearing drops only the pre-clear span; spans added afterwards accumulate normally.
-        concentrator.clearBuffer()
-        concentrator.add(makeEligibleSnapshot())
-
-        let buckets = concentrator.flush(now: 100_000_000_000, force: true)
-        XCTAssertEqual(buckets.count, 1)
-        XCTAssertEqual(buckets.first?.stats.first?.hits, 1)
-    }
 }


### PR DESCRIPTION
### What and why?

Reverts `30ad269ff` (`[RUM-16945] Clear buffered client-side stats on clearAllData`) from the `dogfooding` branch.

`clearAllData()` intentionally clears only persisted (on-disk) unsent data and does not touch in-memory aggregators/live state. Doing in-memory clearing consistently across CSS + Flags + other live feature state is a larger, separate effort, so it's deferred to a dedicated follow-up (the CSS-only port dd-sdk-ios#3071 was closed for the same reason).

We want dogfooding to stay as close to the shipping behavior as possible, so this drops the extra CSS-only in-memory clearing that only exists on `dogfooding`.

### How?

Pure inverse of the original commit: removes the `InMemoryDataClearing` protocol, the `DatadogCore.clearAllData()` wiring, `StatsConcentrator.clearBuffer()`, the `ClientStatsFeature` conformance, and their tests (116 deletions, no other changes).

### Review checklist
- [x] JIRA reference in commit and PR
- [ ] CHANGELOG: n/a (CSS unreleased, off by default)
- [ ] Obj-C interface: n/a (internal)
- [ ] api-surface: n/a

[RUM-16945]: https://datadoghq.atlassian.net/browse/RUM-16945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ