### PR TITLE
[RUM-15810] Apply new remote config schema for trace propagation

### DIFF
--- a/DatadogInternal/Sources/Models/RC/RCDataModels.swift
+++ b/DatadogInternal/Sources/Models/RC/RCDataModels.swift
@@ -71,18 +71,12 @@ public struct RemoteConfiguration: Codable {
     }
 
     public struct RUM: Codable {
-        /// Minimum main-thread freeze duration to report as an app hang. Omit to disable.
-        public let appHangThresholdMs: Double?
+        public let appHang: AppHang?
 
         /// UUID of the RUM application
         public let applicationId: String
 
-        public let env: String?
-
-        /// Minimum main-thread task duration to report as a long task
-        public let longTaskThresholdMs: Double?
-
-        public let service: String?
+        public let longTask: LongTask?
 
         public let telemetrySampleRate: Double?
 
@@ -105,11 +99,9 @@ public struct RemoteConfiguration: Codable {
         public let vitalsUpdateFrequency: VitalsUpdateFrequency?
 
         public enum CodingKeys: String, CodingKey {
-            case appHangThresholdMs = "appHangThresholdMs"
+            case appHang = "appHang"
             case applicationId = "applicationId"
-            case env = "env"
-            case longTaskThresholdMs = "longTaskThresholdMs"
-            case service = "service"
+            case longTask = "longTask"
             case telemetrySampleRate = "telemetrySampleRate"
             case trackAnonymousUser = "trackAnonymousUser"
             case trackBackgroundEvents = "trackBackgroundEvents"
@@ -124,11 +116,9 @@ public struct RemoteConfiguration: Codable {
 
         ///
         /// - Parameters:
-        ///   - appHangThresholdMs: Minimum main-thread freeze duration to report as an app hang. Omit to disable.
+        ///   - appHang:
         ///   - applicationId: UUID of the RUM application
-        ///   - env:
-        ///   - longTaskThresholdMs: Minimum main-thread task duration to report as a long task
-        ///   - service:
+        ///   - longTask:
         ///   - telemetrySampleRate:
         ///   - trackAnonymousUser:
         ///   - trackBackgroundEvents:
@@ -140,11 +130,9 @@ public struct RemoteConfiguration: Codable {
         ///   - trackWatchdogTerminations:
         ///   - vitalsUpdateFrequency:
         public init(
-            appHangThresholdMs: Double? = nil,
+            appHang: AppHang? = nil,
             applicationId: String,
-            env: String? = nil,
-            longTaskThresholdMs: Double? = nil,
-            service: String? = nil,
+            longTask: LongTask? = nil,
             telemetrySampleRate: Double? = nil,
             trackAnonymousUser: Bool? = nil,
             trackBackgroundEvents: Bool? = nil,
@@ -156,11 +144,9 @@ public struct RemoteConfiguration: Codable {
             trackWatchdogTerminations: Bool? = nil,
             vitalsUpdateFrequency: VitalsUpdateFrequency? = nil
         ) {
-            self.appHangThresholdMs = appHangThresholdMs
+            self.appHang = appHang
             self.applicationId = applicationId
-            self.env = env
-            self.longTaskThresholdMs = longTaskThresholdMs
-            self.service = service
+            self.longTask = longTask
             self.telemetrySampleRate = telemetrySampleRate
             self.trackAnonymousUser = trackAnonymousUser
             self.trackBackgroundEvents = trackBackgroundEvents
@@ -171,6 +157,54 @@ public struct RemoteConfiguration: Codable {
             self.trackUserInteractions = trackUserInteractions
             self.trackWatchdogTerminations = trackWatchdogTerminations
             self.vitalsUpdateFrequency = vitalsUpdateFrequency
+        }
+
+        public struct AppHang: Codable {
+            public let enabled: Bool?
+
+            /// Minimum main-thread freeze duration in milliseconds to report as an app hang
+            public let threshold: Double?
+
+            public enum CodingKeys: String, CodingKey {
+                case enabled = "enabled"
+                case threshold = "threshold"
+            }
+
+            ///
+            /// - Parameters:
+            ///   - enabled:
+            ///   - threshold: Minimum main-thread freeze duration in milliseconds to report as an app hang
+            public init(
+                enabled: Bool? = nil,
+                threshold: Double? = nil
+            ) {
+                self.enabled = enabled
+                self.threshold = threshold
+            }
+        }
+
+        public struct LongTask: Codable {
+            public let enabled: Bool?
+
+            /// Minimum main-thread task duration in milliseconds to report as a long task
+            public let threshold: Double?
+
+            public enum CodingKeys: String, CodingKey {
+                case enabled = "enabled"
+                case threshold = "threshold"
+            }
+
+            ///
+            /// - Parameters:
+            ///   - enabled:
+            ///   - threshold: Minimum main-thread task duration in milliseconds to report as a long task
+            public init(
+                enabled: Bool? = nil,
+                threshold: Double? = nil
+            ) {
+                self.enabled = enabled
+                self.threshold = threshold
+            }
         }
 
         public enum VitalsUpdateFrequency: String, Codable {
@@ -186,9 +220,6 @@ public struct RemoteConfiguration: Codable {
 
         public let sampleRate: Double?
 
-        /// Whether Session Replay starts recording as soon as the SDK initializes
-        public let startRecordingImmediately: Bool?
-
         public let textAndInputPrivacy: TextAndInputPrivacy?
 
         public let touchPrivacy: TouchPrivacy?
@@ -196,7 +227,6 @@ public struct RemoteConfiguration: Codable {
         public enum CodingKeys: String, CodingKey {
             case imagePrivacy = "imagePrivacy"
             case sampleRate = "sampleRate"
-            case startRecordingImmediately = "startRecordingImmediately"
             case textAndInputPrivacy = "textAndInputPrivacy"
             case touchPrivacy = "touchPrivacy"
         }
@@ -205,19 +235,16 @@ public struct RemoteConfiguration: Codable {
         /// - Parameters:
         ///   - imagePrivacy:
         ///   - sampleRate:
-        ///   - startRecordingImmediately: Whether Session Replay starts recording as soon as the SDK initializes
         ///   - textAndInputPrivacy:
         ///   - touchPrivacy:
         public init(
             imagePrivacy: ImagePrivacy? = nil,
             sampleRate: Double? = nil,
-            startRecordingImmediately: Bool? = nil,
             textAndInputPrivacy: TextAndInputPrivacy? = nil,
             touchPrivacy: TouchPrivacy? = nil
         ) {
             self.imagePrivacy = imagePrivacy
             self.sampleRate = sampleRate
-            self.startRecordingImmediately = startRecordingImmediately
             self.textAndInputPrivacy = textAndInputPrivacy
             self.touchPrivacy = touchPrivacy
         }
@@ -245,35 +272,28 @@ public struct RemoteConfiguration: Codable {
 
         public let traceContextInjection: TraceContextInjection?
 
-        /// Hostnames for which distributed tracing headers are injected
-        public let tracedHosts: [String]?
-
-        /// Tracing header formats injected on requests to all traced hosts
-        public let tracingHeaderTypes: [TracingHeaderTypes]?
+        /// Per-host distributed tracing configuration. Aligns with browser's allowedTracingUrls model (without regex matching).
+        public let tracedHosts: [TracedHosts]?
 
         public enum CodingKeys: String, CodingKey {
             case sampleRate = "sampleRate"
             case traceContextInjection = "traceContextInjection"
             case tracedHosts = "tracedHosts"
-            case tracingHeaderTypes = "tracingHeaderTypes"
         }
 
         ///
         /// - Parameters:
         ///   - sampleRate:
         ///   - traceContextInjection:
-        ///   - tracedHosts: Hostnames for which distributed tracing headers are injected
-        ///   - tracingHeaderTypes: Tracing header formats injected on requests to all traced hosts
+        ///   - tracedHosts: Per-host distributed tracing configuration. Aligns with browser's allowedTracingUrls model (without regex matching).
         public init(
             sampleRate: Double? = nil,
             traceContextInjection: TraceContextInjection? = nil,
-            tracedHosts: [String]? = nil,
-            tracingHeaderTypes: [TracingHeaderTypes]? = nil
+            tracedHosts: [TracedHosts]? = nil
         ) {
             self.sampleRate = sampleRate
             self.traceContextInjection = traceContextInjection
             self.tracedHosts = tracedHosts
-            self.tracingHeaderTypes = tracingHeaderTypes
         }
 
         public enum TraceContextInjection: String, Codable {
@@ -281,13 +301,36 @@ public struct RemoteConfiguration: Codable {
             case sampled = "sampled"
         }
 
-        public enum TracingHeaderTypes: String, Codable {
-            case datadog = "datadog"
-            case b3 = "b3"
-            case b3multi = "b3multi"
-            case tracecontext = "tracecontext"
+        public struct TracedHosts: Codable {
+            public let host: String
+
+            public let propagatorTypes: [PropagatorTypes]
+
+            public enum CodingKeys: String, CodingKey {
+                case host = "host"
+                case propagatorTypes = "propagatorTypes"
+            }
+
+            ///
+            /// - Parameters:
+            ///   - host:
+            ///   - propagatorTypes:
+            public init(
+                host: String,
+                propagatorTypes: [PropagatorTypes]
+            ) {
+                self.host = host
+                self.propagatorTypes = propagatorTypes
+            }
+
+            public enum PropagatorTypes: String, Codable {
+                case datadog = "datadog"
+                case b3 = "b3"
+                case b3multi = "b3multi"
+                case tracecontext = "tracecontext"
+            }
         }
     }
 }
 
-// Generated from https://github.com/DataDog/dd-go/blob/2fc3a72fc0222d5275db1c478dbfee942dd0f816/remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/STAGING/ios.json
+// Generated from https://github.com/DataDog/dd-go/blob/96df9f634c7c1215670fce6a12adee84ae5bc392/remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/STAGING/ios.json

--- a/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration+RemoteConfiguration.swift
@@ -42,11 +42,11 @@ extension RUM.Configuration {
     /// are modeled as the presence of a tracking configuration / action predicate — so they are toggled
     /// through the `override(_:with:)` overloads instead.
     ///
-    /// `longTaskThreshold` and `appHangThreshold` are overridden through `override(_:withMilliseconds:)`,
-    /// which follows "omit to disable" semantics: it converts milliseconds to seconds and, within a
-    /// present `rum` namespace, lets the remote value always drive the property — so an omitted threshold
-    /// clears the in-code value (disabling the feature) rather than keeping it. This mirrors the in-code
-    /// configuration, where a `nil` threshold disables the feature.
+    /// `longTaskThreshold` and `appHangThreshold` are overridden through `override(_:with:)` for
+    /// `AppHang`/`LongTask`, which follows: an explicit `enabled == false` clears the in-code value
+    /// (disabling the feature); otherwise a present `threshold` overrides it (converted from
+    /// milliseconds to seconds); an omitted `threshold` (or an omitted `appHang`/`longTask` namespace)
+    /// leaves the in-code value untouched.
     ///
     /// - Parameter rum: The `rum` namespace, or `nil` to leave the configuration unchanged.
     private mutating func apply(rum: RemoteConfiguration.RUM?) {
@@ -58,8 +58,8 @@ extension RUM.Configuration {
         override(\.trackAnonymousUser, with: rum.trackAnonymousUser)
         override(\.trackBackgroundEvents, with: rum.trackBackgroundEvents)
         override(\.trackFrustrations, with: rum.trackFrustrations)
-        override(\.longTaskThreshold, withMilliseconds: rum.longTaskThresholdMs)
-        override(\.appHangThreshold, withMilliseconds: rum.appHangThresholdMs)
+        override(\.longTaskThreshold, with: rum.longTask)
+        override(\.appHangThreshold, with: rum.appHang)
         override(\.trackSlowFrames, with: rum.trackSlowFrames)
         override(\.trackWatchdogTerminations, with: rum.trackWatchdogTerminations)
         override(\.vitalsUpdateFrequency, with: rum.vitalsUpdateFrequency.map { VitalsFrequency($0) })
@@ -86,51 +86,16 @@ extension RUM.Configuration {
     /// present sample rate / injection still updates existing propagation; an empty list is a no-op when
     /// no `urlSessionTracking` was configured in code (there is nothing to clear).
     ///
+    /// Each entry in `tracedHosts` carries its own `propagatorTypes`, mapped directly onto the host's
+    /// header formats — an empty list traces the host with no header formats.
+    ///
     /// - Parameter trace: The `trace` namespace, or `nil` to leave the configuration unchanged.
     private mutating func apply(trace: RemoteConfiguration.Trace?) {
         guard let trace else {
             return
         }
 
-        // Resolve the tracing sample rate and injection strategy: a present remote value wins,
-        // otherwise the in-code value is kept, falling back to the module defaults when neither exists.
-        let existing = urlSessionTracking?.firstPartyHostsTracing
-        let sampleRate = trace.sampleRate.map { SampleRate($0) } ?? existing?.sampleRate ?? .maxSampleRate
-        let traceControlInjection = trace.traceContextInjection
-            .map { TraceContextInjection($0) } ?? existing?.traceControlInjection ?? .sampled
-
-        switch trace.tracedHosts {
-        case .some(let tracedHosts) where !tracedHosts.isEmpty:
-            // A non-empty list configures (or replaces) propagation for the remote hosts.
-            var tracking = urlSessionTracking ?? URLSessionTracking()
-            tracking.firstPartyHostsTracing = URLSessionTracking.FirstPartyHostsTracing(
-                trace,
-                sampleRate: sampleRate,
-                traceControlInjection: traceControlInjection
-            )
-            urlSessionTracking = tracking
-
-        case .some:
-            // An explicit empty list clears propagation, keeping any other instrumentation settings;
-            // there is nothing to clear when no instrumentation was configured in code.
-            if var tracking = urlSessionTracking {
-                tracking.firstPartyHostsTracing = nil
-                urlSessionTracking = tracking
-            }
-
-        case .none:
-            // Hosts omitted: a present sample rate or injection strategy still updates existing
-            // propagation; without existing propagation there are no hosts to configure.
-            guard trace.sampleRate != nil || trace.traceContextInjection != nil,
-                  var tracking = urlSessionTracking,
-                  let firstPartyHostsTracing = tracking.firstPartyHostsTracing else {
-                return
-            }
-
-            tracking.firstPartyHostsTracing = firstPartyHostsTracing
-                .overriding(sampleRate: sampleRate, traceControlInjection: traceControlInjection)
-            urlSessionTracking = tracking
-        }
+        urlSessionTracking = urlSessionTracking?.overriding(with: trace) ?? URLSessionTracking(trace)
     }
 
     /// Overrides the value at `keyPath` with `remoteValue` when it is present.
@@ -147,17 +112,22 @@ extension RUM.Configuration {
         }
     }
 
-    /// Overrides a threshold property (stored in seconds) with a remote value in milliseconds.
+    /// Overrides a threshold property (stored in seconds) with a remote `appHang`/`longTask` value.
     ///
-    /// Unlike `override(_:with:)`, the remote value always drives the property: within a present `rum`
-    /// namespace an omitted (`nil`) threshold disables the feature — matching the in-code configuration,
-    /// where a `nil` threshold disables it. Milliseconds are converted to seconds.
+    /// An explicit `enabled == false` clears the property, disabling the feature regardless of
+    /// `threshold`. Otherwise, a present `threshold` (in milliseconds) overrides the property, converted
+    /// to seconds. An omitted `threshold` — or an omitted `remote` namespace entirely — leaves the
+    /// in-code value untouched.
     ///
     /// - Parameters:
     ///   - keyPath: The threshold property to override.
-    ///   - milliseconds: The remote threshold in milliseconds, or `nil` to disable the feature.
-    private mutating func override(_ keyPath: WritableKeyPath<Self, TimeInterval?>, withMilliseconds milliseconds: Double?) {
-        self[keyPath: keyPath] = milliseconds.map { .ddFromMilliseconds(.ddWithNoOverflow($0)) }
+    ///   - remote: The remote `appHang` or `longTask` configuration, or `nil` when omitted.
+    private mutating func override(_ keyPath: WritableKeyPath<Self, TimeInterval?>, with remote: RemoteThreshold?) {
+        if remote?.enabled == false {
+            self[keyPath: keyPath] = nil
+        } else if let threshold = remote?.threshold {
+            self[keyPath: keyPath] = .ddFromMilliseconds(.ddWithNoOverflow(threshold))
+        }
     }
 
     /// Toggles resource tracking, which is modeled in-code as the presence of `urlSessionTracking`.
@@ -219,6 +189,15 @@ extension RUM.Configuration {
     #endif
 }
 
+/// A remote `appHang`/`longTask` configuration: an `enabled` switch and a `threshold` in milliseconds.
+private protocol RemoteThreshold {
+    var enabled: Bool? { get }
+    var threshold: Double? { get }
+}
+
+extension RemoteConfiguration.RUM.AppHang: RemoteThreshold {}
+extension RemoteConfiguration.RUM.LongTask: RemoteThreshold {}
+
 private extension RUM.Configuration.VitalsFrequency {
     /// Creates the in-code vitals frequency matching a remote `vitalsUpdateFrequency`.
     ///
@@ -232,6 +211,64 @@ private extension RUM.Configuration.VitalsFrequency {
         case .rare: self = .rare
         case .never: return nil
         }
+    }
+}
+
+private extension RUM.Configuration.URLSessionTracking {
+    /// Returns a copy merging the remote `trace` namespace's first-party hosts tracing on top of this
+    /// in-code configuration, leaving any other settings (e.g. resource attributes, header capture)
+    /// intact.
+    ///
+    /// The host list drives whether propagation exists: a non-empty list configures (or replaces) it,
+    /// while an explicit empty list clears it. When `tracedHosts` is omitted, a present sample rate /
+    /// injection still updates existing propagation; there is nothing to clear or update when no
+    /// propagation was configured in code. Either way, the sample rate and injection strategy fall back
+    /// to the in-code value, then the module default, when the remote omits them.
+    ///
+    /// - Parameter trace: The remote `trace` namespace.
+    /// - Returns: A copy with first-party hosts tracing merged with `trace`.
+    func overriding(with trace: RemoteConfiguration.Trace) -> Self {
+        var tracking = self
+        let sampleRate = trace.sampleRate.map { SampleRate($0) }
+        let traceControlInjection = trace.traceContextInjection.map { TraceContextInjection($0) }
+
+        guard let tracedHosts = trace.tracedHosts else {
+            // No hosts in the remote config: keep whatever propagation exists, refreshing only its
+            // sample rate / injection strategy when the remote provides them.
+            tracking.firstPartyHostsTracing = tracking.firstPartyHostsTracing?.overriding(
+                sampleRate: sampleRate,
+                traceControlInjection: traceControlInjection
+            )
+            return tracking
+        }
+
+        if tracedHosts.isEmpty {
+            // Explicit empty list: clear propagation.
+            tracking.firstPartyHostsTracing = nil
+            return tracking
+        }
+
+        // Non-empty list: configure (or replace) propagation for these hosts.
+        tracking.firstPartyHostsTracing = FirstPartyHostsTracing(
+            tracedHosts,
+            sampleRate: sampleRate ?? tracking.firstPartyHostsTracing?.sampleRate,
+            traceControlInjection: traceControlInjection ?? tracking.firstPartyHostsTracing?.traceControlInjection
+        )
+        return tracking
+    }
+
+    /// Builds a fresh tracking configuration for a remote `trace` namespace, when no in-code
+    /// `urlSessionTracking` exists to merge onto.
+    ///
+    /// - Parameter trace: The remote `trace` namespace.
+    /// - Returns: A configuration holding the resulting first-party hosts tracing, or `nil` when `trace`
+    ///   configures no propagation (nothing to instrument).
+    init?(_ trace: RemoteConfiguration.Trace) {
+        let tracking = Self().overriding(with: trace)
+        guard tracking.firstPartyHostsTracing != nil else {
+            return nil
+        }
+        self = tracking
     }
 }
 
@@ -252,57 +289,47 @@ private extension RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing {
         }
     }
 
-    /// Builds first-party hosts tracing configuration for a remote `trace` namespace's hosts.
+    /// Builds first-party hosts tracing configuration for a non-empty list of remote traced hosts, with
+    /// the given sample rate and injection strategy.
     ///
-    /// When header formats are provided they apply to every traced host (`.traceWithHeaders`);
-    /// otherwise the default trace headers are used (`.trace`). The sample rate and injection strategy
-    /// are resolved by the caller (remote value, else in-code value, else module default).
-    ///
-    /// - Parameters:
-    ///   - trace: The remote `trace` namespace.
-    ///   - sampleRate: The resolved trace propagation sample rate.
-    ///   - traceControlInjection: The resolved trace context injection strategy.
-    /// - Returns: The tracing configuration, or `nil` when no hosts are provided (nothing to instrument).
-    init?(_ trace: RemoteConfiguration.Trace, sampleRate: SampleRate, traceControlInjection: TraceContextInjection) {
-        guard let tracedHosts = trace.tracedHosts, !tracedHosts.isEmpty else {
-            return nil
-        }
-
-        let hosts = Set(tracedHosts)
-
-        if let tracingHeaderTypes = trace.tracingHeaderTypes, !tracingHeaderTypes.isEmpty {
-            let headerTypes = Set(tracingHeaderTypes.map { TracingHeaderType($0) })
-            self = .traceWithHeaders(
-                hostsWithHeaders: Dictionary(uniqueKeysWithValues: hosts.map { ($0, headerTypes) }),
-                sampleRate: sampleRate,
-                traceControlInjection: traceControlInjection
-            )
-        } else {
-            self = .trace(
-                hosts: hosts,
-                sampleRate: sampleRate,
-                traceControlInjection: traceControlInjection
-            )
-        }
-    }
-
-    /// Returns a copy overriding the sample rate and injection strategy while preserving the hosts and
-    /// any header formats.
+    /// Each host's `propagatorTypes` are mapped directly onto its header formats in `.traceWithHeaders`.
     ///
     /// - Parameters:
+    ///   - tracedHosts: The remote `trace` namespace's traced hosts; must be non-empty.
     ///   - sampleRate: The trace propagation sample rate to apply.
     ///   - traceControlInjection: The trace context injection strategy to apply.
-    /// - Returns: A configuration with the same hosts (and header formats) but the given sample rate
-    ///   and injection strategy.
-    func overriding(sampleRate: SampleRate, traceControlInjection: TraceContextInjection) -> Self {
+    init(_ tracedHosts: [RemoteConfiguration.Trace.TracedHosts], sampleRate: SampleRate?, traceControlInjection: TraceContextInjection?) {
+        self = .traceWithHeaders(
+            hostsWithHeaders: tracedHosts.reduce(into: [:]) {
+                $0[$1.host] = Set($1.propagatorTypes.map { TracingHeaderType($0) })
+            },
+            sampleRate: sampleRate ?? .maxSampleRate,
+            traceControlInjection: traceControlInjection ?? .sampled
+        )
+    }
+
+    /// Returns a copy overriding the sample rate and/or injection strategy while preserving the hosts
+    /// and any header formats. A `nil` argument keeps the current value.
+    ///
+    /// - Parameters:
+    ///   - sampleRate: The trace propagation sample rate to apply, or `nil` to keep the current one.
+    ///   - traceControlInjection: The trace context injection strategy to apply, or `nil` to keep the
+    ///     current one.
+    /// - Returns: A configuration with the same hosts (and header formats), the given sample rate and
+    ///   injection strategy overriding the current ones where present.
+    func overriding(sampleRate: SampleRate?, traceControlInjection: TraceContextInjection?) -> Self {
         switch self {
-        case let .trace(hosts, _, _):
-            return .trace(hosts: hosts, sampleRate: sampleRate, traceControlInjection: traceControlInjection)
-        case let .traceWithHeaders(hostsWithHeaders, _, _):
+        case let .trace(hosts, currentSampleRate, currentInjection):
+            return .trace(
+                hosts: hosts,
+                sampleRate: sampleRate ?? currentSampleRate,
+                traceControlInjection: traceControlInjection ?? currentInjection
+            )
+        case let .traceWithHeaders(hostsWithHeaders, currentSampleRate, currentInjection):
             return .traceWithHeaders(
                 hostsWithHeaders: hostsWithHeaders,
-                sampleRate: sampleRate,
-                traceControlInjection: traceControlInjection
+                sampleRate: sampleRate ?? currentSampleRate,
+                traceControlInjection: traceControlInjection ?? currentInjection
             )
         }
     }
@@ -321,10 +348,10 @@ private extension TraceContextInjection {
 }
 
 private extension TracingHeaderType {
-    /// Maps a remote tracing header format onto the in-code `TracingHeaderType`.
+    /// Maps a remote propagator type onto the in-code `TracingHeaderType`.
     ///
-    /// - Parameter remote: The remote tracing header format.
-    init(_ remote: RemoteConfiguration.Trace.TracingHeaderTypes) {
+    /// - Parameter remote: The remote propagator type.
+    init(_ remote: RemoteConfiguration.Trace.TracedHosts.PropagatorTypes) {
         switch remote {
         case .datadog: self = .datadog
         case .b3: self = .b3

--- a/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
@@ -124,12 +124,12 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
         XCTAssertEqual(injection, .all)
     }
 
-    /// When the `trace` namespace provides hosts but no header formats, those hosts are traced with no
-    /// header formats; the sample rate / injection strategy fall back to the module defaults.
-    func testWhenRemoteTraceProvidesHostsWithoutHeaderTypes_itUsesNoHeaderFormats() throws {
+    /// When the `trace` namespace provides hosts with a single header format, that host is traced with
+    /// exactly that header format; the sample rate / injection strategy fall back to the module defaults.
+    func testWhenRemoteTraceProvidesHostsWithSingleHeaderType_itUsesThatHeaderFormat() throws {
         // Given no in-code network instrumentation
         var configuration: RUM.Configuration = .mockWith { $0.urlSessionTracking = nil }
-        let remote: RemoteConfiguration = .mockWith(trace: .init(tracedHosts: [.init(host: "example.com", propagatorTypes: [])]))
+        let remote: RemoteConfiguration = .mockWith(trace: .init(tracedHosts: [.init(host: "example.com", propagatorTypes: [.b3])]))
 
         // When
         configuration.apply(remoteConfiguration: remote)
@@ -139,7 +139,7 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
             configuration.urlSessionTracking?.firstPartyHostsTracing else {
             return XCTFail("Expected `.traceWithHeaders` first-party hosts tracing to be configured")
         }
-        XCTAssertEqual(hostsWithHeaders, ["example.com": []])
+        XCTAssertEqual(hostsWithHeaders, ["example.com": [.b3]])
         XCTAssertEqual(sampleRate, .maxSampleRate) // default when the remote omits `sampleRate`
         XCTAssertEqual(injection, .sampled) // default when the remote omits `traceContextInjection`
     }
@@ -186,12 +186,12 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
             )
         }
 
-        configuration.apply(remoteConfiguration: .mockWith(trace: .init(tracedHosts: [.init(host: "remote.example.com", propagatorTypes: [])])))
+        configuration.apply(remoteConfiguration: .mockWith(trace: .init(tracedHosts: [.init(host: "remote.example.com", propagatorTypes: [.b3])])))
 
         guard case let .traceWithHeaders(hostsWithHeaders, sampleRate, injection) = configuration.urlSessionTracking?.firstPartyHostsTracing else {
             return XCTFail("Expected `.traceWithHeaders` first-party hosts tracing to be configured")
         }
-        XCTAssertEqual(hostsWithHeaders, ["remote.example.com": []])
+        XCTAssertEqual(hostsWithHeaders, ["remote.example.com": [.b3]])
         XCTAssertEqual(sampleRate, 30)
         XCTAssertEqual(injection, .all)
     }
@@ -223,7 +223,7 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
         configuration.apply(
             remoteConfiguration: .mockWith(
                 rum: .mockWith(trackResources: false),
-                trace: .init(tracedHosts: [.init(host: "example.com", propagatorTypes: [])])
+                trace: .init(tracedHosts: [.init(host: "example.com", propagatorTypes: [.b3])])
             )
         )
 

--- a/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfiguration+RemoteConfigurationTests.swift
@@ -42,8 +42,8 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
             XCTAssertEqual(configuration.trackAnonymousUser, rum.trackAnonymousUser)
             XCTAssertEqual(configuration.trackBackgroundEvents, rum.trackBackgroundEvents)
             XCTAssertEqual(configuration.trackFrustrations, rum.trackFrustrations)
-            XCTAssertEqual(configuration.longTaskThreshold, .ddFromMilliseconds(.ddWithNoOverflow(try XCTUnwrap(rum.longTaskThresholdMs))))
-            XCTAssertEqual(configuration.appHangThreshold, .ddFromMilliseconds(.ddWithNoOverflow(try XCTUnwrap(rum.appHangThresholdMs))))
+            XCTAssertEqual(configuration.longTaskThreshold, .ddFromMilliseconds(.ddWithNoOverflow(try XCTUnwrap(rum.longTask?.threshold))))
+            XCTAssertEqual(configuration.appHangThreshold, .ddFromMilliseconds(.ddWithNoOverflow(try XCTUnwrap(rum.appHang?.threshold))))
             XCTAssertEqual(configuration.trackSlowFrames, rum.trackSlowFrames)
             XCTAssertEqual(configuration.trackWatchdogTerminations, rum.trackWatchdogTerminations)
             XCTAssertEqual(configuration.vitalsUpdateFrequency, expectedVitalsFrequency(try XCTUnwrap(rum.vitalsUpdateFrequency)))
@@ -93,7 +93,7 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
 
     /// The `trace` namespace must enable network instrumentation (even when none was configured
     /// in-code) and set up distributed tracing for the given hosts. When header formats are provided,
-    /// they apply to every traced host.
+    /// they apply to their host.
     func testWhenRemoteTraceProvidesHostsAndHeaderTypes_itConfiguresDistributedTracing() throws {
         // Given no in-code network instrumentation
         var configuration: RUM.Configuration = .mockWith { $0.urlSessionTracking = nil }
@@ -101,8 +101,10 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
             trace: .init(
                 sampleRate: 55,
                 traceContextInjection: .all,
-                tracedHosts: ["api.example.com", "example.com"],
-                tracingHeaderTypes: [.datadog, .b3]
+                tracedHosts: [
+                    .init(host: "api.example.com", propagatorTypes: [.datadog, .b3]),
+                    .init(host: "example.com", propagatorTypes: [.datadog, .b3])
+                ]
             )
         )
 
@@ -122,22 +124,22 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
         XCTAssertEqual(injection, .all)
     }
 
-    /// When the `trace` namespace provides hosts but no header formats, RUM falls back to the default
-    /// trace headers and the default sample rate / injection strategy.
-    func testWhenRemoteTraceProvidesHostsWithoutHeaderTypes_itUsesDefaultTraceHeaders() throws {
+    /// When the `trace` namespace provides hosts but no header formats, those hosts are traced with no
+    /// header formats; the sample rate / injection strategy fall back to the module defaults.
+    func testWhenRemoteTraceProvidesHostsWithoutHeaderTypes_itUsesNoHeaderFormats() throws {
         // Given no in-code network instrumentation
         var configuration: RUM.Configuration = .mockWith { $0.urlSessionTracking = nil }
-        let remote: RemoteConfiguration = .mockWith(trace: .init(tracedHosts: ["example.com"]))
+        let remote: RemoteConfiguration = .mockWith(trace: .init(tracedHosts: [.init(host: "example.com", propagatorTypes: [])]))
 
         // When
         configuration.apply(remoteConfiguration: remote)
 
         // Then
-        guard case let .trace(hosts, sampleRate, injection) =
+        guard case let .traceWithHeaders(hostsWithHeaders, sampleRate, injection) =
             configuration.urlSessionTracking?.firstPartyHostsTracing else {
-            return XCTFail("Expected `.trace` first-party hosts tracing to be configured")
+            return XCTFail("Expected `.traceWithHeaders` first-party hosts tracing to be configured")
         }
-        XCTAssertEqual(hosts, ["example.com"])
+        XCTAssertEqual(hostsWithHeaders, ["example.com": []])
         XCTAssertEqual(sampleRate, .maxSampleRate) // default when the remote omits `sampleRate`
         XCTAssertEqual(injection, .sampled) // default when the remote omits `traceContextInjection`
     }
@@ -184,12 +186,12 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
             )
         }
 
-        configuration.apply(remoteConfiguration: .mockWith(trace: .init(tracedHosts: ["remote.example.com"])))
+        configuration.apply(remoteConfiguration: .mockWith(trace: .init(tracedHosts: [.init(host: "remote.example.com", propagatorTypes: [])])))
 
-        guard case let .trace(hosts, sampleRate, injection) = configuration.urlSessionTracking?.firstPartyHostsTracing else {
-            return XCTFail("Expected `.trace` first-party hosts tracing to be configured")
+        guard case let .traceWithHeaders(hostsWithHeaders, sampleRate, injection) = configuration.urlSessionTracking?.firstPartyHostsTracing else {
+            return XCTFail("Expected `.traceWithHeaders` first-party hosts tracing to be configured")
         }
-        XCTAssertEqual(hosts, ["remote.example.com"])
+        XCTAssertEqual(hostsWithHeaders, ["remote.example.com": []])
         XCTAssertEqual(sampleRate, 30)
         XCTAssertEqual(injection, .all)
     }
@@ -221,35 +223,50 @@ class RUMConfiguration_RemoteConfigurationTests: XCTestCase {
         configuration.apply(
             remoteConfiguration: .mockWith(
                 rum: .mockWith(trackResources: false),
-                trace: .init(tracedHosts: ["example.com"])
+                trace: .init(tracedHosts: [.init(host: "example.com", propagatorTypes: [])])
             )
         )
 
         XCTAssertNil(configuration.urlSessionTracking)
     }
 
-    /// `appHangThresholdMs` follows "omit to disable" semantics: within a present `rum` namespace, an
-    /// omitted value clears the in-code `appHangThreshold`, disabling app-hang monitoring — even though
-    /// it was enabled in code.
-    func testWhenRemoteRUMOmitsAppHangThreshold_itDisablesAppHangMonitoring() {
+    /// An explicit `appHang.enabled == false` clears the in-code `appHangThreshold`, disabling app-hang
+    /// monitoring — even though it was enabled in code — regardless of any `threshold` value.
+    func testWhenRemoteAppHangIsDisabled_itDisablesAppHangMonitoring() {
         var configuration: RUM.Configuration = .mockWith { $0.appHangThreshold = 0.25 }
 
-        // A present `rum` namespace that does not carry `appHangThresholdMs`.
-        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(appHangThresholdMs: nil)))
+        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(appHang: .mockWith(enabled: false, threshold: 800))))
 
         XCTAssertNil(configuration.appHangThreshold)
     }
 
-    /// `longTaskThresholdMs` follows "omit to disable" semantics: within a present `rum` namespace, an
-    /// omitted value clears the in-code `longTaskThreshold`, disabling long-task tracking — even though
-    /// it was enabled in code.
-    func testWhenRemoteRUMOmitsLongTaskThreshold_itDisablesLongTaskTracking() {
+    /// When `appHang` (or its `threshold`) is omitted, the in-code `appHangThreshold` is left untouched.
+    func testWhenRemoteAppHangOmitsThreshold_itPreservesInCodeValue() {
+        var configuration: RUM.Configuration = .mockWith { $0.appHangThreshold = 0.25 }
+
+        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(appHang: .mockWith(enabled: true, threshold: nil))))
+
+        XCTAssertEqual(configuration.appHangThreshold, 0.25)
+    }
+
+    /// An explicit `longTask.enabled == false` clears the in-code `longTaskThreshold`, disabling
+    /// long-task tracking — even though it was enabled in code — regardless of any `threshold` value.
+    func testWhenRemoteLongTaskIsDisabled_itDisablesLongTaskTracking() {
         var configuration: RUM.Configuration = .mockWith { $0.longTaskThreshold = 0.5 }
 
-        // A present `rum` namespace that does not carry `longTaskThresholdMs`.
-        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(longTaskThresholdMs: nil)))
+        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(longTask: .mockWith(enabled: false, threshold: 800))))
 
         XCTAssertNil(configuration.longTaskThreshold)
+    }
+
+    /// When `longTask` (or its `threshold`) is omitted, the in-code `longTaskThreshold` is left
+    /// untouched.
+    func testWhenRemoteLongTaskOmitsThreshold_itPreservesInCodeValue() {
+        var configuration: RUM.Configuration = .mockWith { $0.longTaskThreshold = 0.5 }
+
+        configuration.apply(remoteConfiguration: .mockWith(rum: .mockWith(longTask: .mockWith(enabled: true, threshold: nil))))
+
+        XCTAssertEqual(configuration.longTaskThreshold, 0.5)
     }
 
     /// A remote `vitalsUpdateFrequency == .never` disables vitals collection: `VitalsFrequency.init?`

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -460,7 +460,7 @@ class RUMTests: XCTestCase {
         config = RUM.Configuration(applicationID: .mockRandom())
         config.urlSessionTracking = nil
         core.remoteConfiguration = RemoteConfiguration(
-            trace: .init(tracedHosts: ["example.com"])
+            trace: .init(tracedHosts: [.init(host: "example.com", propagatorTypes: [])])
         )
 
         // When

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration+RemoteConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration+RemoteConfiguration.swift
@@ -11,10 +11,10 @@ import DatadogInternal
 extension SessionReplay.Configuration {
     /// Merges the remote configuration on top of this in-code configuration.
     ///
-    /// The `sessionReplay` namespace overrides the supported behavioral parameters: sample rate, the
-    /// three privacy levels, and whether recording starts immediately. Remote values take precedence,
-    /// while any parameter the remote configuration omits keeps its in-code value; passing `nil` (no
-    /// remote configuration was fetched) therefore leaves the configuration entirely unchanged.
+    /// The `sessionReplay` namespace overrides the supported behavioral parameters: sample rate and the
+    /// three privacy levels. Remote values take precedence, while any parameter the remote configuration
+    /// omits keeps its in-code value; passing `nil` (no remote configuration was fetched) therefore
+    /// leaves the configuration entirely unchanged.
     ///
     /// The merge happens once, at `SessionReplay.enable(with:)` time; live updates after initialization
     /// are out of scope.
@@ -39,7 +39,6 @@ extension SessionReplay.Configuration {
         }
 
         override(\.replaySampleRate, with: sessionReplay.sampleRate.map { SampleRate($0) })
-        override(\.startRecordingImmediately, with: sessionReplay.startRecordingImmediately)
         override(\.textAndInputPrivacyLevel, with: sessionReplay.textAndInputPrivacy.map { TextAndInputPrivacyLevel($0) })
         override(\.imagePrivacyLevel, with: sessionReplay.imagePrivacy.map { ImagePrivacyLevel($0) })
         override(\.touchPrivacyLevel, with: sessionReplay.touchPrivacy.map { TouchPrivacyLevel($0) })

--- a/DatadogSessionReplay/Tests/SessionReplayConfiguration+RemoteConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfiguration+RemoteConfigurationTests.swift
@@ -55,7 +55,6 @@ class SessionReplayConfiguration_RemoteConfigurationTests: XCTestCase {
 
             // Then
             XCTAssertEqual(configuration.replaySampleRate, SampleRate(try XCTUnwrap(sessionReplay.sampleRate)))
-            XCTAssertEqual(configuration.startRecordingImmediately, try XCTUnwrap(sessionReplay.startRecordingImmediately))
             XCTAssertEqual(configuration.textAndInputPrivacyLevel, expectedTextAndInputPrivacy(try XCTUnwrap(sessionReplay.textAndInputPrivacy)))
             XCTAssertEqual(configuration.imagePrivacyLevel, expectedImagePrivacy(try XCTUnwrap(sessionReplay.imagePrivacy)))
             XCTAssertEqual(configuration.touchPrivacyLevel, expectedTouchPrivacy(try XCTUnwrap(sessionReplay.touchPrivacy)))

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RemoteConfigurationMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RemoteConfigurationMocks.swift
@@ -74,11 +74,9 @@ extension RemoteConfiguration.RUM: AnyMockable, RandomMockable {
     /// `RUMConfiguration_RemoteConfigurationTests` detect any newly generated schema field.
     public static func mockRandom() -> RemoteConfiguration.RUM {
         .init(
-            appHangThresholdMs: .mockRandom(min: 100, max: 5_000),
+            appHang: .mockRandom(),
             applicationId: .mockRandom(),
-            env: .mockRandom(),
-            longTaskThresholdMs: .mockRandom(min: 100, max: 5_000),
-            service: .mockRandom(),
+            longTask: .mockRandom(),
             telemetrySampleRate: .mockRandom(min: 0, max: 100),
             trackAnonymousUser: .mockRandom(),
             trackBackgroundEvents: .mockRandom(),
@@ -93,11 +91,9 @@ extension RemoteConfiguration.RUM: AnyMockable, RandomMockable {
     }
 
     public static func mockWith(
-        appHangThresholdMs: Double? = nil,
+        appHang: RemoteConfiguration.RUM.AppHang? = nil,
         applicationId: String = .mockAny(),
-        env: String? = nil,
-        longTaskThresholdMs: Double? = nil,
-        service: String? = nil,
+        longTask: RemoteConfiguration.RUM.LongTask? = nil,
         telemetrySampleRate: Double? = nil,
         trackAnonymousUser: Bool? = nil,
         trackBackgroundEvents: Bool? = nil,
@@ -110,11 +106,9 @@ extension RemoteConfiguration.RUM: AnyMockable, RandomMockable {
         vitalsUpdateFrequency: RemoteConfiguration.RUM.VitalsUpdateFrequency? = nil
     ) -> RemoteConfiguration.RUM {
         .init(
-            appHangThresholdMs: appHangThresholdMs,
+            appHang: appHang,
             applicationId: applicationId,
-            env: env,
-            longTaskThresholdMs: longTaskThresholdMs,
-            service: service,
+            longTask: longTask,
             telemetrySampleRate: telemetrySampleRate,
             trackAnonymousUser: trackAnonymousUser,
             trackBackgroundEvents: trackBackgroundEvents,
@@ -126,6 +120,44 @@ extension RemoteConfiguration.RUM: AnyMockable, RandomMockable {
             trackWatchdogTerminations: trackWatchdogTerminations,
             vitalsUpdateFrequency: vitalsUpdateFrequency
         )
+    }
+}
+
+extension RemoteConfiguration.RUM.AppHang: AnyMockable, RandomMockable {
+    public static func mockAny() -> RemoteConfiguration.RUM.AppHang {
+        mockWith()
+    }
+
+    /// `enabled` is fixed to `true` so callers exercising every field (e.g. exhaustiveness checks) can
+    /// rely on `threshold` always taking effect; use `mockWith(enabled:)` to test `enabled == false`.
+    public static func mockRandom() -> RemoteConfiguration.RUM.AppHang {
+        .init(enabled: true, threshold: .mockRandom(min: 100, max: 5_000))
+    }
+
+    public static func mockWith(
+        enabled: Bool? = nil,
+        threshold: Double? = nil
+    ) -> RemoteConfiguration.RUM.AppHang {
+        .init(enabled: enabled, threshold: threshold)
+    }
+}
+
+extension RemoteConfiguration.RUM.LongTask: AnyMockable, RandomMockable {
+    public static func mockAny() -> RemoteConfiguration.RUM.LongTask {
+        mockWith()
+    }
+
+    /// `enabled` is fixed to `true` so callers exercising every field (e.g. exhaustiveness checks) can
+    /// rely on `threshold` always taking effect; use `mockWith(enabled:)` to test `enabled == false`.
+    public static func mockRandom() -> RemoteConfiguration.RUM.LongTask {
+        .init(enabled: true, threshold: .mockRandom(min: 100, max: 5_000))
+    }
+
+    public static func mockWith(
+        enabled: Bool? = nil,
+        threshold: Double? = nil
+    ) -> RemoteConfiguration.RUM.LongTask {
+        .init(enabled: enabled, threshold: threshold)
     }
 }
 
@@ -148,22 +180,19 @@ extension RemoteConfiguration.Trace: AnyMockable, RandomMockable {
         .init(
             sampleRate: .mockRandom(min: 0, max: 100),
             traceContextInjection: .mockRandom(),
-            tracedHosts: ["api.example.com", "example.com"],
-            tracingHeaderTypes: [.mockRandom()]
+            tracedHosts: [.mockRandom(), .mockRandom()]
         )
     }
 
     public static func mockWith(
         sampleRate: Double? = nil,
         traceContextInjection: RemoteConfiguration.Trace.TraceContextInjection? = nil,
-        tracedHosts: [String]? = nil,
-        tracingHeaderTypes: [RemoteConfiguration.Trace.TracingHeaderTypes]? = nil
+        tracedHosts: [RemoteConfiguration.Trace.TracedHosts]? = nil
     ) -> RemoteConfiguration.Trace {
         .init(
             sampleRate: sampleRate,
             traceContextInjection: traceContextInjection,
-            tracedHosts: tracedHosts,
-            tracingHeaderTypes: tracingHeaderTypes
+            tracedHosts: tracedHosts
         )
     }
 }
@@ -174,8 +203,18 @@ extension RemoteConfiguration.Trace.TraceContextInjection: RandomMockable {
     }
 }
 
-extension RemoteConfiguration.Trace.TracingHeaderTypes: RandomMockable {
-    public static func mockRandom() -> RemoteConfiguration.Trace.TracingHeaderTypes {
+extension RemoteConfiguration.Trace.TracedHosts: AnyMockable, RandomMockable {
+    public static func mockAny() -> RemoteConfiguration.Trace.TracedHosts {
+        .init(host: .mockAny(), propagatorTypes: [.mockRandom()])
+    }
+
+    public static func mockRandom() -> RemoteConfiguration.Trace.TracedHosts {
+        .init(host: .mockRandom(), propagatorTypes: [.mockRandom()])
+    }
+}
+
+extension RemoteConfiguration.Trace.TracedHosts.PropagatorTypes: RandomMockable {
+    public static func mockRandom() -> RemoteConfiguration.Trace.TracedHosts.PropagatorTypes {
         [.datadog, .b3, .b3multi, .tracecontext].randomElement()!
     }
 }
@@ -193,7 +232,6 @@ extension RemoteConfiguration.SessionReplay: AnyMockable, RandomMockable {
         .init(
             imagePrivacy: .mockRandom(),
             sampleRate: .mockRandom(min: 0, max: 100),
-            startRecordingImmediately: .mockRandom(),
             textAndInputPrivacy: .mockRandom(),
             touchPrivacy: .mockRandom()
         )
@@ -202,14 +240,12 @@ extension RemoteConfiguration.SessionReplay: AnyMockable, RandomMockable {
     public static func mockWith(
         imagePrivacy: RemoteConfiguration.SessionReplay.ImagePrivacy? = nil,
         sampleRate: Double? = nil,
-        startRecordingImmediately: Bool? = nil,
         textAndInputPrivacy: RemoteConfiguration.SessionReplay.TextAndInputPrivacy? = nil,
         touchPrivacy: RemoteConfiguration.SessionReplay.TouchPrivacy? = nil
     ) -> RemoteConfiguration.SessionReplay {
         .init(
             imagePrivacy: imagePrivacy,
             sampleRate: sampleRate,
-            startRecordingImmediately: startRecordingImmediately,
             textAndInputPrivacy: textAndInputPrivacy,
             touchPrivacy: touchPrivacy
         )


### PR DESCRIPTION
### What and why?

Remote Configuration's schema changed for three namespaces consumed by RUM and Session Replay: `RUM.appHang`/`RUM.longTask`, `Trace.tracedHosts`, and `SessionReplay`. This PR updates the SDK to consume the new shapes.

### How?

Regenerated `RCDataModels.swift` from the updated RC schema and adjusted the three modules that consume it.

`RUM.appHang` and `RUM.longTask` replace the flat `appHangThresholdMs`/`longTaskThresholdMs` fields with `{enabled, threshold}` objects (the `RUM` namespace also dropped the unused `env`/`service` fields). The threshold override now checks `enabled` first, falls back to `threshold` when present, and otherwise leaves the in-code value alone.

`Trace.tracedHosts` is now `[TracedHosts]`, an array of `host` + `propagatorTypes` pairs, replacing the old flat `[String]` host list plus a separate `tracingHeaderTypes` field. `overriding(with:)` on `URLSessionTracking` was rewritten as three guard branches, no hosts, empty hosts, non-empty hosts, instead of a switch, and `FirstPartyHostsTracing` now builds straight from the `[TracedHosts]` array, mapping each host's own `propagatorTypes` onto its header formats.

`SessionReplay.startRecordingImmediately` was dropped from the remote schema entirely, so the merge no longer touches it.

Updated `RemoteConfigurationMocks` and the dependent tests in `DatadogRUM` and `DatadogSessionReplay` to match.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs