### PR TITLE
Fix DatadogTracer Sendable conformance

### DIFF
--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -8,7 +8,7 @@ import Foundation
 import DatadogInternal
 import OpenTelemetryApi
 
-internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
+internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer, @unchecked Sendable {
     /// Trace feature scope.
     let featureScope: FeatureScope
 

--- a/DatadogTrace/Sources/DatadogTracer.swift
+++ b/DatadogTrace/Sources/DatadogTracer.swift
@@ -8,7 +8,7 @@ import Foundation
 import DatadogInternal
 import OpenTelemetryApi
 
-internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer, @unchecked Sendable {
+internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer {
     /// Trace feature scope.
     let featureScope: FeatureScope
 
@@ -36,9 +36,7 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer, @unchecke
     let spanEventBuilder: SpanEventBuilder
 
     /// Optional callback invoked when any span finishes, regardless of sampling.
-    /// Set by `Trace.enableOrThrow()` when client-side stats is enabled.
-    @ReadWriteLock
-    var onSpanFinished: ((SpanSnapshot) -> Void)?
+    let onSpanFinished: (@Sendable (SpanSnapshot) -> Void)?
 
     // MARK: - Initialization
 
@@ -50,7 +48,8 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer, @unchecke
         spanIDGenerator: SpanIDGenerator,
         dateProvider: DateProvider,
         loggingIntegration: TracingWithLoggingIntegration,
-        spanEventBuilder: SpanEventBuilder
+        spanEventBuilder: SpanEventBuilder,
+        onSpanFinished: (@Sendable (SpanSnapshot) -> Void)? = nil
     ) {
         self.init(
             featureScope: core.scope(for: TraceFeature.self),
@@ -60,7 +59,8 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer, @unchecke
             spanIDGenerator: spanIDGenerator,
             dateProvider: dateProvider,
             loggingIntegration: loggingIntegration,
-            spanEventBuilder: spanEventBuilder
+            spanEventBuilder: spanEventBuilder,
+            onSpanFinished: onSpanFinished
         )
     }
 
@@ -72,7 +72,8 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer, @unchecke
         spanIDGenerator: SpanIDGenerator,
         dateProvider: DateProvider,
         loggingIntegration: TracingWithLoggingIntegration,
-        spanEventBuilder: SpanEventBuilder
+        spanEventBuilder: SpanEventBuilder,
+        onSpanFinished: (@Sendable (SpanSnapshot) -> Void)? = nil
     ) {
         self.featureScope = featureScope
         self.tags = tags
@@ -82,6 +83,7 @@ internal final class DatadogTracer: OTTracer, OpenTelemetryApi.Tracer, @unchecke
         self.loggingIntegration = loggingIntegration
         self.samplerProvider = samplingProvider
         self.spanEventBuilder = spanEventBuilder
+        self.onSpanFinished = onSpanFinished
     }
 
     // MARK: - Open Tracing interface

--- a/DatadogTrace/Sources/Feature/TraceFeature.swift
+++ b/DatadogTrace/Sources/Feature/TraceFeature.swift
@@ -21,7 +21,8 @@ internal final class TraceFeature: DatadogRemoteFeature {
 
     init(
         in core: DatadogCoreProtocol,
-        configuration: Trace.Configuration
+        configuration: Trace.Configuration,
+        onSpanFinished: (@Sendable (SpanSnapshot) -> Void)? = nil
     ) {
         self.requestBuilder = TracingRequestBuilder(
             customIntakeURL: configuration.customEndpoint,
@@ -51,7 +52,8 @@ internal final class TraceFeature: DatadogRemoteFeature {
                 bundleWithRUM: configuration.bundleWithRumEnabled,
                 statsComputationEnabled: configuration.statsComputationEnabled,
                 telemetry: core.telemetry
-            )
+            ),
+            onSpanFinished: onSpanFinished
         )
         self.performanceOverride = nil
 

--- a/DatadogTrace/Sources/Trace.swift
+++ b/DatadogTrace/Sources/Trace.swift
@@ -51,15 +51,23 @@ public enum Trace {
             stats = statsFeature
         }
 
-        // Register Trace feature:
-        let trace = TraceFeature(in: core, configuration: configuration)
-        try core.register(feature: trace)
-
+        let onSpanFinished: (@Sendable (SpanSnapshot) -> Void)?
         if let stats {
-            trace.tracer.onSpanFinished = { [weak stats] snapshot in
-                stats?.concentrator.add(snapshot)
+            let concentrator = stats.concentrator
+            onSpanFinished = { [weak concentrator] snapshot in
+                concentrator?.add(snapshot)
             }
+        } else {
+            onSpanFinished = nil
         }
+
+        // Register Trace feature:
+        let trace = TraceFeature(
+            in: core,
+            configuration: configuration,
+            onSpanFinished: onSpanFinished
+        )
+        try core.register(feature: trace)
 
         // If `URLSession` tracking is configured, register `URLSessionHandler` to enable distributed tracing:
         if let urlSessionTracking = configuration.urlSessionTracking {

--- a/DatadogTrace/Tests/DDSpanTests.swift
+++ b/DatadogTrace/Tests/DDSpanTests.swift
@@ -273,9 +273,9 @@ class DDSpanTests: XCTestCase {
         let tracer: DatadogTracer = .mockWith(
             core: core,
             samplingProvider: TracerSamplerProviderMock.mockKeepAll(),
-            spanEventBuilder: .mockWith(eventsMapper: invocations.mapper)
+            spanEventBuilder: .mockWith(eventsMapper: invocations.mapper),
+            onSpanFinished: { _ in /* stats hook installed */ }
         )
-        tracer.onSpanFinished = { _ in /* stats hook installed */ }
 
         tracer.startSpan(operationName: .mockAny()).finish()
 
@@ -287,19 +287,18 @@ class DDSpanTests: XCTestCase {
     func testWhenStatsEnabled_eventMapperRunsExactlyOnce_forSampledOutSpan() {
         let invocations = MapperInvocationCounter()
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
             samplingProvider: TracerSamplerProviderMock.mockRejectAll(),
-            spanEventBuilder: .mockWith(eventsMapper: invocations.mapper)
+            spanEventBuilder: .mockWith(eventsMapper: invocations.mapper),
+            onSpanFinished: capture.capture
         )
-
-        var snapshotDelivered = false
-        tracer.onSpanFinished = { _ in snapshotDelivered = true }
 
         tracer.startSpan(operationName: .mockAny()).finish()
 
         XCTAssertEqual(invocations.count, 1, "Mapper must run for the snapshot even when sampled out")
-        XCTAssertTrue(snapshotDelivered)
+        XCTAssertNotNil(capture.snapshot)
         let envelopes: [SpanEventsEnvelope] = core.events()
         XCTAssertEqual(envelopes.count, 0, "Sampled-out span must not be uploaded")
     }

--- a/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
+++ b/DatadogTrace/Tests/Span/SpanSnapshotTests.swift
@@ -15,7 +15,8 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotCapturesBasicSpanData() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(
             operationName: "network.request",
@@ -25,14 +26,9 @@ class SpanSnapshotTests: XCTestCase {
             ]
         ) as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { snapshot in
-            capturedSnapshot = snapshot
-        }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.operationName, "network.request")
         XCTAssertEqual(snapshot.resource, "GET /api/users")
         XCTAssertEqual(snapshot.service, "my-service")
@@ -40,61 +36,56 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotCapturesSpanKind() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(
             operationName: "rpc.call",
             tags: [SpanTags.kind: "client"]
         ) as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.spanKind, "client")
     }
 
     func testSnapshotCapturesHTTPStatusCode() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(
             operationName: "http.request",
             tags: [OTTags.httpStatusCode: 404]
         ) as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.httpStatusCode, 404)
     }
 
     func testSnapshotCapturesErrorFromTag() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(
             operationName: "failing.op",
             tags: [OTTags.error: true]
         ) as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertTrue(snapshot.isError)
     }
 
     func testSnapshotCapturesErrorFromLogFields() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(operationName: "error.op") as! DDSpan
         span.log(
@@ -104,27 +95,22 @@ class SpanSnapshotTests: XCTestCase {
             ]
         )
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertTrue(snapshot.isError)
     }
 
     func testSnapshotDefaultsToNoError() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(operationName: "ok.op") as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertFalse(snapshot.isError)
     }
 
@@ -132,23 +118,22 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotIsTopLevel_whenRootSpan() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(operationName: "root.span") as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertTrue(snapshot.isTopLevel)
         XCTAssertNil(snapshot.parentSpanID)
     }
 
     func testSnapshotIsNotTopLevel_whenChildSpan() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let parent = tracer.startSpan(operationName: "parent")
         let child = tracer.startSpan(
@@ -156,33 +141,28 @@ class SpanSnapshotTests: XCTestCase {
             references: [OTReference.child(of: parent.context)]
         )
 
-        var snapshots: [SpanSnapshot] = []
-        tracer.onSpanFinished = { snapshots.append($0) }
-
         child.finish()
         parent.finish()
 
-        XCTAssertEqual(snapshots.count, 2)
-        let childSnapshot = try XCTUnwrap(snapshots.first { $0.operationName == "child" })
+        XCTAssertEqual(capture.snapshots.count, 2)
+        let childSnapshot = try XCTUnwrap(capture.snapshots.first { $0.operationName == "child" })
         XCTAssertFalse(childSnapshot.isTopLevel)
         XCTAssertNotNil(childSnapshot.parentSpanID)
     }
 
     func testSnapshotIsMeasured_whenTagSet() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(
             operationName: "measured.op",
             tags: ["_dd.measured": 1]
         ) as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertTrue(snapshot.isMeasured)
     }
 
@@ -190,7 +170,8 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotCapturesPeerTags() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(
             operationName: "db.call",
@@ -202,12 +183,9 @@ class SpanSnapshotTests: XCTestCase {
             ]
         ) as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.peerTags["peer.service"], "postgres-primary")
         XCTAssertEqual(snapshot.peerTags["db.instance"], "users_db")
         XCTAssertEqual(snapshot.peerTags["out.host"], "db.internal.io")
@@ -218,34 +196,30 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotCapturesServiceSource() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(
             operationName: "op",
             tags: ["_dd.svc_src": "m"]
         ) as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.serviceSource, "m")
     }
 
     func testSnapshotDefaultsToEmptyServiceSource() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(operationName: "op") as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.serviceSource, "")
     }
 
@@ -256,19 +230,18 @@ class SpanSnapshotTests: XCTestCase {
         let finishDate = Date(timeIntervalSince1970: 1_000.5)
 
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
-            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 0)
+            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 0),
+            onSpanFinished: capture.capture
         )
 
         let span = tracer.startSpan(operationName: "timed.op", startTime: startDate) as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish(at: finishDate)
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.duration, 500_000_000)
         XCTAssertEqual(snapshot.startTime, 1_000_000_000_000)
     }
@@ -277,16 +250,14 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotUsesOperationNameAsResourceFallback() throws {
         let core = PassthroughCoreMock()
-        let tracer: DatadogTracer = .mockWith(core: core)
+        let capture = SpanSnapshotCapture()
+        let tracer: DatadogTracer = .mockWith(core: core, onSpanFinished: capture.capture)
 
         let span = tracer.startSpan(operationName: "fallback.op") as! DDSpan
 
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
-
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.resource, "fallback.op")
     }
 
@@ -304,18 +275,17 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotIsCapturedEvenForSampledOutSpans() throws {
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
-            samplingProvider: TracerSamplerProviderMock.mockRejectAll()
+            samplingProvider: TracerSamplerProviderMock.mockRejectAll(),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(operationName: "sampled.out")
         span.finish()
 
-        XCTAssertNotNil(capturedSnapshot, "Snapshot must be captured regardless of sampling decision")
+        XCTAssertNotNil(capture.snapshot, "Snapshot must be captured regardless of sampling decision")
     }
 
     // MARK: - EventMapper Consistency
@@ -329,17 +299,16 @@ class SpanSnapshotTests: XCTestCase {
 
     func testSnapshotReflectsMappedResourceName() throws {
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
             spanEventBuilder: .mockWith(eventsMapper: { event in
                 var mapped = event
                 mapped.resource = "REDACTED"
                 return mapped
-            })
+            }),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(
             operationName: "network.request",
@@ -347,44 +316,42 @@ class SpanSnapshotTests: XCTestCase {
         )
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.resource, "REDACTED")
     }
 
     func testSnapshotReflectsMappedOperationName() throws {
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
             spanEventBuilder: .mockWith(eventsMapper: { event in
                 var mapped = event
                 mapped.operationName = "http.request.normalized"
                 return mapped
-            })
+            }),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(operationName: "http.request")
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.operationName, "http.request.normalized")
     }
 
     func testSnapshotReflectsMappedPeerTags() throws {
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
             spanEventBuilder: .mockWith(eventsMapper: { event in
                 var mapped = event
                 mapped.tags["peer.service"] = "redacted-db"
                 return mapped
-            })
+            }),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(
             operationName: "db.query",
@@ -392,23 +359,22 @@ class SpanSnapshotTests: XCTestCase {
         )
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.peerTags["peer.service"], "redacted-db")
     }
 
     func testSnapshotReflectsMapperRemovingPeerTag() throws {
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
             spanEventBuilder: .mockWith(eventsMapper: { event in
                 var mapped = event
                 mapped.tags.removeValue(forKey: "peer.service")
                 return mapped
-            })
+            }),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(
             operationName: "db.query",
@@ -416,23 +382,22 @@ class SpanSnapshotTests: XCTestCase {
         )
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertNil(snapshot.peerTags["peer.service"])
     }
 
     func testSnapshotReflectsMappedHTTPStatusCode() throws {
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
             spanEventBuilder: .mockWith(eventsMapper: { event in
                 var mapped = event
                 mapped.tags[OTTags.httpStatusCode] = "500"
                 return mapped
-            })
+            }),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(
             operationName: "http.request",
@@ -440,7 +405,7 @@ class SpanSnapshotTests: XCTestCase {
         )
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.httpStatusCode, 500)
     }
 
@@ -454,18 +419,17 @@ class SpanSnapshotTests: XCTestCase {
         let serverOffset: TimeInterval = 5
 
         let core = PassthroughCoreMock(context: .mockWith(serverTimeOffset: serverOffset))
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
-            dateProvider: RelativeDateProvider(startingFrom: deviceStartDate, advancingBySeconds: 0)
+            dateProvider: RelativeDateProvider(startingFrom: deviceStartDate, advancingBySeconds: 0),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(operationName: "timed.op", startTime: deviceStartDate)
         span.finish(at: deviceStartDate.addingTimeInterval(0.5))
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.startTime, 1_000_000_000_000, "Snapshot must use device-local start time, not server-adjusted")
 
         // Sanity check: the uploaded SpanEvent applies the offset, confirming the
@@ -480,39 +444,37 @@ class SpanSnapshotTests: XCTestCase {
         // regardless of any `span.type` tag. The snapshot must match so stats and
         // uploads agree on the type dimension.
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
             spanEventBuilder: .mockWith(eventsMapper: { event in
                 var mapped = event
                 mapped.tags["span.type"] = "http"
                 return mapped
-            })
+            }),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(operationName: "http.request")
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         XCTAssertEqual(snapshot.type, "custom", "Snapshot type must match the encoder's hardcoded value")
     }
 
     func testSnapshotMatchesUploadedSpanEvent_whenMapperRewritesResource() throws {
         // The strongest guarantee: snapshot and uploaded trace agree on resource name post-mapper.
         let core = PassthroughCoreMock()
+        let capture = SpanSnapshotCapture()
         let tracer: DatadogTracer = .mockWith(
             core: core,
             spanEventBuilder: .mockWith(eventsMapper: { event in
                 var mapped = event
                 mapped.resource = "GET /users/{id}/profile"
                 return mapped
-            })
+            }),
+            onSpanFinished: capture.capture
         )
-
-        var capturedSnapshot: SpanSnapshot?
-        tracer.onSpanFinished = { capturedSnapshot = $0 }
 
         let span = tracer.startSpan(
             operationName: "network.request",
@@ -520,7 +482,7 @@ class SpanSnapshotTests: XCTestCase {
         )
         span.finish()
 
-        let snapshot = try XCTUnwrap(capturedSnapshot)
+        let snapshot = try XCTUnwrap(capture.snapshot)
         let envelopes: [SpanEventsEnvelope] = core.events()
         let uploadedSpan = try XCTUnwrap(envelopes.first?.spans.first)
 

--- a/DatadogTrace/Tests/Utils/Casting+Tracing.swift
+++ b/DatadogTrace/Tests/Utils/Casting+Tracing.swift
@@ -25,3 +25,13 @@ internal extension OTSpan {
 internal extension OTSpanContext {
     var dd: DDSpanContext { self as! DDSpanContext }
 }
+
+final class SpanSnapshotCapture: @unchecked Sendable {
+    private(set) var snapshots: [SpanSnapshot] = []
+
+    var snapshot: SpanSnapshot? { snapshots.last }
+
+    func capture(_ snapshot: SpanSnapshot) {
+        snapshots.append(snapshot)
+    }
+}

--- a/TestUtilities/Sources/Mocks/DatadogTrace/TracingFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogTrace/TracingFeatureMocks.swift
@@ -107,7 +107,8 @@ extension DatadogTracer {
         spanIDGenerator: SpanIDGenerator = DefaultSpanIDGenerator(),
         dateProvider: DateProvider = SystemDateProvider(),
         spanEventBuilder: SpanEventBuilder = .mockAny(),
-        loggingIntegration: TracingWithLoggingIntegration = .mockAny()
+        loggingIntegration: TracingWithLoggingIntegration = .mockAny(),
+        onSpanFinished: (@Sendable (SpanSnapshot) -> Void)? = nil
     ) -> DatadogTracer {
         return DatadogTracer(
             core: core,
@@ -117,7 +118,8 @@ extension DatadogTracer {
             spanIDGenerator: spanIDGenerator,
             dateProvider: dateProvider,
             loggingIntegration: loggingIntegration,
-            spanEventBuilder: spanEventBuilder
+            spanEventBuilder: spanEventBuilder,
+            onSpanFinished: onSpanFinished
         )
     }
 
@@ -129,7 +131,8 @@ extension DatadogTracer {
         spanIDGenerator: SpanIDGenerator = DefaultSpanIDGenerator(),
         dateProvider: DateProvider = SystemDateProvider(),
         spanEventBuilder: SpanEventBuilder = .mockAny(),
-        loggingIntegration: TracingWithLoggingIntegration = .mockAny()
+        loggingIntegration: TracingWithLoggingIntegration = .mockAny(),
+        onSpanFinished: (@Sendable (SpanSnapshot) -> Void)? = nil
     ) -> DatadogTracer {
         return DatadogTracer(
             featureScope: featureScope,
@@ -139,7 +142,8 @@ extension DatadogTracer {
             spanIDGenerator: spanIDGenerator,
             dateProvider: dateProvider,
             loggingIntegration: loggingIntegration,
-            spanEventBuilder: spanEventBuilder
+            spanEventBuilder: spanEventBuilder,
+            onSpanFinished: onSpanFinished
         )
     }
 }


### PR DESCRIPTION
## Problem
API Surface Verify and SPI Docs Build fail when compiling DatadogTrace under Swift 6. `DatadogTracer` conforms to the `Sendable`-based tracer protocols and stores its mutable callback behind `ReadWriteLock`, but the explicit unchecked conformance was missing.

## Fix
Restore `@unchecked Sendable` on `DatadogTracer`, matching the existing locking pattern used by other shared mutable SDK types.

## Verification
- `make api-surface-verify` passes locally
- Focused tests could not start locally because `Carthage/Build/OpenTelemetryApi.xcframework` is unavailable