### PR TITLE
Fix NetworkInstrumentationFeatureTests crashes.

### DIFF
--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -65,6 +65,22 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     /// process-global, so foreign URLSession activity in the test process would otherwise reach
     /// the handler.
     private func scopeHandler(to server: ServerMock) {
+        // When Swift access a member of a value stored as a weak reference (like `server?.isMyRequest(req)`
+        // below), that call is wrapped by a scope that does the equivalent of temporarily holding it by a
+        // strong reference, effectively extending its lifetime.
+        //
+        // The purpose of such mechanism is to prevent the situation where, if this code is running on a
+        // specific thread, and code running on a different thread drops the last strong reference to the
+        // object, the object does not get deallocated while being accessed by the original thread.
+        //
+        // When that happens, the object will be held only by the temporary reference, and as soon as the
+        // call is over, its reference count will be decreased and the object will be released on the
+        // specific thread that was temporarily holding it.
+        //
+        // This happens occasionally in these tests, causing a precondition failure and therefore a crash.
+        // To avoid this, the server mocks need to be created with `skipIsMainThreadCheck` set to true to
+        // bypass this check.
+        XCTAssert(server.skipIsMainThreadCheck, "ServerMocks passed to this method must be created with skipIsMainThreadCheck set to `true`.")
         handler.shouldInterceptRequest = { [weak server] req in server?.isMyRequest(req) ?? false }
     }
 
@@ -110,7 +126,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let notifyRequestMutation = expectation(description: "Notify request mutation")
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
         let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
-        let server = ServerMock(delivery: .success(response: .mockWith(statusCode: 200, mimeType: "application/json"), data: .mock(ofSize: 10)))
+        let server = ServerMock(delivery: .success(response: .mockWith(statusCode: 200, mimeType: "application/json"), data: .mock(ofSize: 10)), skipIsMainThreadCheck: true)
 
         handler.onRequestMutation = { _, _, _ in notifyRequestMutation.fulfill() }
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
@@ -1637,7 +1653,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
 
         let randomData: Data = .mockRandom()
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: randomData))
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: randomData), skipIsMainThreadCheck: true)
 
         handler.onInterceptionDidStart = { _ in notifyInterceptionDidStart.fulfill() }
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
@@ -2079,7 +2095,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     func testAutomaticMode_detectsFirstPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)), skipIsMainThreadCheck: true)
         scopeHandler(to: server)
 
         // Given - Configure first-party hosts
@@ -2110,7 +2126,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     func testAutomaticMode_injectsTraceHeadersForFirstPartyHosts() throws {
         let notifyRequestMutation = expectation(description: "Notify request mutation")
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)), skipIsMainThreadCheck: true)
         scopeHandler(to: server)
 
         // Given - Configure first-party hosts
@@ -2145,7 +2161,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     func testAutomaticMode_doesNotInjectHeadersForThirdPartyHosts() throws {
         let notifyInterceptionDidStart = expectation(description: "Notify interception did start")
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)), skipIsMainThreadCheck: true)
         scopeHandler(to: server)
 
         // Given - Configure first-party hosts that don't match the request URL

--- a/TestUtilities/Sources/Proxies/ServerMock.swift
+++ b/TestUtilities/Sources/Proxies/ServerMock.swift
@@ -169,7 +169,7 @@ public class ServerMock {
     /// An unique identifier of the `URLSession` produced by this instance of `ServerMock`.
     public let urlSessionUUID = UUID()
     private let queue: DispatchQueue
-    private let skipIsMainThreadCheck: Bool
+    public let skipIsMainThreadCheck: Bool
 
     #if os(watchOS)
     /// Swizzler that intercepts `__NSCFLocalSessionTask._onqueue_resume` to deliver mocked


### PR DESCRIPTION
### What and why?

Occasionally we see crashes like this in the test runs: Test Case '-[DatadogInternalTests.NetworkInstrumentationFeatureTests testAutomaticMode_injectsTraceHeadersForFirstPartyHosts]' started. TestUtilities/ServerMock.swift:225: Precondition failed: `ServerMock` should be deinitialized on the main thread.

This is caused by ServerMock being deallocated on a non-main thread. This is expected behavior, per the comment added to the code in this commit. This patch disables the check for the main thread in all the tests, and adds a check to make sure future tests written in this class that use ServerMock and scopeHandler do it as well.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
