### PR TITLE
RUM-17782 Add missing launchInfo.appStateAtSdkInit key to Session Ended metrics.

### DIFF
--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -409,6 +409,7 @@ internal class SessionEndedMetric {
                 case timeToSdkInit = "tt_sdk_init"
                 case timeToDidBecomeActive = "tt_become_active"
                 case hasScenesLifecycle = "has_scenes_lifecycle"
+                case appStateAtSdkInit = "app_state_at_sdk_init"
             }
         }
 

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -760,6 +760,13 @@ class SessionEndedMetricTests: XCTestCase {
         XCTAssertNotNil(try matcher.value("rse.no_view_events_count.errors") as Int)
         XCTAssertNotNil(try matcher.value("rse.no_view_events_count.long_tasks") as Int)
         XCTAssertNotNil(try matcher.value("rse.upload_quality.feature.cycle_count") as Int)
+        XCTAssertNotNil(try matcher.value("rse.launch_info.launch_reason") as String)
+        XCTAssertNotNil(try matcher.value("rse.launch_info.task_role") as String)
+        XCTAssertNotNil(try matcher.value("rse.launch_info.prewarmed") as Bool)
+        XCTAssertNotNil(try matcher.value("rse.launch_info.tt_sdk_init") as Int)
+        XCTAssertNotNil(try matcher.value("rse.launch_info.tt_become_active") as Int)
+        XCTAssertNotNil(try matcher.value("rse.launch_info.has_scenes_lifecycle") as Bool)
+        XCTAssertNotNil(try matcher.value("rse.launch_info.app_state_at_sdk_init") as String)
     }
 }
 


### PR DESCRIPTION
### What and why?

In `SessionEndedMetric.Attributes.LaunchInfo` the `CodingKey` for `appStateAtSdkInit` was missing.

### How?

Adds the coding key, and tests.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
