### PR TITLE
Wait for WebView resources in scenario test

### DIFF
--- a/IntegrationTests/IntegrationScenarios/Scenarios/WebView/WebViewScenarioTest.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/WebView/WebViewScenarioTest.swift
@@ -32,7 +32,13 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
 
         // Get single RUM Session with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests, eventsPatch: patchBrowserEvents)?.views.count == 3
+            guard let session = try RUMSessionMatcher.singleSession(from: requests, eventsPatch: patchBrowserEvents),
+                  session.views.count == 3 else {
+                return false
+            }
+            // Browser resource events can arrive after the browser view event, so wait for the
+            // resource that is asserted below instead of racing the first 3-view session snapshot.
+            return !session.views[2].resourceEvents.isEmpty
         }
         assertRUM(requests: recordedRUMRequests)
 


### PR DESCRIPTION
### What and why?

`WebViewScenarioTest` is flaky. The assertion pulls recorded RUM requests and stops as soon as it sees a single session with 3 views, but browser resource events can arrive after the browser view event. When the 3-view snapshot is captured before the resource lands, the later `resourceEvents` assertion fails intermittently.

### How?

Wait for the resource that is asserted downstream instead of racing the first 3-view session snapshot: only accept the pulled requests once the third view actually has a resource event.

```swift
guard let session = try RUMSessionMatcher.singleSession(from: requests, eventsPatch: patchBrowserEvents),
      session.views.count == 3 else {
    return false
}
return !session.views[2].resourceEvents.isEmpty
```

### Review checklist
- [ ] CHANGELOG: n/a (test-only change)
- [ ] Obj-C interface: n/a
- [ ] api-surface: n/a