### PR TITLE
[FFL-2785] Avoid blocking provider initialization on flags cache read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add support for UK1 Datadog Site. See [#3087][]
+- [FIX] Avoid delaying `DatadogFlags` provider initialization on the initial cached flags read. See [#3078][]
 
 # 3.14.0 / 15-07-2026
 
@@ -1200,6 +1201,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3019]: https://github.com/DataDog/dd-sdk-ios/pull/3019
 [#3051]: https://github.com/DataDog/dd-sdk-ios/pull/3051
 [#3087]: https://github.com/DataDog/dd-sdk-ios/pull/3087
+[#3078]: https://github.com/DataDog/dd-sdk-ios/pull/3078
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogFlags/Sources/Client/FlagAssignmentsFetcher.swift
+++ b/DatadogFlags/Sources/Client/FlagAssignmentsFetcher.swift
@@ -19,6 +19,7 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
     let customHeaders: [String: String]?
 
     private let featureScope: any FeatureScope
+    private let assignmentFetchQueue: DispatchQueue
     private let fetch: (URLRequest, @escaping (Result<Data, Error>) -> Void) -> Void
 
     private static let decoder = JSONDecoder()
@@ -45,11 +46,17 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
         customEndpoint: URL?,
         customHeaders: [String: String]?,
         featureScope: any FeatureScope,
+        assignmentFetchQueue: DispatchQueue = DispatchQueue(
+            label: "com.datadoghq.ios-sdk-flags-assignment-fetch",
+            qos: .userInitiated,
+            autoreleaseFrequency: .workItem
+        ),
         fetch: @escaping (URLRequest, @escaping (Result<Data, Error>) -> Void) -> Void
     ) {
         self.customEndpoint = customEndpoint
         self.customHeaders = customHeaders
         self.featureScope = featureScope
+        self.assignmentFetchQueue = assignmentFetchQueue
         self.fetch = fetch
     }
 
@@ -62,56 +69,85 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
                 completion(.failure(.clientNotInitialized))
                 return
             }
-            do {
-                let request = try URLRequest.flagAssignmentsRequest(
-                    url: self.url(with: context),
-                    evaluationContext: evaluationContext,
+
+            self.assignmentFetchQueue.async {
+                self.fetchAssignments(
+                    for: evaluationContext,
                     context: context,
-                    customHeaders: self.customHeaders
+                    completion: completion
                 )
-                self.fetch(request) { [featureScope] result in
-                    switch result {
-                    case .success(let data):
-                        do {
-                            let response = try Self.decoder.decode(FlagAssignmentsResponse.self, from: data)
+            }
+        }
+    }
 
-                            // Log any flags that failed to decode to telemetry
-                            if !response.failedFlags.isEmpty {
-                                for (flagKey, errorDescription) in response.failedFlags {
-                                    let error = InternalError(description: errorDescription)
-                                    DD.logger.warn(
-                                        "Failed to decode flag '\(flagKey)' from flag assignments response. Flag will be dropped from configuration.",
-                                        error: error
-                                    )
-                                    featureScope.telemetry.debug(
-                                        "Failed to decode flag '\(flagKey)' from flag assignments response",
-                                        attributes: [
-                                            "flagKey": flagKey,
-                                            "errorDescription": errorDescription
-                                        ]
-                                    )
-                                }
-                            }
+    private func fetchAssignments(
+        for evaluationContext: FlagsEvaluationContext,
+        context: DatadogContext,
+        completion: @escaping (Result<[String: FlagAssignment], FlagsError>) -> Void
+    ) {
+        do {
+            let request = try URLRequest.flagAssignmentsRequest(
+                url: url(with: context),
+                evaluationContext: evaluationContext,
+                context: context,
+                customHeaders: customHeaders
+            )
+            fetch(request) { [assignmentFetchQueue, featureScope] result in
+                assignmentFetchQueue.async {
+                    Self.handleFetchResult(
+                        result,
+                        featureScope: featureScope,
+                        completion: completion
+                    )
+                }
+            }
+        } catch let error {
+            DD.logger.error("Failed to encode flag assignments request body.", error: error)
+            featureScope.telemetry.error("Failed to encode flag assignments request body.", error: error)
+            completion(.failure(.invalidConfiguration))
+        }
+    }
 
-                            completion(.success(response.flags))
-                        } catch {
-                            featureScope.telemetry.error(
-                                "Failed to decode \(FlagAssignmentsResponse.self) from flag assignments response",
-                                error: error
-                            )
-                            completion(.failure(.invalidResponse))
-                        }
-                    case .failure(let error):
-                        DD.logger.error("Failed to fetch flag assignments from the server.", error: error)
-                        featureScope.telemetry.error("Failed to fetch flag assignments from the server", error: error)
-                        completion(.failure(.networkError(error)))
+    private static func handleFetchResult(
+        _ result: Result<Data, Error>,
+        featureScope: any FeatureScope,
+        completion: @escaping (Result<[String: FlagAssignment], FlagsError>) -> Void
+    ) {
+        switch result {
+        case .success(let data):
+            do {
+                let response = try decoder.decode(FlagAssignmentsResponse.self, from: data)
+
+                // Log any flags that failed to decode to telemetry
+                if !response.failedFlags.isEmpty {
+                    for (flagKey, errorDescription) in response.failedFlags {
+                        let error = InternalError(description: errorDescription)
+                        DD.logger.warn(
+                            "Failed to decode flag '\(flagKey)' from flag assignments response. Flag will be dropped from configuration.",
+                            error: error
+                        )
+                        featureScope.telemetry.debug(
+                            "Failed to decode flag '\(flagKey)' from flag assignments response",
+                            attributes: [
+                                "flagKey": flagKey,
+                                "errorDescription": errorDescription
+                            ]
+                        )
                     }
                 }
-            } catch let error {
-                DD.logger.error("Failed to encode flag assignments request body.", error: error)
-                featureScope.telemetry.error("Failed to encode flag assignments request body.", error: error)
-                completion(.failure(.invalidConfiguration))
+
+                completion(.success(response.flags))
+            } catch {
+                featureScope.telemetry.error(
+                    "Failed to decode \(FlagAssignmentsResponse.self) from flag assignments response",
+                    error: error
+                )
+                completion(.failure(.invalidResponse))
             }
+        case .failure(let error):
+            DD.logger.error("Failed to fetch flag assignments from the server.", error: error)
+            featureScope.telemetry.error("Failed to fetch flag assignments from the server", error: error)
+            completion(.failure(.networkError(error)))
         }
     }
 

--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -295,3 +295,9 @@ extension FlagsClient: FlagsClientInternal {
         trackEvaluation(key: key, assignment: assignment, context: context)
     }
 }
+
+extension FlagsClient: FlagsClientFlushable {
+    func flush() {
+        repository.flush()
+    }
+}

--- a/DatadogFlags/Sources/Client/FlagsClientRegistry.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientRegistry.swift
@@ -7,6 +7,10 @@
 import Foundation
 import DatadogInternal
 
+internal protocol FlagsClientFlushable: AnyObject {
+    func flush()
+}
+
 internal final class FlagsClientRegistry {
     @ReadWriteLock
     private var clients: [String: FlagsClientProtocol] = [:]
@@ -30,5 +34,9 @@ internal final class FlagsClientRegistry {
 
     func client(named name: String) -> FlagsClientProtocol? {
         clients[name]
+    }
+
+    func flushClients() {
+        clients.values.compactMap { $0 as? FlagsClientFlushable }.forEach { $0.flush() }
     }
 }

--- a/DatadogFlags/Sources/Client/FlagsDataStore.swift
+++ b/DatadogFlags/Sources/Client/FlagsDataStore.swift
@@ -14,13 +14,25 @@ internal struct FlagsDataStore {
     let featureScope: FeatureScope
 
     func setFlagsData(_ flagsData: FlagsData, forClientNamed clientName: String) {
+        guard let data = encodeFlagsData(flagsData) else {
+            return
+        }
+
+        setEncodedFlagsData(data, forClientNamed: clientName)
+    }
+
+    func encodeFlagsData(_ flagsData: FlagsData) -> Data? {
         do {
-            let data = try Self.encoder.encode(flagsData)
-            featureScope.dataStore.setValue(data, forKey: clientName)
+            return try Self.encoder.encode(flagsData)
         } catch let error {
             DD.logger.error("Failed to encode \(type(of: flagsData)) in Flags Data Store", error: error)
             featureScope.telemetry.error("Failed to encode \(type(of: flagsData)) in Flags Data Store", error: error)
+            return nil
         }
+    }
+
+    func setEncodedFlagsData(_ data: Data, forClientNamed clientName: String) {
+        featureScope.dataStore.setValue(data, forKey: clientName)
     }
 
     func flagsData(forClientNamed clientName: String, callback: @escaping (FlagsData?) -> Void) {

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -39,22 +39,50 @@ internal final class FlagsRepository {
     private let featureScope: any FeatureScope
 
     @ReadWriteLock
-    private var flagsData: FlagsData?
+    private var repositoryState = RepositoryState()
 
-    /// Version counter for `flagsData`. Incremented on every write to detect
-    /// when a newer request has succeeded while an older request was in-flight.
-    @ReadWriteLock
-    private var flagsDataVersion: UInt64 = 0
+    /// Groups cached flags and disk-read lifecycle under one lock so a delayed initial read
+    /// cannot race with a network reconciliation that has already produced fresher flags.
+    private struct RepositoryState {
+        var flagsData: FlagsData?
+        var cachedFlagsData: FlagsData?
+        var flagsDataVersion: UInt64 = 0
+        var hasStartedEvaluationContextRequest = false
+        var reconcilingContext: FlagsEvaluationContext?
+        var isDiskReadComplete = false
 
-    /// Tracks disk read state and pending callbacks for async operations.
-    /// When `isComplete` is false, callbacks are queued and executed once disk read finishes.
-    /// When `isComplete` is true, callbacks execute immediately.
-    @ReadWriteLock
-    private var diskReadState = DiskReadState()
+        var shouldWaitForFlagsDataRead: Bool {
+            !isDiskReadComplete && flagsData == nil
+        }
 
-    private struct DiskReadState {
-        var isComplete = false
-        var pendingCallbacks: [() -> Void] = []
+        var shouldWaitBrieflyForFlagsDataRead: Bool {
+            !isDiskReadComplete
+        }
+
+        mutating func applyInitialFlagsData(_ data: FlagsData?) {
+            cachedFlagsData = data
+
+            let isInitialReadStillAuthoritative = !hasStartedEvaluationContextRequest
+            let isReconcilingSameContextBeforeFirstSuccess = data.map {
+                flagsDataVersion == 0 && reconcilingContext == $0.context
+            } ?? false
+
+            if isInitialReadStillAuthoritative || isReconcilingSameContextBeforeFirstSuccess {
+                flagsData = data
+            }
+
+            isDiskReadComplete = true
+        }
+
+        func flagsData(matching context: FlagsEvaluationContext) -> FlagsData? {
+            if flagsData?.context == context {
+                return flagsData
+            }
+            if cachedFlagsData?.context == context {
+                return cachedFlagsData
+            }
+            return nil
+        }
     }
 
     /// Semaphore for blocking synchronous getters until disk read completes.
@@ -84,24 +112,13 @@ internal final class FlagsRepository {
                 }
                 return
             }
-            self.flagsData = data
-
-            // Mark complete and grab pending callbacks atomically
-            var callbacks: [() -> Void] = []
-            self._diskReadState.mutate { state in
-                state.isComplete = true
-                callbacks = state.pendingCallbacks
-                state.pendingCallbacks = []
+            self._repositoryState.mutate { state in
+                state.applyInitialFlagsData(data)
             }
 
             // Signal semaphore for blocking getters (on elevated queue to avoid priority inversion)
             DispatchQueue.global(qos: .userInitiated).async {
                 readSemaphore.signal()
-            }
-
-            // Execute async callbacks outside the lock
-            for callback in callbacks {
-                callback()
             }
         }
     }
@@ -109,33 +126,21 @@ internal final class FlagsRepository {
     /// Blocks until disk read completes (up to timeout).
     /// Used by synchronous getters where callers expect cached data if available.
     private func waitForFlagsDataRead() {
-        guard !diskReadState.isComplete else {
+        guard repositoryState.shouldWaitForFlagsDataRead else {
             return
         }
         _ = readSemaphore.wait(timeout: .now() + Constants.readTimeout)
     }
 
-    /// Executes the callback after disk read completes without blocking.
-    /// Used by setEvaluationContext to avoid blocking the caller's thread.
-    private func whenFlagsDataRead(_ callback: @escaping () -> Void) {
-        var shouldExecuteNow = false
-        _diskReadState.mutate { state in
-            if state.isComplete {
-                shouldExecuteNow = true
-            } else {
-                state.pendingCallbacks.append(callback)
-            }
-        }
-
-        if shouldExecuteNow {
-            callback()
-        }
-    }
-
-    private func writeState() {
-        guard let flagsData else {
+    /// Gives the initial disk read a short chance to complete for stale-cache fallback.
+    private func waitBrieflyForFlagsDataRead() {
+        guard repositoryState.shouldWaitBrieflyForFlagsDataRead else {
             return
         }
+        _ = readSemaphore.wait(timeout: .now() + Constants.readTimeout)
+    }
+
+    private func writeState(_ flagsData: FlagsData) {
         featureScope.flagsDataStore.setFlagsData(flagsData, forClientNamed: clientName)
     }
 }
@@ -145,74 +150,90 @@ extension FlagsRepository: FlagsRepositoryProtocol {
 
     var context: FlagsEvaluationContext? {
         waitForFlagsDataRead()
-        return flagsData?.context
+        return repositoryState.flagsData?.context
     }
 
     func flagAssignment(for key: String) -> FlagAssignment? {
         waitForFlagsDataRead()
-        return flagsData?.flags[key]
+        return repositoryState.flagsData?.flags[key]
     }
 
     func flagAssignments() -> [String: FlagAssignment]? {
         waitForFlagsDataRead()
-        return flagsData?.flags
+        return repositoryState.flagsData?.flags
     }
 
     func setEvaluationContext(
         _ context: FlagsEvaluationContext,
         completion: @escaping (Result<Void, FlagsError>) -> Void
     ) {
-        // Chain after disk read completes to ensure correct hadFlags determination
-        whenFlagsDataRead { [weak self] in
+        var versionAtStart: UInt64 = 0
+        _repositoryState.mutate { state in
+            state.hasStartedEvaluationContextRequest = true
+            state.reconcilingContext = context
+            versionAtStart = state.flagsDataVersion
+        }
+        stateManager.updateState(.reconciling)
+
+        flagAssignmentsFetcher.flagAssignments(for: context) { [weak self] result in
             guard let self else {
                 completion(.failure(.clientNotInitialized))
                 return
             }
 
-            let hadFlags = self.flagsData != nil
-            let cachedContext = self.flagsData?.context
-            let versionAtStart = self.flagsDataVersion
-            self.stateManager.updateState(.reconciling)
+            switch result {
+            case .success(let flags):
+                let flagsData = FlagsData(
+                    flags: flags,
+                    context: context,
+                    date: self.dateProvider.now
+                )
+                self._repositoryState.mutate { state in
+                    state.flagsData = flagsData
+                    state.cachedFlagsData = flagsData
+                    state.flagsDataVersion += 1
+                    state.reconcilingContext = nil
+                }
+                self.writeState(flagsData)
+                self.stateManager.updateState(.ready)
+                completion(.success(()))
+            case .failure(let error):
+                self.waitBrieflyForFlagsDataRead()
 
-            self.flagAssignmentsFetcher.flagAssignments(for: context) { [weak self] result in
-                switch result {
-                case .success(let flags):
-                    guard let self else {
-                        completion(.failure(.clientNotInitialized))
+                // Only update state if no newer request has succeeded.
+                // This prevents an older failing request from clearing data
+                // written by a newer successful request.
+                var stateToUpdate: FlagsClientState?
+                self._repositoryState.mutate { state in
+                    guard state.flagsDataVersion == versionAtStart else {
                         return
                     }
-                    self.flagsData = .init(
-                        flags: flags,
-                        context: context,
-                        date: self.dateProvider.now
-                    )
-                    self._flagsDataVersion.mutate { $0 += 1 }
-                    self.writeState()
-                    self.stateManager.updateState(.ready)
-                    completion(.success(()))
-                case .failure(let error):
-                    // Only update state if no newer request has succeeded.
-                    // This prevents an older failing request from clearing data
-                    // written by a newer successful request.
-                    guard self?.flagsDataVersion == versionAtStart else {
-                        completion(.failure(error))
-                        return
-                    }
-                    // State must be updated before calling completion —
-                    // dd-openfeature-provider-swift checks currentState in the callback.
+
+                    state.reconcilingContext = nil
+
                     // Only use cached flags if they match the requested context to avoid
                     // serving flags from a different user/context.
-                    if hadFlags && cachedContext == context {
-                        self?.stateManager.updateState(.stale)
+                    if let matchingFlagsData = state.flagsData(matching: context) {
+                        state.flagsData = matchingFlagsData
+                        stateToUpdate = .stale
                     } else {
                         // Clear cached data to prevent cross-context flag leakage.
                         // Without this, flagAssignment() could return the previous
                         // user's flags while in .error state.
-                        self?.flagsData = nil
-                        self?.stateManager.updateState(.error)
+                        state.flagsData = nil
+                        stateToUpdate = .error
                     }
-                    completion(.failure(error))
                 }
+
+                guard let stateToUpdate else {
+                    completion(.failure(error))
+                    return
+                }
+
+                // State must be updated before calling completion —
+                // dd-openfeature-provider-swift checks currentState in the callback.
+                self.stateManager.updateState(stateToUpdate)
+                completion(.failure(error))
             }
         }
     }
@@ -222,7 +243,11 @@ extension FlagsRepository: FlagsRepositoryProtocol {
         // This prevents race conditions where a listener reacts to the state
         // change and queries the data store before disk is cleared.
         featureScope.flagsDataStore.removeFlagsData(forClientNamed: clientName)
-        flagsData = nil
+        _repositoryState.mutate { state in
+            state.flagsData = nil
+            state.cachedFlagsData = nil
+            state.reconcilingContext = nil
+        }
         stateManager.updateState(.notReady)
     }
 }

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -37,6 +37,11 @@ internal final class FlagsRepository {
     private let flagAssignmentsFetcher: any FlagAssignmentsFetching
     private let dateProvider: any DateProvider
     private let featureScope: any FeatureScope
+    private let cachePersistenceQueue = DispatchQueue(
+        label: "com.datadoghq.ios-sdk-flags-cache-persistence",
+        autoreleaseFrequency: .workItem,
+        target: .global(qos: .utility)
+    )
 
     @ReadWriteLock
     private var repositoryState = RepositoryState()
@@ -157,8 +162,17 @@ internal final class FlagsRepository {
         }
     }
 
-    private func writeState(_ flagsData: FlagsData) {
-        featureScope.flagsDataStore.setFlagsData(flagsData, forClientNamed: clientName)
+    private func writeState(_ flagsData: FlagsData, version: UInt64) {
+        let featureScope = featureScope
+        let clientName = clientName
+
+        cachePersistenceQueue.async { [weak self] in
+            guard self?.repositoryState.flagsDataVersion == version else {
+                return
+            }
+
+            featureScope.flagsDataStore.setFlagsData(flagsData, forClientNamed: clientName)
+        }
     }
 
     private func handleFailedContextUpdate(
@@ -247,13 +261,15 @@ extension FlagsRepository: FlagsRepositoryProtocol {
                     context: context,
                     date: self.dateProvider.now
                 )
+                var versionAfterSuccess: UInt64 = 0
                 self._repositoryState.mutate { state in
                     state.flagsData = flagsData
                     state.cachedFlagsData = flagsData
                     state.flagsDataVersion += 1
+                    versionAfterSuccess = state.flagsDataVersion
                     state.reconcilingContext = nil
                 }
-                self.writeState(flagsData)
+                self.writeState(flagsData, version: versionAfterSuccess)
                 self.stateManager.updateState(.ready)
                 completion(.success(()))
             case .failure(let error):
@@ -282,6 +298,7 @@ extension FlagsRepository: FlagsRepositoryProtocol {
         _repositoryState.mutate { state in
             state.flagsData = nil
             state.cachedFlagsData = nil
+            state.flagsDataVersion += 1
             state.reconcilingContext = nil
         }
         stateManager.updateState(.notReady)

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -163,7 +163,7 @@ internal final class FlagsRepository {
     }
 
     private func writeState(_ flagsData: FlagsData, version: UInt64) {
-        let featureScope = featureScope
+        let flagsDataStore = featureScope.flagsDataStore
         let clientName = clientName
 
         cachePersistenceQueue.async { [weak self] in
@@ -171,7 +171,15 @@ internal final class FlagsRepository {
                 return
             }
 
-            featureScope.flagsDataStore.setFlagsData(flagsData, forClientNamed: clientName)
+            guard let encodedFlagsData = flagsDataStore.encodeFlagsData(flagsData) else {
+                return
+            }
+
+            guard self?.repositoryState.flagsDataVersion == version else {
+                return
+            }
+
+            flagsDataStore.setEncodedFlagsData(encodedFlagsData, forClientNamed: clientName)
         }
     }
 
@@ -291,15 +299,19 @@ extension FlagsRepository: FlagsRepositoryProtocol {
     }
 
     func reset() {
-        // Clear disk first, then memory, then update state.
-        // This prevents race conditions where a listener reacts to the state
-        // change and queries the data store before disk is cleared.
-        featureScope.flagsDataStore.removeFlagsData(forClientNamed: clientName)
+        let flagsDataStore = featureScope.flagsDataStore
+        let clientName = clientName
+
         _repositoryState.mutate { state in
             state.flagsData = nil
             state.cachedFlagsData = nil
             state.flagsDataVersion += 1
             state.reconcilingContext = nil
+        }
+        // Enqueue removal after any already-started cache write to avoid
+        // re-persisting stale flags after reset.
+        cachePersistenceQueue.sync {
+            flagsDataStore.removeFlagsData(forClientNamed: clientName)
         }
         stateManager.updateState(.notReady)
     }

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -24,6 +24,8 @@ internal protocol FlagsRepositoryProtocol {
     func flagAssignments() -> [String: FlagAssignment]?
 
     func reset()
+
+    func flush()
 }
 
 internal final class FlagsRepository {
@@ -326,5 +328,9 @@ extension FlagsRepository: FlagsRepositoryProtocol {
             flagsDataStore.removeFlagsData(forClientNamed: clientName)
         }
         stateManager.updateState(.notReady)
+    }
+
+    func flush() {
+        cachePersistenceQueue.sync {}
     }
 }

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -50,16 +50,13 @@ internal final class FlagsRepository {
         var hasStartedEvaluationContextRequest = false
         var reconcilingContext: FlagsEvaluationContext?
         var isDiskReadComplete = false
+        var pendingDiskReadCallbacks: [() -> Void] = []
 
         var shouldWaitForFlagsDataRead: Bool {
             !isDiskReadComplete && flagsData == nil
         }
 
-        var shouldWaitBrieflyForFlagsDataRead: Bool {
-            !isDiskReadComplete
-        }
-
-        mutating func applyInitialFlagsData(_ data: FlagsData?) {
+        mutating func applyInitialFlagsData(_ data: FlagsData?) -> [() -> Void] {
             cachedFlagsData = data
 
             let isInitialReadStillAuthoritative = !hasStartedEvaluationContextRequest
@@ -72,6 +69,9 @@ internal final class FlagsRepository {
             }
 
             isDiskReadComplete = true
+            let callbacks = pendingDiskReadCallbacks
+            pendingDiskReadCallbacks = []
+            return callbacks
         }
 
         func flagsData(matching context: FlagsEvaluationContext) -> FlagsData? {
@@ -82,6 +82,15 @@ internal final class FlagsRepository {
                 return cachedFlagsData
             }
             return nil
+        }
+
+        mutating func executeAfterDiskReadCompletes(_ callback: @escaping () -> Void) -> Bool {
+            if isDiskReadComplete {
+                return true
+            } else {
+                pendingDiskReadCallbacks.append(callback)
+                return false
+            }
         }
     }
 
@@ -112,14 +121,17 @@ internal final class FlagsRepository {
                 }
                 return
             }
+            var callbacks: [() -> Void] = []
             self._repositoryState.mutate { state in
-                state.applyInitialFlagsData(data)
+                callbacks = state.applyInitialFlagsData(data)
             }
 
             // Signal semaphore for blocking getters (on elevated queue to avoid priority inversion)
             DispatchQueue.global(qos: .userInitiated).async {
                 readSemaphore.signal()
             }
+
+            callbacks.forEach { $0() }
         }
     }
 
@@ -132,16 +144,63 @@ internal final class FlagsRepository {
         _ = readSemaphore.wait(timeout: .now() + Constants.readTimeout)
     }
 
-    /// Gives the initial disk read a short chance to complete for stale-cache fallback.
-    private func waitBrieflyForFlagsDataRead() {
-        guard repositoryState.shouldWaitBrieflyForFlagsDataRead else {
-            return
+    /// Executes the callback after the initial disk read completes.
+    /// Used on fetch failure so cached flags can be used without delaying the network request.
+    private func whenFlagsDataRead(_ callback: @escaping () -> Void) {
+        var shouldExecuteNow = false
+        _repositoryState.mutate { state in
+            shouldExecuteNow = state.executeAfterDiskReadCompletes(callback)
         }
-        _ = readSemaphore.wait(timeout: .now() + Constants.readTimeout)
+
+        if shouldExecuteNow {
+            callback()
+        }
     }
 
     private func writeState(_ flagsData: FlagsData) {
         featureScope.flagsDataStore.setFlagsData(flagsData, forClientNamed: clientName)
+    }
+
+    private func handleFailedContextUpdate(
+        error: FlagsError,
+        context: FlagsEvaluationContext,
+        versionAtStart: UInt64,
+        completion: @escaping (Result<Void, FlagsError>) -> Void
+    ) {
+        // Only update state if no newer request has succeeded.
+        // This prevents an older failing request from clearing data
+        // written by a newer successful request.
+        var stateToUpdate: FlagsClientState?
+        _repositoryState.mutate { state in
+            guard state.flagsDataVersion == versionAtStart else {
+                return
+            }
+
+            state.reconcilingContext = nil
+
+            // Only use cached flags if they match the requested context to avoid
+            // serving flags from a different user/context.
+            if let matchingFlagsData = state.flagsData(matching: context) {
+                state.flagsData = matchingFlagsData
+                stateToUpdate = .stale
+            } else {
+                // Clear cached data to prevent cross-context flag leakage.
+                // Without this, flagAssignment() could return the previous
+                // user's flags while in .error state.
+                state.flagsData = nil
+                stateToUpdate = .error
+            }
+        }
+
+        guard let stateToUpdate else {
+            completion(.failure(error))
+            return
+        }
+
+        // State must be updated before calling completion —
+        // dd-openfeature-provider-swift checks currentState in the callback.
+        stateManager.updateState(stateToUpdate)
+        completion(.failure(error))
     }
 }
 
@@ -198,42 +257,19 @@ extension FlagsRepository: FlagsRepositoryProtocol {
                 self.stateManager.updateState(.ready)
                 completion(.success(()))
             case .failure(let error):
-                self.waitBrieflyForFlagsDataRead()
-
-                // Only update state if no newer request has succeeded.
-                // This prevents an older failing request from clearing data
-                // written by a newer successful request.
-                var stateToUpdate: FlagsClientState?
-                self._repositoryState.mutate { state in
-                    guard state.flagsDataVersion == versionAtStart else {
+                self.whenFlagsDataRead { [weak self] in
+                    guard let self else {
+                        completion(.failure(.clientNotInitialized))
                         return
                     }
 
-                    state.reconcilingContext = nil
-
-                    // Only use cached flags if they match the requested context to avoid
-                    // serving flags from a different user/context.
-                    if let matchingFlagsData = state.flagsData(matching: context) {
-                        state.flagsData = matchingFlagsData
-                        stateToUpdate = .stale
-                    } else {
-                        // Clear cached data to prevent cross-context flag leakage.
-                        // Without this, flagAssignment() could return the previous
-                        // user's flags while in .error state.
-                        state.flagsData = nil
-                        stateToUpdate = .error
-                    }
+                    self.handleFailedContextUpdate(
+                        error: error,
+                        context: context,
+                        versionAtStart: versionAtStart,
+                        completion: completion
+                    )
                 }
-
-                guard let stateToUpdate else {
-                    completion(.failure(error))
-                    return
-                }
-
-                // State must be updated before calling completion —
-                // dd-openfeature-provider-swift checks currentState in the callback.
-                self.stateManager.updateState(stateToUpdate)
-                completion(.failure(error))
             }
         }
     }

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -136,6 +136,18 @@ internal final class FlagsRepository {
                 readSemaphore.signal()
             }
 
+            self.executePendingDiskReadCallbacks(callbacks)
+        }
+    }
+
+    private func executePendingDiskReadCallbacks(_ callbacks: [() -> Void]) {
+        guard !callbacks.isEmpty else {
+            return
+        }
+
+        // The initial disk-read callback runs on DatadogCore's shared read/write queue.
+        // Hop off that queue before notifying state listeners or invoking public completions.
+        DispatchQueue.global(qos: .utility).async {
             callbacks.forEach { $0() }
         }
     }

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -91,5 +91,6 @@ internal struct FlagsFeature: DatadogRemoteFeature {
 extension FlagsFeature: Flushable {
     func flush() {
         evaluationAggregator?.sendEvaluations()
+        clientRegistry.flushClients()
     }
 }

--- a/DatadogFlags/Tests/Client/FlagAssignmentsFetcherTests.swift
+++ b/DatadogFlags/Tests/Client/FlagAssignmentsFetcherTests.swift
@@ -37,7 +37,7 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(
             capturedRequest?.url?.absoluteString,
             "https://preview.ff-cdn.us3.datadoghq.com/precompute-assignments"
@@ -68,7 +68,7 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 1)
     }
 
     func testFlagAssignmentsInvalidResponse() {
@@ -91,7 +91,7 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 1)
     }
 
     func testFlagAssignmentsCustomEndpoint() {
@@ -116,9 +116,37 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(capturedRequest?.url, customEndpoint)
         XCTAssertEqual(capturedRequest?.allHTTPHeaderFields?["X-Custom-Header"], "custom-value")
+    }
+
+    func testFlagAssignmentsFetchRunsOffContextQueue() {
+        // Given
+        let contextQueue = DispatchQueue(label: "com.datadoghq.flags-tests-context")
+        let assignmentFetchQueue = DispatchQueue(label: "com.datadoghq.flags-tests-assignment-fetch")
+        let featureScope = QueuedFeatureScope(contextQueue: contextQueue)
+        var wasFetchCalledOnContextQueue: Bool?
+        let fetcher = FlagAssignmentsFetcher(
+            customEndpoint: nil,
+            customHeaders: [:],
+            featureScope: featureScope,
+            assignmentFetchQueue: assignmentFetchQueue,
+            fetch: { _, completion in
+                wasFetchCalledOnContextQueue = featureScope.isOnContextQueue
+                completion(.success(.mockAnyFlagAssignmentsResponse()))
+            }
+        )
+        let completed = expectation(description: "completed")
+
+        // When
+        fetcher.flagAssignments(for: .mockAny()) { _ in
+            completed.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(wasFetchCalledOnContextQueue, false)
     }
 
     func testFlagsEndpointForAllSites() {
@@ -136,4 +164,38 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
             XCTAssertEqual(site.flagsEndpoint().absoluteString, expectedEndpoint)
         }
     }
+}
+
+private final class QueuedFeatureScope: FeatureScope, @unchecked Sendable {
+    private let contextQueue: DispatchQueue
+    private let contextQueueKey = DispatchSpecificKey<Void>()
+    private let contextMock: DatadogContext
+
+    var isOnContextQueue: Bool {
+        DispatchQueue.getSpecific(key: contextQueueKey) != nil
+    }
+
+    init(contextQueue: DispatchQueue, context: DatadogContext = .mockAny()) {
+        self.contextQueue = contextQueue
+        self.contextMock = context
+        self.contextQueue.setSpecific(key: contextQueueKey, value: ())
+    }
+
+    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {}
+
+    func context(_ block: @escaping (DatadogContext) -> Void) {
+        contextQueue.async {
+            block(self.contextMock)
+        }
+    }
+
+    var dataStore: DataStore { NOPDataStore() }
+
+    var telemetry: Telemetry { NOPTelemetry() }
+
+    func send(message: FeatureMessage, else fallback: @escaping () -> Void) {}
+
+    func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {}
+
+    func set(anonymousId: String?) {}
 }

--- a/DatadogFlags/Tests/Client/FlagsClientMocks.swift
+++ b/DatadogFlags/Tests/Client/FlagsClientMocks.swift
@@ -145,6 +145,7 @@ final class FlagsRepositoryMock: FlagsRepositoryProtocol {
     var flagsData: FlagsData?
     let state: FlagsStateObservable = NOPStateObservable.notReady
     var setEvaluationContextStub: ((FlagsEvaluationContext, @escaping (Result<Void, FlagsError>) -> Void) -> Void)?
+    var flushCallsCount = 0
 
     var context: FlagsEvaluationContext? {
         flagsData?.context
@@ -177,6 +178,10 @@ final class FlagsRepositoryMock: FlagsRepositoryProtocol {
 
     func reset() {
         flagsData = nil
+    }
+
+    func flush() {
+        flushCallsCount += 1
     }
 }
 

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -94,6 +94,228 @@ final class FlagsRepositoryTests: XCTestCase {
         )
     }
 
+    func testSetEvaluationContext_whenInitialDataStoreReadIsDelayed_startsFetchingAssignmentsWithoutWaitingForRead() {
+        // Given
+        let dataStore = DelayedReadDataStore()
+        let readStarted = expectation(description: "initial data store read started")
+        dataStore.onReadStarted = {
+            readStarted.fulfill()
+        }
+
+        let fetchStarted = expectation(description: "fetch started")
+        let flagsRepository = FlagsRepository(
+            clientName: "client",
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                fetchStarted.fulfill()
+                completion(.success(["test": .mockAny()]))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+        defer {
+            dataStore.resumeRead()
+            dataStore.flush()
+        }
+        wait(for: [readStarted], timeout: 1)
+
+        let completed = expectation(description: "completed")
+
+        // When
+        flagsRepository.setEvaluationContext(.mockAny()) { result in
+            if case .failure(let error) = result {
+                XCTFail("Expected success, got \(error)")
+            }
+            completed.fulfill()
+        }
+
+        // Then
+        wait(for: [fetchStarted, completed], timeout: 1)
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+    }
+
+    func testInitialDataStoreRead_whenCompletesAfterSuccessfulContextUpdate_doesNotOverwriteFetchedFlags() throws {
+        // Given
+        let clientName = "client"
+        let cachedContext = FlagsEvaluationContext(targetingKey: "cached-user", attributes: [:])
+        let requestedContext = FlagsEvaluationContext(targetingKey: "fresh-user", attributes: [:])
+        let cachedData = FlagsData(
+            flags: ["cached": .mockAny()],
+            context: cachedContext,
+            date: .mockAny()
+        )
+        let dataStore = DelayedReadDataStore(
+            storage: [
+                clientName: .value(
+                    try JSONEncoder().encode(cachedData),
+                    dataStoreDefaultKeyVersion
+                )
+            ]
+        )
+        let readStarted = expectation(description: "initial data store read started")
+        dataStore.onReadStarted = {
+            readStarted.fulfill()
+        }
+
+        let flagsRepository = FlagsRepository(
+            clientName: clientName,
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.success(["fresh": .mockAny()]))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+        defer {
+            dataStore.resumeRead()
+            dataStore.flush()
+        }
+        wait(for: [readStarted], timeout: 1)
+
+        let completed = expectation(description: "completed")
+
+        // When
+        flagsRepository.setEvaluationContext(requestedContext) { result in
+            if case .failure(let error) = result {
+                XCTFail("Expected success, got \(error)")
+            }
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 1)
+
+        dataStore.resumeRead()
+        dataStore.flush()
+
+        // Then
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+        XCTAssertEqual(flagsRepository.context, requestedContext)
+        XCTAssertNotNil(flagsRepository.flagAssignment(for: "fresh"))
+        XCTAssertNil(flagsRepository.flagAssignment(for: "cached"))
+    }
+
+    func testInitialDataStoreRead_whenCompletesDuringReconcilingWithMatchingContext_servesCachedFlags() throws {
+        // Given
+        let clientName = "client"
+        let requestedContext = FlagsEvaluationContext(targetingKey: "cached-user", attributes: [:])
+        let cachedData = FlagsData(
+            flags: ["cached": .mockAny()],
+            context: requestedContext,
+            date: .mockAny()
+        )
+        let dataStore = DelayedReadDataStore(
+            storage: [
+                clientName: .value(
+                    try JSONEncoder().encode(cachedData),
+                    dataStoreDefaultKeyVersion
+                )
+            ]
+        )
+        let readStarted = expectation(description: "initial data store read started")
+        dataStore.onReadStarted = {
+            readStarted.fulfill()
+        }
+
+        let fetchStarted = expectation(description: "fetch started")
+        var fetchCompletion: ((Result<[String: FlagAssignment], FlagsError>) -> Void)?
+        let flagsRepository = FlagsRepository(
+            clientName: clientName,
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                fetchCompletion = completion
+                fetchStarted.fulfill()
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+        defer {
+            dataStore.resumeRead()
+            dataStore.flush()
+        }
+        wait(for: [readStarted], timeout: 1)
+
+        let completed = expectation(description: "completed")
+
+        // When
+        flagsRepository.setEvaluationContext(requestedContext) { result in
+            if case .failure(let error) = result {
+                XCTFail("Expected success, got \(error)")
+            }
+            completed.fulfill()
+        }
+        wait(for: [fetchStarted], timeout: 1)
+
+        dataStore.resumeRead()
+        dataStore.flush()
+
+        // Then
+        XCTAssertEqual(flagsRepository.state.currentState, .reconciling)
+        XCTAssertEqual(flagsRepository.context, requestedContext)
+        XCTAssertNotNil(flagsRepository.flagAssignment(for: "cached"))
+        XCTAssertNil(flagsRepository.flagAssignment(for: "fresh"))
+
+        fetchCompletion?(.success(["fresh": .mockAny()]))
+        wait(for: [completed], timeout: 1)
+
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+        XCTAssertEqual(flagsRepository.context, requestedContext)
+        XCTAssertNil(flagsRepository.flagAssignment(for: "cached"))
+        XCTAssertNotNil(flagsRepository.flagAssignment(for: "fresh"))
+    }
+
+    func testInitialDataStoreRead_whenCompletesAfterFailedContextUpdate_doesNotRestoreMismatchedCachedFlags() throws {
+        // Given
+        let clientName = "client"
+        let cachedContext = FlagsEvaluationContext(targetingKey: "cached-user", attributes: [:])
+        let requestedContext = FlagsEvaluationContext(targetingKey: "fresh-user", attributes: [:])
+        let cachedData = FlagsData(
+            flags: ["cached": .mockAny()],
+            context: cachedContext,
+            date: .mockAny()
+        )
+        let dataStore = DelayedReadDataStore(
+            storage: [
+                clientName: .value(
+                    try JSONEncoder().encode(cachedData),
+                    dataStoreDefaultKeyVersion
+                )
+            ]
+        )
+        let readStarted = expectation(description: "initial data store read started")
+        dataStore.onReadStarted = {
+            readStarted.fulfill()
+        }
+
+        let flagsRepository = FlagsRepository(
+            clientName: clientName,
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.failure(.networkError(URLError(.notConnectedToInternet))))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+        defer {
+            dataStore.resumeRead()
+            dataStore.flush()
+        }
+        wait(for: [readStarted], timeout: 1)
+
+        let completed = expectation(description: "completed")
+
+        // When
+        flagsRepository.setEvaluationContext(requestedContext) { result in
+            if case .success = result {
+                XCTFail("Expected failure")
+            }
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 1)
+
+        dataStore.resumeRead()
+        dataStore.flush()
+
+        // Then
+        XCTAssertEqual(flagsRepository.state.currentState, .error)
+        XCTAssertNil(flagsRepository.context)
+        XCTAssertNil(flagsRepository.flagAssignment(for: "cached"))
+    }
+
     func testSetEvaluationContextError() throws {
         // Given
         let flagsRepository = FlagsRepository(
@@ -475,5 +697,48 @@ final class FlagsRepositoryTests: XCTestCase {
         // (dd-openfeature-provider-swift depends on this ordering)
         waitForExpectations(timeout: 0)
         XCTAssertEqual(stateInCompletion, .error)
+    }
+}
+
+private final class DelayedReadDataStore: DataStore, @unchecked Sendable {
+    @ReadWriteLock
+    private var storage: [String: DataStoreValueResult]
+
+    private let queue = DispatchQueue(label: "com.datadoghq.flags-delayed-read-data-store")
+    private let readSemaphore = DispatchSemaphore(value: 0)
+
+    var onReadStarted: (() -> Void)?
+
+    init(storage: [String: DataStoreValueResult] = [:]) {
+        self.storage = storage
+    }
+
+    func setValue(_ value: Data, forKey key: String, version: DataStoreKeyVersion) {
+        storage[key] = .value(value, version)
+    }
+
+    func value(forKey key: String, callback: @escaping (DataStoreValueResult) -> Void) {
+        queue.async {
+            let result = self.storage[key] ?? .noValue
+            self.onReadStarted?()
+            self.readSemaphore.wait()
+            callback(result)
+        }
+    }
+
+    func removeValue(forKey key: String) {
+        storage[key] = nil
+    }
+
+    func clearAllData() {
+        storage.removeAll()
+    }
+
+    func flush() {
+        queue.sync {}
+    }
+
+    func resumeRead() {
+        readSemaphore.signal()
     }
 }

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -55,13 +55,18 @@ final class FlagsRepositoryTests: XCTestCase {
         let evaluationContext = FlagsEvaluationContext.mockAny()
         let flags = ["test": FlagAssignment.mockAny()]
         let dateProvider = DateProviderMock(now: .mockAny())
+        let dataStore = WriteObservingDataStore()
+        let cacheWriteCompleted = expectation(description: "cache write completed")
+        dataStore.onSetValue = {
+            cacheWriteCompleted.fulfill()
+        }
         let flagsRepository = FlagsRepository(
             clientName: .mockAny(),
             flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
                 completion(.success(flags))
             },
             dateProvider: dateProvider,
-            featureScope: featureScope
+            featureScope: FeatureScopeMock(dataStore: dataStore)
         )
         let completed = expectation(description: "completed")
 
@@ -73,7 +78,7 @@ final class FlagsRepositoryTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
+        wait(for: [completed], timeout: 0)
 
         XCTAssertNotNil(capturedResult)
         XCTAssertNoThrow(try capturedResult?.get())
@@ -81,7 +86,9 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertEqual(flagsRepository.context, .mockAny())
         XCTAssertEqual(flagsRepository.flagAssignment(for: "test"), .mockAny())
 
-        let data = try XCTUnwrap(featureScope.dataStoreMock.storage[.mockAny()]?.data())
+        wait(for: [cacheWriteCompleted], timeout: 1)
+
+        let data = try XCTUnwrap(dataStore.value(forKey: .mockAny())?.data())
         let storedState = try JSONDecoder().decode(FlagsData.self, from: data)
 
         XCTAssertEqual(
@@ -92,6 +99,49 @@ final class FlagsRepositoryTests: XCTestCase {
                 date: dateProvider.now
             )
         )
+    }
+
+    func testSetEvaluationContext_whenCacheWriteIsBlocked_doesNotDelayReadyOrCompletion() {
+        // Given
+        let dataStore = BlockingWriteDataStore()
+        let cacheWriteStarted = expectation(description: "cache write started")
+        dataStore.onSetValueStarted = {
+            cacheWriteStarted.fulfill()
+        }
+        defer {
+            dataStore.resumeWrite()
+        }
+
+        let flagsRepository = FlagsRepository(
+            clientName: "client",
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.success(["test": .mockAny()]))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+
+        let completed = expectation(description: "completed")
+        var stateInCompletion: FlagsClientState?
+
+        // When
+        DispatchQueue.global().async {
+            flagsRepository.setEvaluationContext(.mockAny()) { _ in
+                stateInCompletion = flagsRepository.state.currentState
+                completed.fulfill()
+            }
+        }
+
+        // Then
+        wait(for: [completed], timeout: 1)
+
+        XCTAssertEqual(stateInCompletion, .ready)
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+        XCTAssertFalse(dataStore.isWriteFinished)
+
+        wait(for: [cacheWriteStarted], timeout: 1)
+        dataStore.resumeWrite()
+        XCTAssertTrue(dataStore.waitForWriteFinished(timeout: 1))
     }
 
     func testSetEvaluationContext_whenInitialDataStoreReadIsDelayed_startsFetchingAssignmentsWithoutWaitingForRead() {
@@ -763,6 +813,87 @@ final class FlagsRepositoryTests: XCTestCase {
         // (dd-openfeature-provider-swift depends on this ordering)
         waitForExpectations(timeout: 0)
         XCTAssertEqual(stateInCompletion, .error)
+    }
+}
+
+private final class WriteObservingDataStore: DataStore, @unchecked Sendable {
+    @ReadWriteLock
+    private var storage: [String: DataStoreValueResult]
+
+    var onSetValue: (() -> Void)?
+
+    init(storage: [String: DataStoreValueResult] = [:]) {
+        self.storage = storage
+    }
+
+    func setValue(_ value: Data, forKey key: String, version: DataStoreKeyVersion) {
+        storage[key] = .value(value, version)
+        onSetValue?()
+    }
+
+    func value(forKey key: String, callback: @escaping (DataStoreValueResult) -> Void) {
+        callback(storage[key] ?? .noValue)
+    }
+
+    func value(forKey key: String) -> DataStoreValueResult? {
+        storage[key]
+    }
+
+    func removeValue(forKey key: String) {
+        storage[key] = nil
+    }
+
+    func clearAllData() {
+        storage.removeAll()
+    }
+
+    func flush() {}
+}
+
+private final class BlockingWriteDataStore: DataStore, @unchecked Sendable {
+    @ReadWriteLock
+    private var storage: [String: DataStoreValueResult] = [:]
+
+    @ReadWriteLock
+    private var hasFinishedWrite = false
+
+    private let writeSemaphore = DispatchSemaphore(value: 0)
+    private let writeFinishedSemaphore = DispatchSemaphore(value: 0)
+
+    var onSetValueStarted: (() -> Void)?
+
+    var isWriteFinished: Bool {
+        hasFinishedWrite
+    }
+
+    func setValue(_ value: Data, forKey key: String, version: DataStoreKeyVersion) {
+        onSetValueStarted?()
+        writeSemaphore.wait()
+        storage[key] = .value(value, version)
+        hasFinishedWrite = true
+        writeFinishedSemaphore.signal()
+    }
+
+    func value(forKey key: String, callback: @escaping (DataStoreValueResult) -> Void) {
+        callback(storage[key] ?? .noValue)
+    }
+
+    func removeValue(forKey key: String) {
+        storage[key] = nil
+    }
+
+    func clearAllData() {
+        storage.removeAll()
+    }
+
+    func flush() {}
+
+    func resumeWrite() {
+        writeSemaphore.signal()
+    }
+
+    func waitForWriteFinished(timeout: TimeInterval) -> Bool {
+        writeFinishedSemaphore.wait(timeout: .now() + timeout) == .success
     }
 }
 

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -144,6 +144,64 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertTrue(dataStore.waitForWriteFinished(timeout: 1))
     }
 
+    func testReset_whenCacheWriteIsBlocked_doesNotLeaveStaleFlagsOnDisk() {
+        // Given
+        let clientName = "client"
+        let dataStore = BlockingWriteDataStore()
+        let cacheWriteStarted = expectation(description: "cache write started")
+        let cacheRemoveCompleted = expectation(description: "cache remove completed")
+        dataStore.onSetValueStarted = {
+            cacheWriteStarted.fulfill()
+        }
+        dataStore.onRemoveValue = {
+            cacheRemoveCompleted.fulfill()
+        }
+        defer {
+            dataStore.resumeWrite()
+        }
+
+        let flagsRepository = FlagsRepository(
+            clientName: clientName,
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.success(["test": .mockAny()]))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+
+        let completed = expectation(description: "completed")
+
+        DispatchQueue.global().async {
+            flagsRepository.setEvaluationContext(.mockAny()) { _ in
+                completed.fulfill()
+            }
+        }
+        wait(for: [completed, cacheWriteStarted], timeout: 1)
+
+        let resetStarted = expectation(description: "reset started")
+        let resetCompleted = expectation(description: "reset completed")
+
+        // When
+        DispatchQueue.global().async {
+            resetStarted.fulfill()
+            flagsRepository.reset()
+            resetCompleted.fulfill()
+        }
+        wait(for: [resetStarted], timeout: 1)
+
+        // Then
+        XCTAssertFalse(dataStore.isWriteFinished)
+
+        dataStore.resumeWrite()
+        XCTAssertTrue(dataStore.waitForWriteFinished(timeout: 1))
+        wait(for: [resetCompleted, cacheRemoveCompleted], timeout: 1)
+
+        XCTAssertEqual(flagsRepository.state.currentState, .notReady)
+        XCTAssertNil(flagsRepository.context)
+        XCTAssertNil(flagsRepository.flagAssignment(for: "test"))
+        XCTAssertNil(dataStore.value(forKey: clientName)?.data())
+    }
+
     func testSetEvaluationContext_whenInitialDataStoreReadIsDelayed_startsFetchingAssignmentsWithoutWaitingForRead() {
         // Given
         let dataStore = DelayedReadDataStore()
@@ -861,6 +919,7 @@ private final class BlockingWriteDataStore: DataStore, @unchecked Sendable {
     private let writeFinishedSemaphore = DispatchSemaphore(value: 0)
 
     var onSetValueStarted: (() -> Void)?
+    var onRemoveValue: (() -> Void)?
 
     var isWriteFinished: Bool {
         hasFinishedWrite
@@ -880,6 +939,7 @@ private final class BlockingWriteDataStore: DataStore, @unchecked Sendable {
 
     func removeValue(forKey key: String) {
         storage[key] = nil
+        onRemoveValue?()
     }
 
     func clearAllData() {
@@ -894,6 +954,10 @@ private final class BlockingWriteDataStore: DataStore, @unchecked Sendable {
 
     func waitForWriteFinished(timeout: TimeInterval) -> Bool {
         writeFinishedSemaphore.wait(timeout: .now() + timeout) == .success
+    }
+
+    func value(forKey key: String) -> DataStoreValueResult? {
+        storage[key]
     }
 }
 

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -144,6 +144,49 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertTrue(dataStore.waitForWriteFinished(timeout: 1))
     }
 
+    func testFlush_whenCacheWriteIsBlocked_waitsForCacheWrite() {
+        // Given
+        let dataStore = BlockingWriteDataStore()
+        let cacheWriteStarted = expectation(description: "cache write started")
+        dataStore.onSetValueStarted = {
+            cacheWriteStarted.fulfill()
+        }
+        defer {
+            dataStore.resumeWrite()
+        }
+
+        let flagsRepository = FlagsRepository(
+            clientName: "client",
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.success(["test": .mockAny()]))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+
+        let setContextCompleted = expectation(description: "set context completed")
+        flagsRepository.setEvaluationContext(.mockAny()) { _ in
+            setContextCompleted.fulfill()
+        }
+        wait(for: [setContextCompleted], timeout: 1)
+
+        let flushSemaphore = DispatchSemaphore(value: 0)
+
+        // When
+        DispatchQueue.global().async {
+            flagsRepository.flush()
+            flushSemaphore.signal()
+        }
+        wait(for: [cacheWriteStarted], timeout: 1)
+
+        // Then
+        XCTAssertEqual(flushSemaphore.wait(timeout: .now() + 0.05), .timedOut)
+
+        dataStore.resumeWrite()
+        XCTAssertEqual(flushSemaphore.wait(timeout: .now() + 1), .success)
+        XCTAssertTrue(dataStore.isWriteFinished)
+    }
+
     func testReset_whenCacheWriteIsBlocked_doesNotLeaveStaleFlagsOnDisk() {
         // Given
         let clientName = "client"

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -297,23 +297,89 @@ final class FlagsRepositoryTests: XCTestCase {
         wait(for: [readStarted], timeout: 1)
 
         let completed = expectation(description: "completed")
+        var didComplete = false
 
         // When
         flagsRepository.setEvaluationContext(requestedContext) { result in
+            didComplete = true
             if case .success = result {
                 XCTFail("Expected failure")
             }
             completed.fulfill()
         }
-        wait(for: [completed], timeout: 1)
+
+        XCTAssertEqual(flagsRepository.state.currentState, .reconciling)
+        XCTAssertFalse(didComplete)
 
         dataStore.resumeRead()
         dataStore.flush()
+        wait(for: [completed], timeout: 1)
 
         // Then
         XCTAssertEqual(flagsRepository.state.currentState, .error)
         XCTAssertNil(flagsRepository.context)
         XCTAssertNil(flagsRepository.flagAssignment(for: "cached"))
+    }
+
+    func testInitialDataStoreRead_whenCompletesAfterFailedContextUpdate_usesMatchingCachedFlags() throws {
+        // Given
+        let clientName = "client"
+        let requestedContext = FlagsEvaluationContext(targetingKey: "cached-user", attributes: [:])
+        let cachedData = FlagsData(
+            flags: ["cached": .mockAny()],
+            context: requestedContext,
+            date: .mockAny()
+        )
+        let dataStore = DelayedReadDataStore(
+            storage: [
+                clientName: .value(
+                    try JSONEncoder().encode(cachedData),
+                    dataStoreDefaultKeyVersion
+                )
+            ]
+        )
+        let readStarted = expectation(description: "initial data store read started")
+        dataStore.onReadStarted = {
+            readStarted.fulfill()
+        }
+
+        let flagsRepository = FlagsRepository(
+            clientName: clientName,
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.failure(.networkError(URLError(.notConnectedToInternet))))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+        defer {
+            dataStore.resumeRead()
+            dataStore.flush()
+        }
+        wait(for: [readStarted], timeout: 1)
+
+        let completed = expectation(description: "completed")
+        var didComplete = false
+
+        // When
+        flagsRepository.setEvaluationContext(requestedContext) { result in
+            didComplete = true
+            if case .success = result {
+                XCTFail("Expected failure")
+            }
+            completed.fulfill()
+        }
+
+        XCTAssertEqual(flagsRepository.state.currentState, .reconciling)
+        XCTAssertFalse(didComplete)
+
+        dataStore.resumeRead()
+        dataStore.flush()
+        wait(for: [completed], timeout: 1)
+
+        // Then
+        XCTAssertEqual(flagsRepository.state.currentState, .stale)
+        XCTAssertEqual(flagsRepository.context, requestedContext)
+        XCTAssertNotNil(flagsRepository.flagAssignment(for: "cached"))
     }
 
     func testSetEvaluationContextError() throws {
@@ -502,7 +568,7 @@ final class FlagsRepositoryTests: XCTestCase {
         )
 
         // When — call setEvaluationContext while the disk read may still be in-flight.
-        // The fix ensures waitForFlagsDataRead() is called before checking hadFlags.
+        // The repository waits for the disk read before deciding stale vs error on failure.
         let completed = expectation(description: "completed")
         flagsRepository.setEvaluationContext(.mockAny()) { _ in
             completed.fulfill()

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -429,6 +429,57 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertNil(flagsRepository.flagAssignment(for: "cached"))
     }
 
+    func testInitialDataStoreRead_whenFetchFailsBeforeReadCompletes_dispatchesFailureCallbacksOffDataStoreQueue() {
+        // Given
+        let dataStore = DelayedReadDataStore()
+        let readStarted = expectation(description: "initial data store read started")
+        dataStore.onReadStarted = {
+            readStarted.fulfill()
+        }
+
+        let flagsRepository = FlagsRepository(
+            clientName: "client",
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.failure(.networkError(URLError(.notConnectedToInternet))))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: FeatureScopeMock(dataStore: dataStore)
+        )
+        defer {
+            dataStore.resumeRead()
+            dataStore.flush()
+        }
+        wait(for: [readStarted], timeout: 1)
+
+        let errorStateObserved = expectation(description: "error state observed")
+        var wasErrorStateNotifiedOnDataStoreQueue: Bool?
+        let listener = StateChangeListener { state in
+            guard state == .error else {
+                return
+            }
+            wasErrorStateNotifiedOnDataStoreQueue = dataStore.isOnReadQueue
+            errorStateObserved.fulfill()
+        }
+        flagsRepository.state.addListener(listener)
+
+        let completed = expectation(description: "completed")
+        var wasCompletionCalledOnDataStoreQueue: Bool?
+
+        // When
+        flagsRepository.setEvaluationContext(.mockAny()) { _ in
+            wasCompletionCalledOnDataStoreQueue = dataStore.isOnReadQueue
+            completed.fulfill()
+        }
+        XCTAssertEqual(flagsRepository.state.currentState, .reconciling)
+
+        dataStore.resumeRead()
+
+        // Then
+        wait(for: [errorStateObserved, completed], timeout: 1)
+        XCTAssertEqual(wasErrorStateNotifiedOnDataStoreQueue, false)
+        XCTAssertEqual(wasCompletionCalledOnDataStoreQueue, false)
+    }
+
     func testInitialDataStoreRead_whenCompletesAfterFailedContextUpdate_usesMatchingCachedFlags() throws {
         // Given
         let clientName = "client"
@@ -966,12 +1017,18 @@ private final class DelayedReadDataStore: DataStore, @unchecked Sendable {
     private var storage: [String: DataStoreValueResult]
 
     private let queue = DispatchQueue(label: "com.datadoghq.flags-delayed-read-data-store")
+    private let queueKey = DispatchSpecificKey<Void>()
     private let readSemaphore = DispatchSemaphore(value: 0)
 
     var onReadStarted: (() -> Void)?
 
+    var isOnReadQueue: Bool {
+        DispatchQueue.getSpecific(key: queueKey) != nil
+    }
+
     init(storage: [String: DataStoreValueResult] = [:]) {
         self.storage = storage
+        queue.setSpecific(key: queueKey, value: ())
     }
 
     func setValue(_ value: Data, forKey key: String, version: DataStoreKeyVersion) {
@@ -1001,5 +1058,17 @@ private final class DelayedReadDataStore: DataStore, @unchecked Sendable {
 
     func resumeRead() {
         readSemaphore.signal()
+    }
+}
+
+private final class StateChangeListener: FlagsStateListener {
+    private let onStateChange: (FlagsClientState) -> Void
+
+    init(onStateChange: @escaping (FlagsClientState) -> Void) {
+        self.onStateChange = onStateChange
+    }
+
+    func flagsStateDidChange(_ newState: FlagsClientState) {
+        onStateChange(newState)
     }
 }

--- a/DatadogFlags/Tests/FlagsTests.swift
+++ b/DatadogFlags/Tests/FlagsTests.swift
@@ -56,4 +56,25 @@ final class FlagsTests: XCTestCase {
         let requestBuilder = try XCTUnwrap(flags.requestBuilder as? ExposureRequestBuilder)
         XCTAssertEqual(requestBuilder.customIntakeURL, config.customExposureEndpoint)
     }
+
+    func testFlushFlushesRegisteredClients() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+        Flags.enable(in: core)
+        let flags = try XCTUnwrap(core.get(feature: FlagsFeature.self))
+        let repository = FlagsRepositoryMock()
+        let client = FlagsClient(
+            repository: repository,
+            exposureLogger: ExposureLoggerMock(),
+            evaluationLogger: EvaluationLoggerMock(),
+            rumFlagEvaluationReporter: RUMFlagEvaluationReporterMock()
+        )
+        flags.clientRegistry.register(client, named: "client")
+
+        // When
+        flags.flush()
+
+        // Then
+        XCTAssertEqual(repository.flushCallsCount, 1)
+    }
 }


### PR DESCRIPTION
### What and why?

`DatadogFlags` provider initialization can be delayed because `FlagsRepository.setEvaluationContext` waits for the initial cached flags read before moving to `.reconciling` and starting the assignment fetch. That cache read uses the SDK data store and can be delayed behind other SDK data-store work, for example RUM or Session Replay data-store reads/writes when those features are enabled, making `setProviderAndWait` appear slow before the network path even starts.

This changes provider initialization so reconciliation and the assignment fetch are not blocked by a delayed cache read.

A customer run confirmed the initial delay happens before reconciliation/network work starts. They instrumented setup by logging:
- `FlagsClient` state changes from a state listener
- timestamps before and after `setProviderAndWait`
- provider `initialize` / `setEvaluationContextAsync` start and end timestamps

The relevant timing breakdown was:

```text
setEvaluationContextAsync start  1784645084.773110
reconciling                      1784645095.290761  +10.52s
ready                            1784645095.511272  +0.22s after reconciling
after setProviderAndWait         1784645095.575045  +0.06s after ready
```

That points to the wait before `.reconciling`, not to the assignment fetch itself. Once reconciliation started, the provider became ready in about 220ms.

After the initial cache-read change, a second instrumented run showed `.reconciling` was no longer delayed, but there was still time between the assignment fetch returning success and `.ready`:

```text
reconciling                        1785310262.249758
assignment fetch start             1785310262.249765  immediate
URLSession dataTask resumed        1785310262.300871  +0.05s after fetch start
URLSession completion received     1785310263.811869  +1.51s after resume
assignment fetch returning success 1785310264.330017  +0.52s after completion
ready                              1785310273.267536  +8.94s after fetch success
```

That narrowed the remaining delay to the success path after the assignment fetch completed. On that path, `writeState(_:)` persisted the fetched flags before updating the client to `.ready`; `FlagsDataStore.setFlagsData` synchronously encodes `FlagsData` before scheduling the data-store write. This PR now moves cache persistence off the readiness path too.

### How?

Start `.reconciling` and the assignment fetch immediately in `setEvaluationContext`, while treating the initial cache read as advisory data.

The initial cache read is stored separately from active `flagsData`, so if it completes late it cannot overwrite newer network-fetched flags.

On a successful assignment fetch, fetched flags are applied to memory synchronously, cache persistence is scheduled on a private flags queue, and the client transitions to `.ready` without waiting for the cache write/encoding path. Queued cache writes are version-gated so a reset or newer successful fetch can make an older scheduled persistence operation a no-op.

Provider setup also avoids doing assignment-fetch request construction and response handling on the SDK context queue. Shared SDK queues remain the default for ordinary storage/context work because they provide ordering, resource containment, and race-safety guardrails. The issue in this path is head-of-line blocking: if latency-sensitive flags initialization is queued behind unrelated SDK work, raising the shared queue QoS would still preserve FIFO ordering and would also boost unrelated bulk SDK work. Instead, this keeps the scope narrow by using flags-owned queues for bounded provider setup work, without changing public API or raising the priority of broader telemetry processing.

The resulting flow is:
- if the cache read completes while the request is in flight and matches the requested context, evaluations can use cached values while the client remains `.reconciling`
- if the network request succeeds, fetched flags replace any cached flags and the client transitions to `.ready` without waiting for cache persistence
- if the network request fails, the repository waits for the initial cache read to finish before deciding between `.stale` and `.error`
- on failure, matching cached flags are used and the client transitions to `.stale`; missing or mismatched cached flags transition to `.error`

Added delayed-read/write tests covering:
- assignment fetch starts while the initial data-store read is blocked
- assignment fetch request and response handling run off the SDK context queue
- late cache read does not overwrite freshly fetched flags
- matching cached flags can still be served during `.reconciling` when the delayed read completes before the network fetch
- failed fetch waits for the delayed cache read and uses matching cached flags
- late mismatched cache read does not restore stale flags after a failed context update
- blocked cache persistence does not delay `.ready` or `setEvaluationContext` completion after a successful fetch

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs

No public API or Objective-C API changes.

Tested:
`xcodebuild test -workspace Datadog.xcworkspace -scheme "DatadogFlags" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' SWIFT_VERSION=5 -only-testing:DatadogFlagsTests/FlagsRepositoryTests`

Result: 20 tests, 0 failures.

`xcodebuild test -workspace Datadog.xcworkspace -scheme "DatadogFlags" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' SWIFT_VERSION=5`

Result: 118 tests, 0 failures.

Note: without `SWIFT_VERSION=5`, the local scheme currently hits unrelated `DatadogTrace` / OpenTelemetry Swift 6 Sendable build errors before reaching the Flags tests. The local `make test-ios` wrapper also could not run because `xcbeautify` is not installed, so the equivalent `xcodebuild` commands were run directly.
