### PR TITLE
fix: skip platform download if already installed in AMI

### DIFF
--- a/tools/runner-setup.sh
+++ b/tools/runner-setup.sh
@@ -100,14 +100,22 @@ fi
 
 if [ "$visionOS" = "true" ]; then
     echo_subtitle "Install visionOS platform"
-    echo "▸ xcodebuild -downloadPlatform visionOS -quiet"
-    xcodebuild -downloadPlatform visionOS -quiet
+    if xcrun simctl runtime list 2>/dev/null | grep -q "^xrOS\|^visionOS"; then
+        echo_succ "visionOS platform already installed, skipping download"
+    else
+        echo "▸ xcodebuild -downloadPlatform visionOS -quiet"
+        xcodebuild -downloadPlatform visionOS -quiet
+    fi
 fi
 
 if [ "$watchOS" = "true" ]; then
     echo_subtitle "Install watchOS platform"
-    echo "▸ xcodebuild -downloadPlatform watchOS -quiet"
-    xcodebuild -downloadPlatform watchOS -quiet
+    if xcrun simctl runtime list 2>/dev/null | grep -q "^watchOS"; then
+        echo_succ "watchOS platform already installed, skipping download"
+    else
+        echo "▸ xcodebuild -downloadPlatform watchOS -quiet"
+        xcodebuild -downloadPlatform watchOS -quiet
+    fi
 fi
 
 if [ "$ssh" = "true" ]; then

--- a/tools/runner-setup.sh
+++ b/tools/runner-setup.sh
@@ -80,8 +80,8 @@ xcodebuild -version
 
 if [ "$iOS" = "true" ]; then
     echo_subtitle "Install iOS platform"
-    if xcrun simctl runtime list 2>/dev/null | grep -q "^iOS"; then
-        echo_succ "iOS platform already installed, skipping download"
+    if xcodebuild -showsdks 2>/dev/null | grep -q "iphoneos"; then
+        echo_succ "iOS platform SDK already available, skipping download"
     else
         echo "▸ xcodebuild -downloadPlatform iOS -quiet"
         xcodebuild -downloadPlatform iOS -quiet
@@ -90,8 +90,8 @@ fi
 
 if [ "$tvOS" = "true" ]; then
     echo_subtitle "Install tvOS platform"
-    if xcrun simctl runtime list 2>/dev/null | grep -q "^tvOS"; then
-        echo_succ "tvOS platform already installed, skipping download"
+    if xcodebuild -showsdks 2>/dev/null | grep -q "appletvos"; then
+        echo_succ "tvOS platform SDK already available, skipping download"
     else
         echo "▸ xcodebuild -downloadPlatform tvOS -quiet"
         xcodebuild -downloadPlatform tvOS -quiet
@@ -100,8 +100,8 @@ fi
 
 if [ "$visionOS" = "true" ]; then
     echo_subtitle "Install visionOS platform"
-    if xcrun simctl runtime list 2>/dev/null | grep -q "^xrOS\|^visionOS"; then
-        echo_succ "visionOS platform already installed, skipping download"
+    if xcodebuild -showsdks 2>/dev/null | grep -q "xros"; then
+        echo_succ "visionOS platform SDK already available, skipping download"
     else
         echo "▸ xcodebuild -downloadPlatform visionOS -quiet"
         xcodebuild -downloadPlatform visionOS -quiet
@@ -110,8 +110,8 @@ fi
 
 if [ "$watchOS" = "true" ]; then
     echo_subtitle "Install watchOS platform"
-    if xcrun simctl runtime list 2>/dev/null | grep -q "^watchOS"; then
-        echo_succ "watchOS platform already installed, skipping download"
+    if xcodebuild -showsdks 2>/dev/null | grep -q "watchos"; then
+        echo_succ "watchOS platform SDK already available, skipping download"
     else
         echo "▸ xcodebuild -downloadPlatform watchOS -quiet"
         xcodebuild -downloadPlatform watchOS -quiet

--- a/tools/runner-setup.sh
+++ b/tools/runner-setup.sh
@@ -80,14 +80,22 @@ xcodebuild -version
 
 if [ "$iOS" = "true" ]; then
     echo_subtitle "Install iOS platform"
-    echo "▸ xcodebuild -downloadPlatform iOS -quiet"
-    xcodebuild -downloadPlatform iOS -quiet
+    if xcrun simctl runtime list 2>/dev/null | grep -q "^iOS"; then
+        echo_succ "iOS platform already installed, skipping download"
+    else
+        echo "▸ xcodebuild -downloadPlatform iOS -quiet"
+        xcodebuild -downloadPlatform iOS -quiet
+    fi
 fi
 
 if [ "$tvOS" = "true" ]; then
     echo_subtitle "Install tvOS platform"
-    echo "▸ xcodebuild -downloadPlatform tvOS -quiet"
-    xcodebuild -downloadPlatform tvOS -quiet
+    if xcrun simctl runtime list 2>/dev/null | grep -q "^tvOS"; then
+        echo_succ "tvOS platform already installed, skipping download"
+    else
+        echo "▸ xcodebuild -downloadPlatform tvOS -quiet"
+        xcodebuild -downloadPlatform tvOS -quiet
+    fi
 fi
 
 if [ "$visionOS" = "true" ]; then


### PR DESCRIPTION
## Problem

`xcodebuild -downloadPlatform iOS -quiet` hits Apple CDN even when the platform is already installed, causing `Unable to connect to simulator` on fresh runner instances after AMI updates.

The Sequoia runner AMI has iOS/tvOS runtimes baked in via S3 — `xcrun simctl runtime list` shows them as Ready. No download needed.

## Fix

Check `xcrun simctl runtime list` before calling `xcodebuild -downloadPlatform`. Skip if runtimes are already present. Applied for both `--iOS` and `--tvOS` flags.