### PR TITLE
fix: RUM Session inflation on prewarmed iOS apps

### DIFF
--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
@@ -126,7 +126,19 @@ internal class AppRunner {
         appStateObservers.forEach { notificationCenter.removeObserver($0) }
         appStateObservers = []
 
-        DeleteTemporaryDirectory()
+        if let core {
+            do {
+                try core.flushAndTearDown()
+            } catch {
+                XCTFail("Failed to tear down AppRunner core: \(error)")
+            }
+        }
+        core = nil
+
+        #if !os(watchOS)
+        frameInfoProvider = nil
+        lastAppearedViewController = nil
+        #endif
 
         appDirectory = nil
         processInfo = nil
@@ -134,7 +146,8 @@ internal class AppRunner {
         dateProvider = nil
         appStateProvider = nil
         appLaunchHandler = nil
-        core = nil
+
+        DeleteTemporaryDirectory()
     }
 
     // swiftlint:disable implicitly_unwrapped_optional

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionTimeOutTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionTimeOutTests.swift
@@ -828,6 +828,40 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
         #endif
     }
 
+    func testGivenPrewarmedSession_whenItTimesOutSilently_andViewIsTrackedInForeground() throws {
+        #if os(tvOS) || os(watchOS)
+        throw XCTSkip("This test is not available on tvOS nor watchOS")
+        #else
+        // Given
+        // - The SDK is initialized while the prewarmed app is in background, with no RUM events tracked.
+        let given = prewarmedSession()
+
+        // When
+        // - The initial session times out silently before the app enters foreground and tracks its first view.
+        let when = given
+            .when(.timeoutSession())
+            .and(.appBecomesActive(after: dt1))
+            .and(.startManualView(after: dt2, viewName: manualViewName))
+            .and(.stopManualView(after: dt3))
+
+        // Then
+        // - The empty prewarm session is skipped and the view belongs to a new session starting at the event time.
+        let session = try when.then().takeSingle()
+        XCTAssertNil(session.ttidEvent)
+        XCTAssertNil(session.timeToInitialDisplay)
+        DDAssertEqual(
+            session.sessionStartDate,
+            processLaunchDate + timeToSDKInit + sessionTimeoutDuration + dt1 + dt2,
+            accuracy: accuracy
+        )
+        DDAssertEqual(session.duration, dt3, accuracy: accuracy)
+        XCTAssertEqual(session.sessionPrecondition, .inactivityTimeout)
+        XCTAssertEqual(session.views.count, 1)
+        XCTAssertEqual(session.views[0].name, manualViewName)
+        DDAssertEqual(session.views[0].duration, dt3, accuracy: accuracy)
+        #endif
+    }
+
     func testGivenBackgroundSession_andBETEnabled_whenItTimesOut_andNextEventIsTrackedInForeground() throws {
         #if os(tvOS) || os(watchOS)
         throw XCTSkip("This test is not available on tvOS nor watchOS")

--- a/Datadog/IntegrationUnitTests/RUM/RUMSessionTimeOutTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/RUMSessionTimeOutTests.swift
@@ -793,36 +793,77 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
             .and(.trackResource(after: dt1, duration: dt2))
 
         for given in [given1, given2] {
-            // When
-            let when1 = given
+            // When - the session times out before the app enters foreground.
+            let afterTimeout = given
                 .when(.timeoutSession())
                 .and(.appBecomesActive(after: dt3))
-            let when2 = given
+
+            let afterTimeoutWithActions = afterTimeout.and(.trackTwoActions(after1: dt4, after2: dt5))
+            let afterTimeoutWithResource = afterTimeout.and(.trackResource(after: dt4, duration: dt5))
+            let afterTimeoutWithLongTasks = afterTimeout.and(.trackTwoLongTasks(after1: dt4, after2: dt5))
+
+            for when in [afterTimeoutWithActions, afterTimeoutWithResource, afterTimeoutWithLongTasks] {
+                // Then - the empty background session is skipped. The foreground transition starts the
+                // inactivity session and its ApplicationLaunch view before the next event.
+                let session = try when.then().takeSingle()
+                XCTAssertNil(session.ttidEvent)
+                XCTAssertNil(session.timeToInitialDisplay)
+                DDAssertEqual(
+                    session.sessionStartDate,
+                    processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3,
+                    accuracy: accuracy
+                )
+                DDAssertEqual(session.duration, dt4 + dt5, accuracy: accuracy)
+                XCTAssertEqual(session.sessionPrecondition, .inactivityTimeout)
+                XCTAssertEqual(session.views.count, 1)
+                XCTAssertEqual(session.views[0].name, applicationLaunchViewName)
+                DDAssertEqual(session.views[0].duration, dt4 + dt5, accuracy: accuracy)
+                XCTAssertEqual(session.views[0].actionEvents.count, when == afterTimeoutWithActions ? 2 : 0)
+                XCTAssertEqual(session.views[0].resourceEvents.count, when == afterTimeoutWithResource ? 1 : 0)
+                XCTAssertEqual(session.views[0].longTaskEvents.count, when == afterTimeoutWithLongTasks ? 2 : 0)
+            }
+
+            // When - the app enters foreground before the initial session times out.
+            let beforeTimeout = given
                 .and(.appBecomesActive(after: dt3))
                 .when(.timeoutSession())
 
-            for when in [when1, when2] {
-                // When
-                let when1 = when.and(.trackTwoActions(after1: dt4, after2: dt5))
-                let when2 = when.and(.trackResource(after: dt4, duration: dt5))
-                let when3 = when.and(.trackTwoLongTasks(after1: dt4, after2: dt5))
+            let beforeTimeoutWithActions = beforeTimeout.and(.trackTwoActions(after1: dt4, after2: dt5))
+            let beforeTimeoutWithResource = beforeTimeout.and(.trackResource(after: dt4, duration: dt5))
+            let beforeTimeoutWithLongTasks = beforeTimeout.and(.trackTwoLongTasks(after1: dt4, after2: dt5))
 
-                for when in [when1, when2, when3] {
-                    // Then
-                    // - It only tracks foreground session ("timed out" session is skipped due to BET disabled):
-                    let session = try when.then().takeSingle()
-                    XCTAssertNil(session.ttidEvent)
-                    XCTAssertNil(session.timeToInitialDisplay)
-                    DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3 + dt4, accuracy: accuracy)
-                    DDAssertEqual(session.duration, dt5, accuracy: accuracy)
-                    XCTAssertEqual(session.sessionPrecondition, .inactivityTimeout)
-                    XCTAssertEqual(session.views.count, 1)
-                    XCTAssertEqual(session.views[0].name, applicationLaunchViewName)
-                    DDAssertEqual(session.views[0].duration, dt5, accuracy: accuracy)
-                    XCTAssertEqual(session.views[0].actionEvents.count, when == when1 ? 2 : 0)
-                    XCTAssertEqual(session.views[0].resourceEvents.count, when == when2 ? 1 : 0)
-                    XCTAssertEqual(session.views[0].longTaskEvents.count, when == when3 ? 2 : 0)
-                }
+            for when in [beforeTimeoutWithActions, beforeTimeoutWithResource, beforeTimeoutWithLongTasks] {
+                // Then - ApplicationLaunch belongs to the initial session. The later event refreshes the
+                // timed-out session and resumes ApplicationLaunch in the new inactivity session.
+                let (session1, session2) = try when.then().takeTwo()
+                XCTAssertNil(session1.ttidEvent)
+                XCTAssertNil(session1.timeToInitialDisplay)
+                DDAssertEqual(
+                    session1.sessionStartDate,
+                    processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3,
+                    accuracy: accuracy
+                )
+                DDAssertEqual(session1.duration, 0, accuracy: accuracy)
+                XCTAssertEqual(session1.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
+                XCTAssertEqual(session1.views.count, 1)
+                XCTAssertEqual(session1.views[0].name, applicationLaunchViewName)
+                DDAssertEqual(session1.views[0].duration, 0, accuracy: accuracy)
+
+                XCTAssertNil(session2.ttidEvent)
+                XCTAssertNil(session2.timeToInitialDisplay)
+                DDAssertEqual(
+                    session2.sessionStartDate,
+                    processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3 + sessionTimeoutDuration + dt4,
+                    accuracy: accuracy
+                )
+                DDAssertEqual(session2.duration, dt5, accuracy: accuracy)
+                XCTAssertEqual(session2.sessionPrecondition, .inactivityTimeout)
+                XCTAssertEqual(session2.views.count, 1)
+                XCTAssertEqual(session2.views[0].name, applicationLaunchViewName)
+                DDAssertEqual(session2.views[0].duration, dt5, accuracy: accuracy)
+                XCTAssertEqual(session2.views[0].actionEvents.count, when == beforeTimeoutWithActions ? 2 : 0)
+                XCTAssertEqual(session2.views[0].resourceEvents.count, when == beforeTimeoutWithResource ? 1 : 0)
+                XCTAssertEqual(session2.views[0].longTaskEvents.count, when == beforeTimeoutWithLongTasks ? 2 : 0)
             }
         }
         #endif
@@ -845,20 +886,23 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
             .and(.stopManualView(after: dt3))
 
         // Then
-        // - The empty prewarm session is skipped and the view belongs to a new session starting at the event time.
+        // - The empty prewarm session is skipped and the foreground transition creates a new session with
+        //   ApplicationLaunch before the manually tracked view.
         let session = try when.then().takeSingle()
         XCTAssertNil(session.ttidEvent)
         XCTAssertNil(session.timeToInitialDisplay)
         DDAssertEqual(
             session.sessionStartDate,
-            processLaunchDate + timeToSDKInit + sessionTimeoutDuration + dt1 + dt2,
+            processLaunchDate + timeToSDKInit + sessionTimeoutDuration + dt1,
             accuracy: accuracy
         )
-        DDAssertEqual(session.duration, dt3, accuracy: accuracy)
+        DDAssertEqual(session.duration, dt2 + dt3, accuracy: accuracy)
         XCTAssertEqual(session.sessionPrecondition, .inactivityTimeout)
-        XCTAssertEqual(session.views.count, 1)
-        XCTAssertEqual(session.views[0].name, manualViewName)
-        DDAssertEqual(session.views[0].duration, dt3, accuracy: accuracy)
+        XCTAssertEqual(session.views.count, 2)
+        XCTAssertEqual(session.views[0].name, applicationLaunchViewName)
+        DDAssertEqual(session.views[0].duration, dt2, accuracy: accuracy)
+        XCTAssertEqual(session.views[1].name, manualViewName)
+        DDAssertEqual(session.views[1].duration, dt3, accuracy: accuracy)
         #endif
     }
 
@@ -917,36 +961,79 @@ class RUMSessionTimeOutTests: RUMSessionTestsBase {
             .and(.trackResource(after: dt1, duration: dt2))
 
         for given in [given1, given2] {
-            // When
-            let when1 = given
+            // When - the session times out before the app enters foreground.
+            let afterTimeout = given
                 .when(.timeoutSession())
                 .and(.appBecomesActive(after: dt3))
-            let when2 = given
+
+            let afterTimeoutWithAutomaticView = afterTimeout
+                .and(.startAutomaticView(after: dt4, viewController: automaticView))
+                .and(.stopAutomaticView(after: dt5, viewController: automaticView))
+            let afterTimeoutWithManualView = afterTimeout
+                .and(.startManualView(after: dt4, viewName: manualViewName, viewKey: "manual-view"))
+                .and(.stopManualView(after: dt5, viewKey: "manual-view"))
+
+            for when in [afterTimeoutWithAutomaticView, afterTimeoutWithManualView] {
+                // Then - the empty background session is skipped. The foreground transition starts the
+                // inactivity session with ApplicationLaunch before the requested view.
+                let session = try when.then().takeSingle()
+                XCTAssertNil(session.ttidEvent)
+                XCTAssertNil(session.timeToInitialDisplay)
+                DDAssertEqual(
+                    session.sessionStartDate,
+                    processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3,
+                    accuracy: accuracy
+                )
+                DDAssertEqual(session.duration, dt4 + dt5, accuracy: accuracy)
+                XCTAssertEqual(session.sessionPrecondition, .inactivityTimeout)
+                XCTAssertEqual(session.views.count, 2)
+                XCTAssertEqual(session.views[0].name, applicationLaunchViewName)
+                DDAssertEqual(session.views[0].duration, dt4, accuracy: accuracy)
+                XCTAssertEqual(session.views[1].name, when == afterTimeoutWithAutomaticView ? automaticViewName : manualViewName)
+                DDAssertEqual(session.views[1].duration, dt5, accuracy: accuracy)
+            }
+
+            // When - the app enters foreground before the initial session times out.
+            let beforeTimeout = given
                 .and(.appBecomesActive(after: dt3))
                 .when(.timeoutSession())
 
-            for when in [when1, when2] {
-                // When
-                let when1 = when
-                    .and(.startAutomaticView(after: dt4, viewController: automaticView))
-                    .and(.stopAutomaticView(after: dt5, viewController: automaticView))
-                let when2 = when
-                    .and(.startManualView(after: dt4, viewName: manualViewName, viewKey: "manual-view"))
-                    .and(.stopManualView(after: dt5, viewKey: "manual-view"))
+            let beforeTimeoutWithAutomaticView = beforeTimeout
+                .and(.startAutomaticView(after: dt4, viewController: automaticView))
+                .and(.stopAutomaticView(after: dt5, viewController: automaticView))
+            let beforeTimeoutWithManualView = beforeTimeout
+                .and(.startManualView(after: dt4, viewName: manualViewName, viewKey: "manual-view"))
+                .and(.stopManualView(after: dt5, viewKey: "manual-view"))
 
-                for when in [when1, when2] {
-                    // Then
-                    // - It only tracks foreground session ("timed out" background session is skipped due to BET disabled):
-                    let session = try when.then().takeSingle()
-                    XCTAssertNil(session.ttidEvent)
-                    XCTAssertNil(session.timeToInitialDisplay)
-                    DDAssertEqual(session.sessionStartDate, processLaunchDate + timeToSDKInit + dt1 + dt2 + sessionTimeoutDuration + dt3 + dt4, accuracy: accuracy)
-                    DDAssertEqual(session.duration, dt5, accuracy: accuracy)
-                    XCTAssertEqual(session.sessionPrecondition, .inactivityTimeout)
-                    XCTAssertEqual(session.views.count, 1)
-                    XCTAssertEqual(session.views[0].name, when == when1 ? automaticViewName : manualViewName)
-                    DDAssertEqual(session.views[0].duration, dt5, accuracy: accuracy)
-                }
+            for when in [beforeTimeoutWithAutomaticView, beforeTimeoutWithManualView] {
+                // Then - ApplicationLaunch belongs to the initial session, while the requested view belongs
+                // to the new inactivity session created after the timeout.
+                let (session1, session2) = try when.then().takeTwo()
+                XCTAssertNil(session1.ttidEvent)
+                XCTAssertNil(session1.timeToInitialDisplay)
+                DDAssertEqual(
+                    session1.sessionStartDate,
+                    processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3,
+                    accuracy: accuracy
+                )
+                DDAssertEqual(session1.duration, 0, accuracy: accuracy)
+                XCTAssertEqual(session1.sessionPrecondition, given == given1 ? .backgroundLaunch : .prewarm)
+                XCTAssertEqual(session1.views.count, 1)
+                XCTAssertEqual(session1.views[0].name, applicationLaunchViewName)
+                DDAssertEqual(session1.views[0].duration, 0, accuracy: accuracy)
+
+                XCTAssertNil(session2.ttidEvent)
+                XCTAssertNil(session2.timeToInitialDisplay)
+                DDAssertEqual(
+                    session2.sessionStartDate,
+                    processLaunchDate + timeToSDKInit + dt1 + dt2 + dt3 + sessionTimeoutDuration + dt4,
+                    accuracy: accuracy
+                )
+                DDAssertEqual(session2.duration, dt5, accuracy: accuracy)
+                XCTAssertEqual(session2.sessionPrecondition, .inactivityTimeout)
+                XCTAssertEqual(session2.views.count, 1)
+                XCTAssertEqual(session2.views[0].name, when == beforeTimeoutWithAutomaticView ? automaticViewName : manualViewName)
+                DDAssertEqual(session2.views[0].duration, dt5, accuracy: accuracy)
             }
         }
         #endif

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -13,8 +13,8 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
     // MARK: - Child Scopes
 
-    // Whether the application is already active. Set to true
-    // when the first session starts.
+    // Whether application-launch handling has completed. While false, deferred prewarm and background launches
+    // keep retrying the ApplicationLaunch view when new commands arrive.
     private(set) var applicationActive = false
 
     /// Session scope. It gets created with the first event.
@@ -130,7 +130,6 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             // This flow is likely stale code as`RUMSDKInitCommand` should already start the session before reaching this point
             dependencies.telemetry.debug("Starting initial session from lazy flow")
             createInitialSession(with: context, on: command)
-            applicationActive = true
         }
 
         // Create the application launch view on any command
@@ -194,6 +193,12 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
                 return nil
             }
         })
+
+        // Once any non-launch view has been tracked, ApplicationLaunch must not be started by a later foreground retry.
+        // This preserves background-view sessions while keeping empty prewarm/background sessions eligible for deferral.
+        if applicationState.numberOfNonApplicationLaunchViewsCreated > 0 {
+            applicationActive = true
+        }
 
         // Sanity telemetry, only end up with one active session
         let activeSessions = sessionScopes.filter { $0.isActive }
@@ -343,14 +348,13 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     /// Forces the `ApplicationLaunchView` to be started.
     /// Added as part of https://github.com/DataDog/dd-sdk-ios/pull/1290 to separate creation of first view
     /// from creation of initial session due to receiving `RUMSDKInitCommand`. Starting from RUM-1649 the "application launch" view
-    /// is started on SDK init only when the app is launched by user with no prewarming or when app was prewarmed but SDK was initialized
-    /// after it became active.
+    /// is started immediately for a user launch, or deferred until the app enters foreground for prewarm and background launches.
     private func startApplicationLaunchView(on command: RUMCommand, context: DatadogContext, writer: Writer) {
         let isUserLaunch = context.launchInfo.launchReason == .userLaunch
         let isPrewarmed = context.launchInfo.launchReason == .prewarming
         let isBackgroundLaunch = context.launchInfo.launchReason == .backgroundLaunch
-        let isStartedInForeground = command is RUMSDKInitCommand && context.applicationStateHistory.currentState != .background
-        guard isUserLaunch || (isPrewarmed && isStartedInForeground) || (isBackgroundLaunch && isStartedInForeground) else {
+        let isInForeground = context.applicationStateHistory.currentState != .background
+        guard isUserLaunch || (isPrewarmed && isInForeground) || (isBackgroundLaunch && isInForeground) else {
             // applicationActive stays false so _process retries on the next command (prewarm/background launch deferral)
             return
         }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -126,10 +126,11 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         // If the application has not been yet activated and no sessions exist -> create the initial session
         // Added in https://github.com/DataDog/dd-sdk-ios/pull/1219 to start new session automatically when
         // a user action is sent (startView or addUserAction).
-        if sessionScopes.isEmpty && !applicationActive {
+        if sessionScopes.isEmpty && !applicationActive && didCreateInitialSessionCount == 0 {
             // This flow is likely stale code as`RUMSDKInitCommand` should already start the session before reaching this point
             dependencies.telemetry.debug("Starting initial session from lazy flow")
             createInitialSession(with: context, on: command)
+            applicationActive = true
         }
 
         // Create the application launch view on any command
@@ -251,6 +252,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
     /// Starts new RUM Session immediately after previous one expires or time outs. It transfers some of the state from the expired session to the new one.
     private func refresh(expiredSession: RUMSessionScope, on command: RUMCommand, context: DatadogContext, writer: Writer) -> RUMSessionScope {
+        applicationActive = true
         var startPrecondition: RUMSessionPrecondition? = nil
 
         // If the app is in background, use the background-aware precondition; otherwise fall through to the end-reason logic.
@@ -287,6 +289,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     }
 
     private func startNewSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
+        applicationActive = true
         var startPrecondition: RUMSessionPrecondition? = nil
 
         // If the app is in background, use the background-aware precondition; otherwise fall through to the end-reason logic.
@@ -343,15 +346,16 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     /// is started on SDK init only when the app is launched by user with no prewarming or when app was prewarmed but SDK was initialized
     /// after it became active.
     private func startApplicationLaunchView(on command: RUMCommand, context: DatadogContext, writer: Writer) {
-        applicationActive = true
-
         let isUserLaunch = context.launchInfo.launchReason == .userLaunch
         let isPrewarmed = context.launchInfo.launchReason == .prewarming
         let isBackgroundLaunch = context.launchInfo.launchReason == .backgroundLaunch
         let isStartedInForeground = command is RUMSDKInitCommand && context.applicationStateHistory.currentState != .background
         guard isUserLaunch || (isPrewarmed && isStartedInForeground) || (isBackgroundLaunch && isStartedInForeground) else {
+            // applicationActive stays false so _process retries on the next command (prewarm/background launch deferral)
             return
         }
+
+        applicationActive = true
 
         // Immediately start the ApplicationLaunchView for the new session
         _ = process(

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -413,7 +413,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     }
 
     private func startApplicationLaunchView(on command: RUMCommand, context: DatadogContext, writer: Writer) {
-        let isActivePrewarm = context.launchInfo.launchReason == .prewarming
+        let isDeferredLaunch = context.launchInfo.launchReason == .prewarming
+            || context.launchInfo.launchReason == .backgroundLaunch
         let startTime: Date
 
         if command is RUMApplicationStartCommand {
@@ -423,12 +424,12 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 // with lazy initialization from already presented view, or if the SDK
                 // was stopped and later re-initialized during runtime.
                 startTime = sessionStartTime
+            } else if isDeferredLaunch {
+                // Prewarm and background launches can initialize RUM while the app is backgrounded. When the
+                // ApplicationLaunch view is started later, its duration must begin at the foreground transition.
+                startTime = command.time
             } else {
-                // For prewarmed apps, use session start time; otherwise, use launch time.
-                //
-                // RUM-8372: In practice, `isActivePrewarm == true` is never reached here because
-                // prewarmed apps start in the BACKGROUND state, and the ApplicationLaunch view is never created in that case.
-                startTime = isActivePrewarm ? sessionStartTime : context.launchInfo.processLaunchDate
+                startTime = context.launchInfo.processLaunchDate
             }
         } else {
             // Lazily starting the ApplicationLaunch view to capture events that would

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -697,6 +697,201 @@ class RUMApplicationScopeTests: XCTestCase {
         XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .prewarm)
     }
 
+    // MARK: - RUMS-6062: Prewarmed App Session Inflation Fix
+
+    func testGivenPrewarmedApp_whenStartViewArrivesBeforeTimeout_itLandsInSessionA() throws {
+        // Given - prewarmed app, SDK initialises in background
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let prewarmContext: DatadogContext = .mockWith(
+            sdkInitDate: currentTime,
+            launchInfo: .mockWith(
+                launchReason: .prewarming,
+                processLaunchDate: currentTime
+            ),
+            applicationStateHistory: .mockWith(initialState: .background, date: currentTime)
+        )
+
+        let scope = RUMApplicationScope(dependencies: .mockWith(samplingRate: 100))
+
+        // SDK init command (app in background — guard fires, applicationActive stays false)
+        let initCommand = RUMSDKInitCommand(time: currentTime, globalAttributes: [:])
+        _ = scope.process(command: initCommand, context: prewarmContext, writer: writer)
+
+        let sessionA = try XCTUnwrap(scope.activeSession)
+        XCTAssertEqual(sessionA.context.sessionPrecondition, .prewarm)
+        XCTAssertFalse(scope.applicationActive, "applicationActive must stay false for prewarmed apps")
+
+        // Lifecycle event (willEnterForeground) — still before any view
+        currentTime.addTimeInterval(1)
+        let lifecycleCommand = RUMHandleAppLifecycleEventCommand(time: currentTime, event: .willEnterForeground)
+        _ = scope.process(command: lifecycleCommand, context: prewarmContext, writer: writer)
+
+        // JS navigation fires startView — within timeout window
+        currentTime.addTimeInterval(1)
+        _ = scope.process(
+            command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
+            context: prewarmContext,
+            writer: writer
+        )
+
+        // Then - only one session, view belongs to Session A
+        XCTAssertEqual(scope.sessionScopes.count, 1)
+        XCTAssertEqual(scope.activeSession?.sessionUUID, sessionA.sessionUUID, "startView must land in Session A")
+        XCTAssertFalse(scope.sessionScopes[0].viewScopes.isEmpty, "Session A must have at least one view")
+    }
+
+    func testGivenPrewarmedApp_whenStartViewArrivesAfterTimeout_itCreatesSessionBWithInactivityPrecondition() throws {
+        // Given - prewarmed app, SDK initialises in background
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let prewarmContext: DatadogContext = .mockWith(
+            sdkInitDate: currentTime,
+            launchInfo: .mockWith(
+                launchReason: .prewarming,
+                processLaunchDate: currentTime
+            ),
+            applicationStateHistory: .mockWith(initialState: .background, date: currentTime)
+        )
+
+        let featureScope = FeatureScopeMock()
+        let scope = RUMApplicationScope(dependencies: .mockWith(featureScope: featureScope, samplingRate: 100))
+
+        let initCommand = RUMSDKInitCommand(time: currentTime, globalAttributes: [:])
+        _ = scope.process(command: initCommand, context: prewarmContext, writer: writer)
+
+        let sessionA = try XCTUnwrap(scope.activeSession)
+
+        // JS navigation fires startView AFTER the timeout — Session A has expired.
+        // By now the user has opened the app, so it is in the foreground.
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let foregroundContext: DatadogContext = .mockWith(
+            sdkInitDate: prewarmContext.sdkInitDate,
+            launchInfo: prewarmContext.launchInfo,
+            applicationStateHistory: .mockAppInForeground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
+            context: foregroundContext,
+            writer: writer
+        )
+
+        // Then - Session B is created with inactivityTimeout, not a spurious userAppLaunch
+        XCTAssertEqual(scope.sessionScopes.count, 1, "Only Session B should exist")
+        let sessionB = try XCTUnwrap(scope.activeSession)
+        XCTAssertNotEqual(sessionA.sessionUUID, sessionB.sessionUUID)
+        XCTAssertEqual(sessionB.context.sessionPrecondition, .inactivityTimeout)
+        XCTAssertTrue(scope.applicationActive, "applicationActive must be true once a session renewal occurs")
+        XCTAssertNil(featureScope.telemetryMock.messages.firstError(), "No spurious telemetry error must be fired")
+    }
+
+    func testGivenPrewarmedApp_whenSessionExpiresOnLifecycleCommand_startViewCreatesSessionBCorrectly() throws {
+        // Given - prewarmed app, SDK initialises in background
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let prewarmContext: DatadogContext = .mockWith(
+            sdkInitDate: currentTime,
+            launchInfo: .mockWith(
+                launchReason: .prewarming,
+                processLaunchDate: currentTime
+            ),
+            applicationStateHistory: .mockWith(initialState: .background, date: currentTime)
+        )
+
+        let featureScope = FeatureScopeMock()
+        let scope = RUMApplicationScope(dependencies: .mockWith(featureScope: featureScope, samplingRate: 100))
+
+        let initCommand = RUMSDKInitCommand(time: currentTime, globalAttributes: [:])
+        _ = scope.process(command: initCommand, context: prewarmContext, writer: writer)
+
+        // Session A idles past the timeout; lifecycle command expires it but does NOT refresh (lifecycle commands skip refresh)
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let lifecycleCommand = RUMHandleAppLifecycleEventCommand(time: currentTime, event: .willEnterForeground)
+        _ = scope.process(command: lifecycleCommand, context: prewarmContext, writer: writer)
+
+        XCTAssertTrue(scope.sessionScopes.isEmpty, "Session A must have been expired and removed by the lifecycle command")
+
+        // JS navigation fires startView — the app is now in the foreground (user opened it).
+        // Must not trigger spurious telemetry error or wrong precondition.
+        currentTime.addTimeInterval(1)
+        let foregroundContext: DatadogContext = .mockWith(
+            sdkInitDate: prewarmContext.sdkInitDate,
+            launchInfo: prewarmContext.launchInfo,
+            applicationStateHistory: .mockAppInForeground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
+            context: foregroundContext,
+            writer: writer
+        )
+
+        // Then - Session B with inactivityTimeout precondition; no error telemetry
+        XCTAssertEqual(scope.sessionScopes.count, 1)
+        let sessionB = try XCTUnwrap(scope.activeSession)
+        XCTAssertEqual(sessionB.context.sessionPrecondition, .inactivityTimeout)
+        XCTAssertTrue(scope.applicationActive)
+        XCTAssertNil(featureScope.telemetryMock.messages.firstError(), "Secondary fix must prevent spurious 'Creating initial session extra time' error")
+    }
+
+    func testGivenUserLaunchedApp_applicationLaunchViewCreatedImmediately() throws {
+        // Given
+        let currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let sdkContext: DatadogContext = .mockWith(
+            sdkInitDate: currentTime,
+            launchInfo: .mockWith(
+                launchReason: .userLaunch,
+                processLaunchDate: currentTime
+            ),
+            applicationStateHistory: .mockAppInForeground(since: currentTime)
+        )
+
+        // When
+        let scope = createRUMApplicationScope(
+            dependencies: .mockWith(samplingRate: 100),
+            sdkContext: sdkContext
+        )
+
+        // Then - ApplicationLaunch view created immediately and applicationActive is true
+        let session = try XCTUnwrap(scope.activeSession)
+        XCTAssertEqual(session.context.sessionPrecondition, .userAppLaunch)
+        XCTAssertFalse(session.viewScopes.isEmpty, "ApplicationLaunch view must be created immediately for user-launched apps")
+        XCTAssertTrue(scope.applicationActive)
+    }
+
+    func testGivenPrewarmedApp_whenSessionRefreshOccurs_applicationActiveBecomesTrue() throws {
+        // Given - prewarmed app, Session A times out on a non-lifecycle command (refresh path)
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let prewarmContext: DatadogContext = .mockWith(
+            sdkInitDate: currentTime,
+            launchInfo: .mockWith(
+                launchReason: .prewarming,
+                processLaunchDate: currentTime
+            ),
+            applicationStateHistory: .mockWith(initialState: .background, date: currentTime)
+        )
+
+        let scope = RUMApplicationScope(dependencies: .mockWith(samplingRate: 100))
+
+        let initCommand = RUMSDKInitCommand(time: currentTime, globalAttributes: [:])
+        _ = scope.process(command: initCommand, context: prewarmContext, writer: writer)
+        XCTAssertFalse(scope.applicationActive)
+
+        // Non-lifecycle command after timeout — triggers refresh() path.
+        // By now the user has opened the app, so it is in the foreground.
+        currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let foregroundContext: DatadogContext = .mockWith(
+            sdkInitDate: prewarmContext.sdkInitDate,
+            launchInfo: prewarmContext.launchInfo,
+            applicationStateHistory: .mockAppInForeground(since: currentTime)
+        )
+        _ = scope.process(
+            command: RUMAddUserActionCommand.mockWith(time: currentTime),
+            context: foregroundContext,
+            writer: writer
+        )
+
+        // Then - applicationActive is true after refresh; retry loop terminated
+        XCTAssertTrue(scope.applicationActive, "applicationActive must become true after refresh() to stop the startApplicationLaunchView retry")
+        XCTAssertEqual(scope.activeSession?.context.sessionPrecondition, .inactivityTimeout)
+    }
+
     func testGivenUserLaunchedApp_whenSessionTimesOutInBackground_itSetsInactivityTimeoutPrecondition() {
         // Given - app launched by user, session becomes inactive
         var currentTime: Date = .mockDecember15th2019At10AMUTC()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -723,14 +723,28 @@ class RUMApplicationScopeTests: XCTestCase {
 
         // Lifecycle event (willEnterForeground) — still before any view
         currentTime.addTimeInterval(1)
+        let foregroundContext: DatadogContext = .mockWith(
+            sdkInitDate: prewarmContext.sdkInitDate,
+            launchInfo: prewarmContext.launchInfo,
+            applicationStateHistory: .mockWith(
+                initialState: .background,
+                date: prewarmContext.sdkInitDate,
+                transitions: [(state: .inactive, date: currentTime)]
+            )
+        )
         let lifecycleCommand = RUMHandleAppLifecycleEventCommand(time: currentTime, event: .willEnterForeground)
-        _ = scope.process(command: lifecycleCommand, context: prewarmContext, writer: writer)
+        _ = scope.process(command: lifecycleCommand, context: foregroundContext, writer: writer)
+
+        let applicationLaunchView = try XCTUnwrap(scope.activeSession?.viewScopes.first)
+        XCTAssertEqual(applicationLaunchView.viewName, RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName)
+        XCTAssertEqual(applicationLaunchView.viewStartTime, currentTime)
+        XCTAssertTrue(scope.applicationActive)
 
         // JS navigation fires startView — within timeout window
         currentTime.addTimeInterval(1)
         _ = scope.process(
             command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()),
-            context: prewarmContext,
+            context: foregroundContext,
             writer: writer
         )
 
@@ -780,6 +794,12 @@ class RUMApplicationScopeTests: XCTestCase {
         XCTAssertNotEqual(sessionA.sessionUUID, sessionB.sessionUUID)
         XCTAssertEqual(sessionB.context.sessionPrecondition, .inactivityTimeout)
         XCTAssertTrue(scope.applicationActive, "applicationActive must be true once a session renewal occurs")
+        XCTAssertTrue(
+            writer.events(ofType: RUMViewEvent.self).contains {
+                $0.view.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName
+            },
+            "The foreground retry must start ApplicationLaunch before the requested view"
+        )
         XCTAssertNil(featureScope.telemetryMock.messages.firstError(), "No spurious telemetry error must be fired")
     }
 
@@ -827,7 +847,50 @@ class RUMApplicationScopeTests: XCTestCase {
         let sessionB = try XCTUnwrap(scope.activeSession)
         XCTAssertEqual(sessionB.context.sessionPrecondition, .inactivityTimeout)
         XCTAssertTrue(scope.applicationActive)
+        XCTAssertTrue(
+            writer.events(ofType: RUMViewEvent.self).contains {
+                $0.view.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName
+            },
+            "The foreground retry must start ApplicationLaunch before the requested view"
+        )
         XCTAssertNil(featureScope.telemetryMock.messages.firstError(), "Secondary fix must prevent spurious 'Creating initial session extra time' error")
+    }
+
+    func testGivenNoSDKInitCommand_whenStartViewLazilyCreatesUserLaunchSession_itStartsApplicationLaunchViewFirst() throws {
+        // Given - RUM receives a view before the SDK-init notification reaches the monitor.
+        let currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let context: DatadogContext = .mockWith(
+            sdkInitDate: currentTime,
+            launchInfo: .mockWith(
+                launchReason: .userLaunch,
+                processLaunchDate: currentTime
+            ),
+            applicationStateHistory: .mockAppInForeground(since: currentTime)
+        )
+        let scope = RUMApplicationScope(dependencies: .mockWith(samplingRate: 100))
+
+        // When
+        _ = scope.process(
+            command: RUMStartViewCommand.mockWith(
+                time: currentTime,
+                identity: .mockViewIdentifier(),
+                name: "RequestedView"
+            ),
+            context: context,
+            writer: writer
+        )
+
+        // Then
+        let session = try XCTUnwrap(scope.activeSession)
+        XCTAssertEqual(session.context.sessionPrecondition, .userAppLaunch)
+        XCTAssertEqual(session.viewScopes.first?.viewName, "RequestedView")
+        XCTAssertTrue(scope.applicationActive)
+        XCTAssertTrue(
+            writer.events(ofType: RUMViewEvent.self).contains {
+                $0.view.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName
+            },
+            "ApplicationLaunch must be started before the requested view"
+        )
     }
 
     func testGivenUserLaunchedApp_applicationLaunchViewCreatedImmediately() throws {


### PR DESCRIPTION
### What and why?

Fixes RUM session inflation on prewarmed iOS apps. 

PR #2299 (RUM-8372, first shipped in dd-sdk-ios 3.0.0) restricted the `ApplicationLaunch` view guard so it can only ever pass on `RUMSDKInitCommand`, whereas before that PR the same guard could pass on any later command once the app left the background.

We have received complaints of orphaned sessions in React Native SDK since the introduction of iOS v3. We believe that the cause is the application launch guard now permanently fails for any launch where the SDK initializes while the app is still backgrounded, and the code marks the app "activated" (`applicationActive = true`) before even checking whether the guard passed, the SDK gives up retrying and the session sits with zero views until it hits the 15-minute inactivity timeout and closes. This produces an empty near-zero-duration orphan session whenever no other RUM event arrives in that window.

### How?

In `RUMApplicationScope.swift`:

**1. Move `applicationActive = true` after the check in `startApplicationLaunchView`.** 

```diff
    private func startApplicationLaunchView(on command: RUMCommand, context: DatadogContext, writer: Writer) {
-        applicationActive = true
        
        let isUserLaunch = context.launchInfo.launchReason == .userLaunch
        let isPrewarmed = context.launchInfo.launchReason == .prewarming
        let isBackgroundLaunch = context.launchInfo.launchReason == .backgroundLaunch
        let isStartedInForeground = command is RUMSDKInitCommand && context.applicationStateHistory.currentState != .background
        guard isUserLaunch || (isPrewarmed && isStartedInForeground) || (isBackgroundLaunch && isStartedInForeground) else {
            return
        }

+       applicationActive = true       
```

Previously, `applicationActive` was set to true before the guard that decides if the view should start, now it's set only when the guard passes. 

When the SDK initializes while the app is still in the background (the prewarming case that causes the bug), the guard fails and `applicationActive` now stays `false`, so the SDK keeps retrying on each new command. This means the first `startView` (or similar) command still finds Session A alive and keeps using it, instead of Session A expiring with no views.

**2. Stop the retry once a session actually gets renewed**

Since `applicationActive` can now stay `false` for longer, we need to make sure the retry stops once it's no longer needed. We set `applicationActive = true` at the start of `refresh()` and `startNewSession()`, which are the two places that create a new session after the previous one expired or was stopped.

**3. Fix a side effect: don't recreate the initial session by mistake**

There's an older piece of code that creates a session if none exists yet and `applicationActive` is `false` (meant for a case where, in theory, no session was ever created). With change 1, `applicationActive` can now stay `false` well into the app's life, and this old code could accidentally trigger again after a session already expired (e.g. when a session times out on a background/foreground lifecycle event). This would cause two problems: the new session woiuld get the wrong "start reason" (appears as a fresh prewarm launch instead of a session that timed out), and it would trigger a telemetry log meant to catch a bug.

That old code path now only runs if no session has ever been created (`didCreateInitialSessionCount == 0`). If a session already existed and expired, the correct path (`startNewSession()`) takes over instead, with the right start reason and no false error log.

### Validation

We are unable to verify that this fix resolves the prewarming-scenario issues in a sample app, since iOS provides no reliable way to force a genuine prewarming condition on demand. We only rely on unit tests passing for this PR.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs
