### PR TITLE
[PANA-8342] Capture content snapshot geometry with layer snapshots

### DIFF
--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -43,7 +43,6 @@ extension CALayerSnapshot {
 
             let request = ContentSnapshotRequest(
                 layerSnapshot: self,
-                visibleFrame: visibleFrame,
                 cache: cache,
                 changeset: changeset
             )
@@ -117,7 +116,6 @@ extension MaskSnapshotRequest {
 extension ContentSnapshotRequest {
     fileprivate init?(
         layerSnapshot: CALayerSnapshot,
-        visibleFrame: CGRect,
         cache: ImageSnapshotCache,
         changeset: CALayerChangeset
     ) {
@@ -145,8 +143,7 @@ extension ContentSnapshotRequest {
             delegateClass: layerSnapshot.delegateClass,
             hasLayerSemantics: layerSnapshot.observation.semantics == .layer,
             bounds: layerSnapshot.bounds,
-            absoluteFrame: layerSnapshot.absoluteFrame,
-            visibleFrame: visibleFrame,
+            geometry: layerSnapshot.contentGeometry,
             isOpaque: layerSnapshot.isOpaque,
             hasContents: layerSnapshot.contentsClass != nil,
             dependencies: layerSnapshot.dependencies,

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Portal.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Portal.swift
@@ -156,6 +156,7 @@ extension CALayerSnapshot {
 
     private mutating func offsetAbsoluteFrames(x: CGFloat, y: CGFloat) {
         absoluteFrame = absoluteFrame.offsetBy(dx: x, dy: y)
+        contentGeometry.frame = contentGeometry.frame.offsetBy(dx: x, dy: y)
 
         if case .webView(let webView) = observation.semantics {
             observation.semantics = .webView(

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
@@ -40,7 +40,7 @@ internal struct CALayerSnapshot: Sendable {
     /// The layer's frame in the root layer coordinate space.
     var absoluteFrame: CGRect
 
-    /// Geometry used to render the layer content into an image.
+    /// The geometry used to capture this layer's rendered content.
     var contentGeometry: ContentGeometry
 
     var sublayers: [CALayerSnapshot]
@@ -73,17 +73,18 @@ internal struct CALayerSnapshot: Sendable {
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
-    /// Geometry captured for rendering the layer content.
+    /// Describes the bounds and placement of a layer's rendered content.
     struct ContentGeometry: Sendable {
-        /// The complete area that can contribute pixels, in the source layer coordinate space.
+        /// The full content bounds in the layer's coordinate space.
         let renderBounds: CGRect
 
-        /// The portion of `renderBounds` captured in the bitmap.
+        /// The captured portion of `renderBounds`, in the layer's coordinate space.
         let localRect: CGRect
 
-        /// The bitmap frame in the root layer coordinate space.
+        /// The captured content frame in the root layer's coordinate space.
         var frame: CGRect
 
+        /// Whether `localRect` contains only part of `renderBounds`.
         var isPartial: Bool {
             !renderBounds.equalTo(localRect)
         }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
@@ -40,6 +40,9 @@ internal struct CALayerSnapshot: Sendable {
     /// The layer's frame in the root layer coordinate space.
     var absoluteFrame: CGRect
 
+    /// Geometry used to render the layer content into an image.
+    var contentGeometry: ContentGeometry
+
     var sublayers: [CALayerSnapshot]
     /// Live descendant layers omitted from `sublayers` but captured when this layer is rendered as an image.
     let dependencies: [CALayerReference]
@@ -70,6 +73,22 @@ internal struct CALayerSnapshot: Sendable {
 
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
+    /// Geometry captured for rendering the layer content.
+    struct ContentGeometry: Sendable {
+        /// The complete area that can contribute pixels, in the source layer coordinate space.
+        let renderBounds: CGRect
+
+        /// The portion of `renderBounds` captured in the bitmap.
+        let localRect: CGRect
+
+        /// The bitmap frame in the root layer coordinate space.
+        var frame: CGRect
+
+        var isPartial: Bool {
+            !renderBounds.equalTo(localRect)
+        }
+    }
+
     @MainActor
     init?(from root: CALayer, in context: Context) {
         let privacy = ResolvedPrivacy(
@@ -137,17 +156,24 @@ extension CALayerSnapshot {
             } ?? []
         }
 
-        let dependencies = if observation.ignoresSublayers && !childVisibleBounds.isEmpty {
+        let dependencies: [CALayer] = if observation.ignoresSublayers && !childVisibleBounds.isEmpty {
             layer.sublayers?.flatMap {
                 $0.visibleDependencies(
                     rootLayer: rootLayer,
                     visibleBounds: childVisibleBounds
                 )
-                .map(CALayerReference.init)
             } ?? []
         } else {
-            [CALayerReference]()
+            []
         }
+
+        let contentGeometry = ContentGeometry(
+            layer: layer,
+            rootLayer: rootLayer,
+            absoluteFrame: absoluteFrame,
+            visibleBounds: visibleBounds,
+            dependencies: dependencies
+        )
 
         var cornerRadii = CornerRadii()
 
@@ -180,8 +206,9 @@ extension CALayerSnapshot {
             zPosition: layer.zPosition,
             transform: layer.transform,
             absoluteFrame: absoluteFrame,
+            contentGeometry: contentGeometry,
             sublayers: sublayers,
-            dependencies: dependencies,
+            dependencies: dependencies.map(CALayerReference.init),
             sublayerTransform: layer.sublayerTransform,
             mask: layer.mask.map(Mask.init),
             masksToBounds: layer.masksToBounds,
@@ -200,6 +227,44 @@ extension CALayerSnapshot {
             shadowOffset: layer.shadowOffset,
             shadowRadius: layer.shadowRadius,
             shadowPath: layer.shadowPath
+        )
+    }
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot.ContentGeometry {
+    @MainActor
+    fileprivate init(
+        layer: CALayer,
+        rootLayer: CALayer,
+        absoluteFrame: CGRect,
+        visibleBounds: CGRect,
+        dependencies: [CALayer]
+    ) {
+        let renderBounds = layer.masksToBounds
+            ? layer.bounds
+            : dependencies.reduce(into: layer.bounds) { bounds, dependency in
+                bounds = bounds.union(dependency.convert(dependency.bounds, to: layer))
+            }
+
+        let rendersLayerBounds = renderBounds.equalTo(layer.bounds)
+        let renderFrame = rendersLayerBounds
+            ? absoluteFrame
+            : layer.convert(renderBounds, to: rootLayer)
+
+        let isOversized = renderBounds.width > rootLayer.bounds.width
+            || renderBounds.height > rootLayer.bounds.height
+
+        let visibleRenderFrame = rendersLayerBounds
+            ? renderFrame.intersection(visibleBounds)
+            : renderFrame.intersection(rootLayer.bounds)
+
+        self.init(
+            renderBounds: renderBounds,
+            localRect: isOversized
+                ? layer.convert(visibleRenderFrame, from: rootLayer)
+                : renderBounds,
+            frame: isOversized ? visibleRenderFrame : renderFrame
         )
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
@@ -44,8 +44,7 @@ internal struct ContentSnapshotRequest: Sendable {
     let delegateClass: AnyClass?
     let hasLayerSemantics: Bool
     let bounds: CGRect
-    let absoluteFrame: CGRect
-    let visibleFrame: CGRect
+    let geometry: CALayerSnapshot.ContentGeometry
     let isOpaque: Bool
     let hasContents: Bool
     let dependencies: [CALayerReference]
@@ -61,8 +60,7 @@ internal struct ContentSnapshotRequest: Sendable {
         delegateClass: AnyClass?,
         hasLayerSemantics: Bool,
         bounds: CGRect,
-        absoluteFrame: CGRect,
-        visibleFrame: CGRect,
+        geometry: CALayerSnapshot.ContentGeometry,
         isOpaque: Bool,
         hasContents: Bool,
         dependencies: [CALayerReference],
@@ -77,8 +75,7 @@ internal struct ContentSnapshotRequest: Sendable {
         self.delegateClass = delegateClass
         self.hasLayerSemantics = hasLayerSemantics
         self.bounds = bounds
-        self.absoluteFrame = absoluteFrame
-        self.visibleFrame = visibleFrame
+        self.geometry = geometry
         self.isOpaque = isOpaque
         self.hasContents = hasContents
         self.dependencies = dependencies
@@ -89,13 +86,11 @@ internal struct ContentSnapshotRequest: Sendable {
     }
 }
 
-/// An image snapshot request resolved against the current layer tree.
+/// A content snapshot request with its live layer resolved for rendering.
 @available(iOS 13.0, tvOS 13.0, *)
 internal struct ResolvedContentSnapshotRequest {
     let layer: CALayer
-    let renderBounds: CGRect
-    let localRect: CGRect
-    let frame: CGRect
+    let geometry: CALayerSnapshot.ContentGeometry
     let needsSnapshot: Bool
 }
 
@@ -152,45 +147,26 @@ internal enum ImageSnapshotRequestResolutionError: Error {
 @available(iOS 13.0, tvOS 13.0, *)
 extension ContentSnapshotRequest {
     @MainActor
-    func resolved(relativeTo rootLayer: CALayer) throws -> ResolvedContentSnapshotRequest {
+    func resolved() throws -> ResolvedContentSnapshotRequest {
         guard let layer = layer.resolve() else {
             throw ImageSnapshotRequestResolutionError.missingLayer
         }
 
-        // Bounds changes invalidate the bitmap coordinate space
-        let snapshotBoundsDidChange = previousSnapshotData.map { !$0.bounds.equalTo(bounds) } ?? false
-
-        // Collapsed sublayers can draw outside the semantic owner's bounds
-        let renderBounds: CGRect
-        if !hasChanges, !snapshotBoundsDidChange, let previousSnapshotData {
-            renderBounds = previousSnapshotData.renderBounds
-        } else {
-            renderBounds = self.renderBounds(for: layer)
-        }
-
-        let renderFrame = frame(for: renderBounds, layer: layer, rootLayer: rootLayer)
-        let requiresPartialSnapshot = self.requiresPartialSnapshot(
-            renderBounds: renderBounds,
-            relativeTo: rootLayer
-        )
-        let visibleRenderFrame = renderBounds.equalTo(bounds)
-            ? visibleFrame
-            : renderFrame.intersection(rootLayer.bounds)
-        let visibleLocalRect = layer.convert(visibleRenderFrame, from: rootLayer)
-
-        guard !visibleLocalRect.isNull, !visibleLocalRect.isEmpty else {
+        guard !geometry.localRect.isNull, !geometry.localRect.isEmpty else {
             throw ImageSnapshotRequestResolutionError.invalidRect
         }
 
+        // Bounds changes invalidate the bitmap coordinate space
+        let snapshotBoundsDidChange = previousSnapshotData.map { !$0.bounds.equalTo(bounds) } ?? false
         let isNewSnapshot = previousSnapshotData == nil
 
-        // Full snapshots can be moved without re-rendering, but partial snapshots depend on the visible slice
-        let partialSnapshotHasChanges = self.hasPartialSnapshotChanges(
-            visibleLocalRect: visibleLocalRect,
-            requiresPartialSnapshot: requiresPartialSnapshot
-        )
+        // Full snapshots can be moved without re-rendering, but partial snapshots
+        // depend on the visible slice captured for this frame
+        let partialSnapshotHasChanges = hasPartialSnapshotChanges()
 
-        let renderBoundsDidChange = previousSnapshotData.map { !$0.renderBounds.equalTo(renderBounds) } ?? false
+        let renderBoundsDidChange = previousSnapshotData.map {
+            !$0.renderBounds.equalTo(geometry.renderBounds)
+        } ?? false
 
         // Plain layers need contents or collapsed dependencies to produce pixels on first capture
         let shouldCaptureInitialSnapshot = layerClass != CALayer.self || hasContents || !dependencies.isEmpty
@@ -202,51 +178,15 @@ extension ContentSnapshotRequest {
             snapshotBoundsDidChange ||
             renderBoundsDidChange
 
-        // Full snapshots capture the render bounds while partial snapshots capture only the visible slice
-        let localRect = requiresPartialSnapshot ? visibleLocalRect : renderBounds
-        let frame = requiresPartialSnapshot ? visibleRenderFrame : renderFrame
-
         return .init(
             layer: layer,
-            renderBounds: renderBounds,
-            localRect: localRect,
-            frame: frame,
+            geometry: geometry,
             needsSnapshot: needsSnapshot
         )
     }
 
-    @MainActor
-    private func renderBounds(for layer: CALayer) -> CGRect {
-        guard !layer.masksToBounds else {
-            return bounds
-        }
-
-        return dependencies.reduce(into: bounds) { renderBounds, dependency in
-            guard !dependency.matches(layer) else {
-                return
-            }
-
-            guard let dependencyLayer = dependency.resolve() else {
-                return
-            }
-
-            renderBounds = renderBounds.union(dependencyLayer.convert(dependencyLayer.bounds, to: layer))
-        }
-    }
-
-    private func frame(for renderBounds: CGRect, layer: CALayer, rootLayer: CALayer) -> CGRect {
-        renderBounds.equalTo(bounds) ? absoluteFrame : layer.convert(renderBounds, to: rootLayer)
-    }
-
-    private func requiresPartialSnapshot(renderBounds: CGRect, relativeTo rootLayer: CALayer) -> Bool {
-        renderBounds.width > rootLayer.bounds.width || renderBounds.height > rootLayer.bounds.height
-    }
-
-    private func hasPartialSnapshotChanges(
-        visibleLocalRect: CGRect,
-        requiresPartialSnapshot: Bool
-    ) -> Bool {
-        guard previousSnapshotData?.isPartial == true || requiresPartialSnapshot else {
+    private func hasPartialSnapshotChanges() -> Bool {
+        guard previousSnapshotData?.isPartial == true || geometry.isPartial else {
             return false
         }
 
@@ -254,7 +194,7 @@ extension ContentSnapshotRequest {
             return true
         }
 
-        return !previousSnapshotData.localRect.equalTo(visibleLocalRect)
+        return !previousSnapshotData.localRect.equalTo(geometry.localRect)
     }
 }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -78,7 +78,7 @@ internal final class ImageSnapshotter: ImageSnapshotting {
         let requests = root.imageSnapshotRequests(for: changeset, cache: cache)
         cache.updateFrameNumber(for: requests)
 
-        guard let rootLayer = root.layer.resolve(), !requests.isEmpty else {
+        guard !requests.isEmpty else {
             return .init()
         }
 
@@ -104,7 +104,7 @@ internal final class ImageSnapshotter: ImageSnapshotting {
 
             switch request {
             case .content(let request):
-                contentSnapshots[request.replayID] = takeContentSnapshot(for: request, rootLayer: rootLayer)
+                contentSnapshots[request.replayID] = takeContentSnapshot(for: request)
             case .mask(let request):
                 maskSnapshots[request.replayID] = takeMaskSnapshot(for: request)
             }
@@ -138,18 +138,15 @@ internal final class ImageSnapshotter: ImageSnapshotting {
         return .init(contentSnapshots: contentSnapshots, maskSnapshots: maskSnapshots)
     }
 
-    private func takeContentSnapshot(
-        for request: ContentSnapshotRequest,
-        rootLayer: CALayer
-    ) -> ContentSnapshotResult {
+    private func takeContentSnapshot(for request: ContentSnapshotRequest) -> ContentSnapshotResult {
         do {
-            let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+            let resolvedRequest = try request.resolved()
             let snapshot: ContentSnapshot
 
             if !resolvedRequest.needsSnapshot, let cachedSnapshot = request.previousSnapshotData?.snapshot {
                 snapshot = ContentSnapshot(
                     image: cachedSnapshot.image,
-                    frame: resolvedRequest.frame,
+                    frame: resolvedRequest.geometry.frame,
                     layerClass: request.layerClass,
                     delegateClass: request.delegateClass,
                     hasLayerSemantics: request.hasLayerSemantics,
@@ -160,10 +157,10 @@ internal final class ImageSnapshotter: ImageSnapshotting {
                 snapshot = ContentSnapshot(
                     image: try renderImage(
                         for: resolvedRequest.layer,
-                        in: resolvedRequest.localRect,
-                        opaque: request.isOpaque && resolvedRequest.renderBounds.equalTo(request.bounds)
+                        in: resolvedRequest.geometry.localRect,
+                        opaque: request.isOpaque && resolvedRequest.geometry.renderBounds.equalTo(request.bounds)
                     ),
-                    frame: resolvedRequest.frame,
+                    frame: resolvedRequest.geometry.frame,
                     layerClass: request.layerClass,
                     delegateClass: request.delegateClass,
                     hasLayerSemantics: request.hasLayerSemantics,
@@ -175,8 +172,8 @@ internal final class ImageSnapshotter: ImageSnapshotting {
             cache.setContentSnapshotData(
                 .init(
                     snapshot: snapshot,
-                    localRect: resolvedRequest.localRect,
-                    renderBounds: resolvedRequest.renderBounds,
+                    localRect: resolvedRequest.geometry.localRect,
+                    renderBounds: resolvedRequest.geometry.renderBounds,
                     bounds: request.bounds,
                     dependencies: request.dependencies
                 ),

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -78,7 +78,9 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         let request = try #require(requests.first?.content)
         #expect(request.replayID == snapshot.replayID)
         #expect(request.layer == snapshot.layer)
-        #expect(request.visibleFrame == snapshot.absoluteFrame)
+        #expect(request.geometry.renderBounds == snapshot.contentGeometry.renderBounds)
+        #expect(request.geometry.localRect == snapshot.contentGeometry.localRect)
+        #expect(request.geometry.frame == snapshot.contentGeometry.frame)
         #expect(request.hasChanges == false)
     }
 
@@ -673,64 +675,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
 
         // Then
         #expect(requests.isEmpty)
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Clips request visible frame to masking ancestor")
-    func clipsRequestVisibleFrameToMaskingAncestor() throws {
-        // Given
-        let root = CALayer()
-        root.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
-
-        let clippingLayer = CALayer()
-        clippingLayer.frame = CGRect(x: 10, y: 10, width: 40, height: 40)
-        clippingLayer.masksToBounds = true
-        root.addSublayer(clippingLayer)
-
-        let child = CATextLayer()
-        child.frame = CGRect(x: 20, y: 20, width: 40, height: 40)
-        clippingLayer.addSublayer(child)
-
-        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
-        let cache = ImageSnapshotCache()
-
-        // When
-        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
-
-        // Then
-        #expect(requests.count == 1)
-        let request = try #require(requests.first?.content)
-        #expect(request.layer.matches(child))
-        #expect(request.visibleFrame == CGRect(x: 30, y: 30, width: 20, height: 20))
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Does not clip request visible frame to non-masking ancestor")
-    func doesNotClipRequestVisibleFrameToNonMaskingAncestor() throws {
-        // Given
-        let root = CALayer()
-        root.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
-
-        let container = CALayer()
-        container.frame = CGRect(x: 10, y: 10, width: 40, height: 40)
-        container.masksToBounds = false
-        root.addSublayer(container)
-
-        let child = CATextLayer()
-        child.frame = CGRect(x: 20, y: 20, width: 90, height: 90)
-        container.addSublayer(child)
-
-        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
-        let cache = ImageSnapshotCache()
-
-        // When
-        let requests = snapshot.imageSnapshotRequests(for: .init(), cache: cache)
-
-        // Then
-        #expect(requests.count == 1)
-        let request = try #require(requests.first?.content)
-        #expect(request.layer.matches(child))
-        #expect(request.visibleFrame == CGRect(x: 30, y: 30, width: 70, height: 70))
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotPortalTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotPortalTests.swift
@@ -107,8 +107,18 @@ struct CALayerSnapshotPortalTests {
 
         let resolvedSource = try #require(resolvedPortal.sublayers.first)
         #expect(resolvedSource.absoluteFrame == portal.absoluteFrame)
+        #expect(resolvedSource.contentGeometry.renderBounds == source.bounds)
+        #expect(resolvedSource.contentGeometry.localRect == source.bounds)
+        #expect(resolvedSource.contentGeometry.frame == portal.absoluteFrame)
         #expect(resolvedSource.opacity == 1)
-        #expect(resolvedSource.sublayers.first?.absoluteFrame == CGRect(x: 202, y: 304, width: 20, height: 10))
+        let resolvedContent = try #require(resolvedSource.sublayers.first)
+        #expect(resolvedContent.absoluteFrame == CGRect(x: 202, y: 304, width: 20, height: 10))
+        #expect(resolvedContent.contentGeometry.renderBounds == sourceContent.bounds)
+        #expect(resolvedContent.contentGeometry.localRect == sourceContent.bounds)
+        #expect(
+            resolvedContent.contentGeometry.frame
+                == CGRect(x: 202, y: 304, width: 20, height: 10)
+        )
     }
 
     @available(iOS 13.0, tvOS 13.0, *)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotTests.swift
@@ -345,6 +345,124 @@ struct CALayerSnapshotTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Captures content geometry")
+    func capturesContentGeometry() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let layer = CALayer()
+        layer.frame = CGRect(x: 20, y: 30, width: 80, height: 40)
+        root.addSublayer(layer)
+
+        // When
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let layerSnapshot = try #require(snapshot.sublayers.first)
+
+        // Then
+        #expect(layerSnapshot.contentGeometry.renderBounds == layer.bounds)
+        #expect(layerSnapshot.contentGeometry.localRect == layer.bounds)
+        #expect(layerSnapshot.contentGeometry.frame == layer.frame)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Expands content geometry to include ignored sublayers")
+    func expandsContentGeometryToIncludeIgnoredSublayers() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let imageView = UIImageView(frame: CGRect(x: 50, y: 60, width: 30, height: 30))
+        root.addSublayer(imageView.layer)
+
+        let ignoredSublayer = CALayer()
+        ignoredSublayer.frame = CGRect(x: -10, y: -12, width: 50, height: 54)
+        imageView.layer.addSublayer(ignoredSublayer)
+
+        // When
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let imageSnapshot = try #require(snapshot.sublayers.first)
+
+        // Then
+        #expect(imageSnapshot.contentGeometry.renderBounds == ignoredSublayer.frame)
+        #expect(imageSnapshot.contentGeometry.localRect == ignoredSublayer.frame)
+        #expect(imageSnapshot.contentGeometry.frame == CGRect(x: 40, y: 48, width: 50, height: 54))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Keeps content geometry within an ignored subtree owner that clips")
+    func keepsContentGeometryWithinIgnoredSublayerOwnerThatClips() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let imageView = UIImageView(frame: CGRect(x: 50, y: 60, width: 30, height: 30))
+        imageView.layer.masksToBounds = true
+        root.addSublayer(imageView.layer)
+
+        let ignoredSublayer = CALayer()
+        ignoredSublayer.frame = CGRect(x: -10, y: -12, width: 50, height: 54)
+        imageView.layer.addSublayer(ignoredSublayer)
+
+        // When
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let imageSnapshot = try #require(snapshot.sublayers.first)
+
+        // Then
+        #expect(imageSnapshot.contentGeometry.renderBounds == imageView.layer.bounds)
+        #expect(imageSnapshot.contentGeometry.localRect == imageView.layer.bounds)
+        #expect(imageSnapshot.contentGeometry.frame == imageView.layer.frame)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Captures complete geometry for a non-oversized layer clipped by an ancestor")
+    func capturesCompleteGeometryForNonOversizedLayerClippedByAncestor() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+
+        let parent = CALayer()
+        parent.frame = CGRect(x: 20, y: 30, width: 50, height: 50)
+        parent.masksToBounds = true
+        root.addSublayer(parent)
+
+        let child = CATextLayer()
+        child.frame = CGRect(x: 30, y: 10, width: 40, height: 20)
+        parent.addSublayer(child)
+
+        // When
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let parentSnapshot = try #require(snapshot.sublayers.first)
+        let childSnapshot = try #require(parentSnapshot.sublayers.first)
+
+        // Then
+        #expect(childSnapshot.contentGeometry.renderBounds == child.bounds)
+        #expect(childSnapshot.contentGeometry.localRect == child.bounds)
+        #expect(childSnapshot.contentGeometry.frame == child.convert(child.bounds, to: root))
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Crops oversized content geometry to the viewport")
+    func cropsOversizedContentGeometryToViewport() throws {
+        // Given
+        let root = CALayer()
+        root.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        let oversizedLayer = CALayer()
+        oversizedLayer.frame = CGRect(x: -180, y: 0, width: 400, height: 120)
+        root.addSublayer(oversizedLayer)
+
+        // When
+        let snapshot = try #require(CALayerSnapshot(from: root, in: .mockAny()))
+        let oversizedSnapshot = try #require(snapshot.sublayers.first)
+
+        // Then
+        #expect(oversizedSnapshot.contentGeometry.renderBounds == oversizedLayer.bounds)
+        #expect(oversizedSnapshot.contentGeometry.localRect == CGRect(x: 180, y: 0, width: 100, height: 100))
+        #expect(oversizedSnapshot.contentGeometry.frame == root.bounds)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures per-corner radii")
     func capturesPerCornerRadii() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ContentSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ContentSnapshotRequestTests.swift
@@ -20,7 +20,6 @@ struct ContentSnapshotRequestTests {
     @Test("Throws when layer reference is deallocated")
     func throwsWhenLayerReferenceIsDeallocated() {
         // Given
-        let rootLayer = CALayer()
         let request: ContentSnapshotRequest = {
             var layer: CALayer? = CALayer()
             let request = ContentSnapshotRequest.mockAny(layer: layer!)
@@ -30,22 +29,23 @@ struct ContentSnapshotRequestTests {
 
         // When / Then
         #expect(throws: ImageSnapshotRequestResolutionError.missingLayer) {
-            _ = try request.resolved(relativeTo: rootLayer)
+            _ = try request.resolved()
         }
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Throws when visible frame resolves to empty rect")
-    func throwsWhenVisibleFrameResolvesToEmptyRect() {
+    @Test("Throws when local rect is empty")
+    func throwsWhenLocalRectIsEmpty() {
         // Given
-        let rootLayer = CALayer()
         let layer = CALayer()
-        rootLayer.addSublayer(layer)
-        let request = ContentSnapshotRequest.mockAny(layer: layer, visibleFrame: .zero)
+        let request = ContentSnapshotRequest.mockAny(
+            layer: layer,
+            geometry: .init(renderBounds: layer.bounds, localRect: .zero, frame: .zero)
+        )
 
         // When / Then
         #expect(throws: ImageSnapshotRequestResolutionError.invalidRect) {
-            _ = try request.resolved(relativeTo: rootLayer)
+            _ = try request.resolved()
         }
     }
 
@@ -63,11 +63,11 @@ struct ContentSnapshotRequestTests {
         let request = ContentSnapshotRequest.mockAny(layer: layer, hasContents: true)
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
         #expect(resolvedRequest.layer === layer)
-        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.geometry.localRect == layer.bounds)
         #expect(resolvedRequest.needsSnapshot)
     }
 
@@ -89,10 +89,10 @@ struct ContentSnapshotRequestTests {
         )
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
-        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.geometry.localRect == layer.bounds)
         #expect(resolvedRequest.needsSnapshot == false)
     }
 
@@ -114,10 +114,10 @@ struct ContentSnapshotRequestTests {
         )
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
-        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.geometry.localRect == layer.bounds)
         #expect(resolvedRequest.needsSnapshot)
     }
 
@@ -138,10 +138,10 @@ struct ContentSnapshotRequestTests {
         )
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
-        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.geometry.localRect == layer.bounds)
         #expect(resolvedRequest.needsSnapshot == false)
     }
 
@@ -163,70 +163,11 @@ struct ContentSnapshotRequestTests {
         )
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
-        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.geometry.localRect == layer.bounds)
         #expect(resolvedRequest.needsSnapshot)
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Expands render bounds to include dependencies outside the layer bounds")
-    func expandsRenderBoundsToIncludeDependenciesOutsideLayerBounds() throws {
-        // Given
-        let rootLayer = CALayer()
-        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
-
-        let layer = CALayer()
-        layer.frame = CGRect(x: 50, y: 60, width: 30, height: 30)
-        rootLayer.addSublayer(layer)
-
-        let dependency = CALayer()
-        dependency.frame = CGRect(x: -10, y: -12, width: 50, height: 54)
-        layer.addSublayer(dependency)
-
-        let request = ContentSnapshotRequest.mockAny(
-            layer: layer,
-            dependencies: [CALayerReference(dependency)]
-        )
-
-        // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
-
-        // Then
-        #expect(resolvedRequest.renderBounds == dependency.frame)
-        #expect(resolvedRequest.localRect == dependency.frame)
-        #expect(resolvedRequest.frame == CGRect(x: 40, y: 48, width: 50, height: 54))
-    }
-
-    @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Keeps layer bounds when the layer clips its dependencies")
-    func keepsLayerBoundsWhenLayerClipsDependencies() throws {
-        // Given
-        let rootLayer = CALayer()
-        rootLayer.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
-
-        let layer = CALayer()
-        layer.frame = CGRect(x: 50, y: 60, width: 30, height: 30)
-        layer.masksToBounds = true
-        rootLayer.addSublayer(layer)
-
-        let dependency = CALayer()
-        dependency.frame = CGRect(x: -10, y: -12, width: 50, height: 54)
-        layer.addSublayer(dependency)
-
-        let request = ContentSnapshotRequest.mockAny(
-            layer: layer,
-            dependencies: [CALayerReference(dependency)]
-        )
-
-        // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
-
-        // Then
-        #expect(resolvedRequest.renderBounds == layer.bounds)
-        #expect(resolvedRequest.localRect == layer.bounds)
-        #expect(resolvedRequest.frame == layer.frame)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
@@ -247,10 +188,10 @@ struct ContentSnapshotRequestTests {
         )
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
-        #expect(resolvedRequest.localRect == layer.bounds)
+        #expect(resolvedRequest.geometry.localRect == layer.bounds)
         #expect(resolvedRequest.needsSnapshot == false)
     }
 
@@ -271,15 +212,15 @@ struct ContentSnapshotRequestTests {
         layer.frame = CGRect(x: 30, y: 40, width: 100, height: 40)
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
-        #expect(resolvedRequest.frame == capturedFrame)
+        #expect(resolvedRequest.geometry.frame == capturedFrame)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Partial snapshot needs snapshot when visible frame changes")
-    func partialSnapshotNeedsSnapshotWhenVisibleFrameChanges() throws {
+    @Test("Partial snapshot needs snapshot when local rect changes")
+    func partialSnapshotNeedsSnapshotWhenLocalRectChanges() throws {
         // Given
         let rootLayer = CALayer()
         rootLayer.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
@@ -289,9 +230,10 @@ struct ContentSnapshotRequestTests {
         layer.position = CGPoint(x: 200, y: 60)
         rootLayer.addSublayer(layer)
 
+        let localRect = CGRect(x: 180, y: 0, width: 20, height: 100)
         let request = ContentSnapshotRequest.mockAny(
             layer: layer,
-            visibleFrame: CGRect(x: 180, y: 0, width: 20, height: 100),
+            geometry: .init(renderBounds: layer.bounds, localRect: localRect, frame: localRect),
             previousSnapshotData: .mockAny(
                 localRect: CGRect(x: 0, y: 0, width: 10, height: 100),
                 bounds: layer.bounds
@@ -299,17 +241,17 @@ struct ContentSnapshotRequestTests {
         )
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
-        #expect(resolvedRequest.localRect == CGRect(x: 180, y: 0, width: 20, height: 100))
-        #expect(resolvedRequest.frame == CGRect(x: 180, y: 0, width: 20, height: 100))
+        #expect(resolvedRequest.geometry.localRect == localRect)
+        #expect(resolvedRequest.geometry.frame == localRect)
         #expect(resolvedRequest.needsSnapshot)
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Partial snapshot does not need snapshot when visible frame is unchanged")
-    func partialSnapshotDoesNotNeedSnapshotWhenVisibleFrameIsUnchanged() throws {
+    @Test("Partial snapshot does not need snapshot when local rect is unchanged")
+    func partialSnapshotDoesNotNeedSnapshotWhenLocalRectIsUnchanged() throws {
         // Given
         let rootLayer = CALayer()
         rootLayer.bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
@@ -319,22 +261,22 @@ struct ContentSnapshotRequestTests {
         layer.position = CGPoint(x: 200, y: 60)
         rootLayer.addSublayer(layer)
 
-        let visibleFrame = CGRect(x: 180, y: 0, width: 20, height: 100)
+        let localRect = CGRect(x: 180, y: 0, width: 20, height: 100)
         let request = ContentSnapshotRequest.mockAny(
             layer: layer,
-            visibleFrame: visibleFrame,
+            geometry: .init(renderBounds: layer.bounds, localRect: localRect, frame: localRect),
             previousSnapshotData: .mockAny(
-                localRect: visibleFrame,
+                localRect: localRect,
                 bounds: layer.bounds
             )
         )
 
         // When
-        let resolvedRequest = try request.resolved(relativeTo: rootLayer)
+        let resolvedRequest = try request.resolved()
 
         // Then
-        #expect(resolvedRequest.localRect == visibleFrame)
-        #expect(resolvedRequest.frame == visibleFrame)
+        #expect(resolvedRequest.geometry.localRect == localRect)
+        #expect(resolvedRequest.geometry.frame == localRect)
         #expect(resolvedRequest.needsSnapshot == false)
     }
 }
@@ -344,7 +286,7 @@ extension ContentSnapshotRequest {
     @MainActor
     fileprivate static func mockAny(
         layer: CALayer,
-        visibleFrame: CGRect? = nil,
+        geometry: CALayerSnapshot.ContentGeometry? = nil,
         hasContents: Bool = false,
         dependencies: [CALayerReference] = [],
         hasChanges: Bool = false,
@@ -357,8 +299,11 @@ extension ContentSnapshotRequest {
             delegateClass: layer.delegate.map { type(of: $0) },
             hasLayerSemantics: true,
             bounds: layer.bounds,
-            absoluteFrame: layer.frame,
-            visibleFrame: visibleFrame ?? layer.frame,
+            geometry: geometry ?? .init(
+                renderBounds: layer.bounds,
+                localRect: layer.bounds,
+                frame: layer.frame
+            ),
             isOpaque: layer.isOpaque,
             hasContents: hasContents,
             dependencies: dependencies,

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
@@ -202,8 +202,11 @@ struct ImageSnapshotCacheTests {
                 delegateClass: nil,
                 hasLayerSemantics: true,
                 bounds: layer.bounds,
-                absoluteFrame: layer.frame,
-                visibleFrame: layer.frame,
+                geometry: .init(
+                    renderBounds: layer.bounds,
+                    localRect: layer.bounds,
+                    frame: layer.frame
+                ),
                 isOpaque: layer.isOpaque,
                 hasContents: false,
                 dependencies: [],

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotMocks.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotMocks.swift
@@ -64,6 +64,7 @@ extension CALayerSnapshot {
         absoluteFrame: CGRect = .zero,
         observation: CALayerSnapshot.SemanticObservation = .init(semantics: .layer),
         bounds: CGRect? = nil,
+        contentGeometry: ContentGeometry? = nil,
         transform: CATransform3D = CATransform3DIdentity,
         backgroundColor: CGColor? = nil,
         cornerRadii: CALayerSnapshot.CornerRadii = .zero,
@@ -75,6 +76,7 @@ extension CALayerSnapshot {
         sublayers: [CALayerSnapshot] = []
     ) -> CALayerSnapshot {
         let layer = CALayer()
+        let bounds = bounds ?? CGRect(origin: .zero, size: absoluteFrame.size)
         return CALayerSnapshot(
             layer: CALayerReference(layer),
             replayID: replayID,
@@ -85,11 +87,16 @@ extension CALayerSnapshot {
             textAndInputPrivacyLevel: .maskSensitiveInputs,
             imagePrivacyLevel: .maskNone,
             isPrivate: isPrivate,
-            bounds: bounds ?? CGRect(origin: .zero, size: absoluteFrame.size),
+            bounds: bounds,
             position: absoluteFrame.origin,
             zPosition: 0,
             transform: transform,
             absoluteFrame: absoluteFrame,
+            contentGeometry: contentGeometry ?? .init(
+                renderBounds: bounds,
+                localRect: bounds,
+                frame: absoluteFrame
+            ),
             sublayers: sublayers,
             dependencies: [],
             sublayerTransform: CATransform3DIdentity,


### PR DESCRIPTION
### What and why?

This PR captures content snapshot geometry while capturing the layer tree.

Previously, image snapshot requests calculated their geometry later from the live layer tree. If the UI changed between these steps, the rendered image could use geometry that no longer matched the captured layer snapshot.

### How?

- Add `CALayerSnapshot.ContentGeometry` for the render bounds, captured region, and root-relative frame.
- Compute this geometry during layer tree capture, including clipping, ignored sublayers, oversized content, and portal resolution.
- Pass the captured geometry through content snapshot requests instead of recalculating it from live layers.
- Keep the existing cache invalidation behavior when bounds or captured regions change.

The bitmap still uses the live layer contents. This change only makes its geometry consistent with the captured layer tree. Mask snapshotting is unchanged.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
