### PR TITLE
[PANA-8388] Add embedded content wireframe model support

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRLayerSnapshotTests/Utils/WireframeView.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRLayerSnapshotTests/Utils/WireframeView.swift
@@ -54,6 +54,8 @@ internal final class WireframeView: UIView {
             return PlaceholderWireframeView(wireframe, frame: bounds)
         case .webviewWireframe(let wireframe):
             return WebViewWireframeView(wireframe, frame: bounds)
+        case .embeddedContentWireframe(let wireframe):
+            return EmbeddedContentWireframeView(wireframe, frame: bounds)
         }
     }
 }
@@ -217,6 +219,33 @@ private final class WebViewWireframeView: UIView {
 }
 
 @available(iOS 13.0, *)
+@MainActor
+private final class EmbeddedContentWireframeView: UIView {
+    init?(_ wireframe: SREmbeddedContentWireframe, frame: CGRect) {
+        guard wireframe.isVisible != false else {
+            return nil
+        }
+
+        super.init(frame: frame)
+        backgroundColor = .clear
+        applyWireframeShapeStyle(wireframe.shapeStyle, border: wireframe.border)
+
+        let label = UILabel(frame: bounds)
+        label.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        label.text = "Embedded Content"
+        label.textAlignment = .center
+        label.textColor = .black
+        label.font = .systemFont(ofSize: 24)
+        addSubview(label)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@available(iOS 13.0, *)
 private extension SRWireframe {
     var absoluteFrame: CGRect {
         switch self {
@@ -225,6 +254,7 @@ private extension SRWireframe {
         case .imageWireframe(let value): value.absoluteFrame
         case .placeholderWireframe(let value): value.absoluteFrame
         case .webviewWireframe(let value): value.absoluteFrame
+        case .embeddedContentWireframe(let value): value.absoluteFrame
         }
     }
 }
@@ -277,6 +307,13 @@ private extension SRPlaceholderWireframe {
 
 @available(iOS 13.0, *)
 private extension SRWebviewWireframe {
+    var absoluteFrame: CGRect {
+        CGRect(x: CGFloat(x), y: CGFloat(y), width: CGFloat(width), height: CGFloat(height))
+    }
+}
+
+@available(iOS 13.0, *)
+private extension SREmbeddedContentWireframe {
     var absoluteFrame: CGRect {
         CGRect(x: CGFloat(x), y: CGFloat(y), width: CGFloat(width), height: CGFloat(height))
     }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
@@ -72,6 +72,8 @@ private extension SRWireframe {
             return placeholder.toFrame()
         case .webviewWireframe(value: let webview):
             return webview.toFrame()
+        case .embeddedContentWireframe(value: let embeddedContent):
+            return embeddedContent.toFrame()
         }
     }
 }
@@ -146,6 +148,28 @@ private extension SRWebviewWireframe {
             clip: clip,
             content: .init(
                 text: "WKWebView",
+                textStyle: nil,
+                textPosition: SRTextPosition(
+                    alignment: SRTextPosition.Alignment(horizontal: .center, vertical: .center),
+                    padding: nil
+                )
+            )
+        )
+    }
+}
+
+private extension SREmbeddedContentWireframe {
+    func toFrame() -> BlueprintFrame {
+        BlueprintFrame(
+            x: x,
+            y: y,
+            width: width,
+            height: height,
+            border: border,
+            style: shapeStyle,
+            clip: clip,
+            content: .init(
+                text: "Embedded Content",
                 textStyle: nil,
                 textPosition: SRTextPosition(
                     alignment: SRTextPosition.Alignment(horizontal: .center, vertical: .center),

--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -649,6 +649,101 @@ public struct SRContentClip: Codable, Hashable {
     }
 }
 
+/// Schema of all properties of an EmbeddedContentWireframe.
+@_spi(Internal)
+public struct SREmbeddedContentWireframe: Codable, Hashable {
+    /// The border properties of this wireframe. The default value is null (no-border).
+    public let border: SRShapeBorder?
+
+    /// Schema of clipping information for a Wireframe.
+    public let clip: SRContentClip?
+
+    /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+    public let height: Int64
+
+    /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+    public let id: Int64
+
+    /// Whether this embedded content is visible or not.
+    public let isVisible: Bool?
+
+    /// A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
+    public let permanentId: String?
+
+    /// The style of this wireframe.
+    public let shapeStyle: SRShapeStyle?
+
+    /// Unique Id of the slot containing this embedded content.
+    public let slotId: String
+
+    /// The type of the wireframe.
+    public let type: String = "embedded_content"
+
+    /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+    public let width: Int64
+
+    /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let x: Int64
+
+    /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public let y: Int64
+
+    public enum CodingKeys: String, CodingKey {
+        case border = "border"
+        case clip = "clip"
+        case height = "height"
+        case id = "id"
+        case isVisible = "isVisible"
+        case permanentId = "permanentId"
+        case shapeStyle = "shapeStyle"
+        case slotId = "slotId"
+        case type = "type"
+        case width = "width"
+        case x = "x"
+        case y = "y"
+    }
+
+    /// Schema of all properties of an EmbeddedContentWireframe.
+    ///
+    /// - Parameters:
+    ///   - border: The border properties of this wireframe. The default value is null (no-border).
+    ///   - clip: Schema of clipping information for a Wireframe.
+    ///   - height: The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+    ///   - id: Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+    ///   - isVisible: Whether this embedded content is visible or not.
+    ///   - permanentId: A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.
+    ///   - shapeStyle: The style of this wireframe.
+    ///   - slotId: Unique Id of the slot containing this embedded content.
+    ///   - width: The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+    ///   - x: The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    ///   - y: The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+    public init(
+        border: SRShapeBorder? = nil,
+        clip: SRContentClip? = nil,
+        height: Int64,
+        id: Int64,
+        isVisible: Bool? = nil,
+        permanentId: String? = nil,
+        shapeStyle: SRShapeStyle? = nil,
+        slotId: String,
+        width: Int64,
+        x: Int64,
+        y: Int64
+    ) {
+        self.border = border
+        self.clip = clip
+        self.height = height
+        self.id = id
+        self.isVisible = isVisible
+        self.permanentId = permanentId
+        self.shapeStyle = shapeStyle
+        self.slotId = slotId
+        self.width = width
+        self.x = x
+        self.y = y
+    }
+}
+
 /// Schema of a Record type which contains focus information.
 @_spi(Internal)
 public struct SRFocusRecord: Codable {
@@ -711,6 +806,9 @@ public struct SRFocusRecord: Codable {
 public struct SRFullSnapshotRecord: Codable {
     public let data: Data
 
+    /// Unique ID of the slot that generated this record.
+    public let slotId: String?
+
     /// Defines the UTC time in milliseconds when this Record was performed.
     public let timestamp: Int64
 
@@ -719,6 +817,7 @@ public struct SRFullSnapshotRecord: Codable {
 
     public enum CodingKeys: String, CodingKey {
         case data = "data"
+        case slotId = "slotId"
         case timestamp = "timestamp"
         case type = "type"
     }
@@ -727,12 +826,15 @@ public struct SRFullSnapshotRecord: Codable {
     ///
     /// - Parameters:
     ///   - data:
+    ///   - slotId: Unique ID of the slot that generated this record.
     ///   - timestamp: Defines the UTC time in milliseconds when this Record was performed.
     public init(
         data: Data,
+        slotId: String? = nil,
         timestamp: Int64
     ) {
         self.data = data
+        self.slotId = slotId
         self.timestamp = timestamp
     }
 
@@ -878,6 +980,9 @@ public struct SRIncrementalSnapshotRecord: Codable {
     /// Mobile-specific. Schema of a Session Replay IncrementalData type.
     public let data: Data
 
+    /// Unique ID of the slot that generated this record.
+    public let slotId: String?
+
     /// Defines the UTC time in milliseconds when this Record was performed.
     public let timestamp: Int64
 
@@ -886,6 +991,7 @@ public struct SRIncrementalSnapshotRecord: Codable {
 
     public enum CodingKeys: String, CodingKey {
         case data = "data"
+        case slotId = "slotId"
         case timestamp = "timestamp"
         case type = "type"
     }
@@ -894,12 +1000,15 @@ public struct SRIncrementalSnapshotRecord: Codable {
     ///
     /// - Parameters:
     ///   - data: Mobile-specific. Schema of a Session Replay IncrementalData type.
+    ///   - slotId: Unique ID of the slot that generated this record.
     ///   - timestamp: Defines the UTC time in milliseconds when this Record was performed.
     public init(
         data: Data,
+        slotId: String? = nil,
         timestamp: Int64
     ) {
         self.data = data
+        self.slotId = slotId
         self.timestamp = timestamp
     }
 
@@ -1060,6 +1169,11 @@ public struct SRIncrementalSnapshotRecord: Codable {
                 case imageWireframeUpdate(value: ImageWireframeUpdate)
                 case placeholderWireframeUpdate(value: PlaceholderWireframeUpdate)
                 case webviewWireframeUpdate(value: WebviewWireframeUpdate)
+                case embeddedContentWireframeUpdate(value: EmbeddedContentWireframeUpdate)
+
+                private enum DiscriminatorCodingKeys: String, CodingKey {
+                    case discriminator = "type"
+                }
 
                 // MARK: - Codable
 
@@ -1078,41 +1192,45 @@ public struct SRIncrementalSnapshotRecord: Codable {
                         try container.encode(value)
                     case .webviewWireframeUpdate(let value):
                         try container.encode(value)
+                    case .embeddedContentWireframeUpdate(let value):
+                        try container.encode(value)
                     }
                 }
 
                 public init(from decoder: Decoder) throws {
-                    // Decode enum case from associated value
+                    // Decode enum case from discriminator
                     let container = try decoder.singleValueContainer()
+                    let discriminatorContainer = try decoder.container(keyedBy: DiscriminatorCodingKeys.self)
 
-                    if let value = try? container.decode(TextWireframeUpdate.self) {
-                        self = .textWireframeUpdate(value: value)
+                    switch try discriminatorContainer.decode(String.self, forKey: .discriminator) {
+                    case "text":
+                        self = .textWireframeUpdate(value: try container.decode(TextWireframeUpdate.self))
                         return
-                    }
-                    if let value = try? container.decode(ShapeWireframeUpdate.self) {
-                        self = .shapeWireframeUpdate(value: value)
+                    case "shape":
+                        self = .shapeWireframeUpdate(value: try container.decode(ShapeWireframeUpdate.self))
                         return
-                    }
-                    if let value = try? container.decode(ImageWireframeUpdate.self) {
-                        self = .imageWireframeUpdate(value: value)
+                    case "image":
+                        self = .imageWireframeUpdate(value: try container.decode(ImageWireframeUpdate.self))
                         return
-                    }
-                    if let value = try? container.decode(PlaceholderWireframeUpdate.self) {
-                        self = .placeholderWireframeUpdate(value: value)
+                    case "placeholder":
+                        self = .placeholderWireframeUpdate(value: try container.decode(PlaceholderWireframeUpdate.self))
                         return
-                    }
-                    if let value = try? container.decode(WebviewWireframeUpdate.self) {
-                        self = .webviewWireframeUpdate(value: value)
+                    case "webview":
+                        self = .webviewWireframeUpdate(value: try container.decode(WebviewWireframeUpdate.self))
                         return
+                    case "embedded_content":
+                        self = .embeddedContentWireframeUpdate(value: try container.decode(EmbeddedContentWireframeUpdate.self))
+                        return
+                    default:
+                        let error = DecodingError.Context(
+                            codingPath: discriminatorContainer.codingPath + [DiscriminatorCodingKeys.discriminator],
+                            debugDescription: """
+                            Failed to decode `Updates`.
+                            Discriminator `type` did not match any known case.
+                            """
+                        )
+                        throw DecodingError.dataCorrupted(error)
                     }
-                    let error = DecodingError.Context(
-                        codingPath: container.codingPath,
-                        debugDescription: """
-                        Failed to decode `Updates`.
-                        Ran out of possibilities when trying to decode the value of associated type.
-                        """
-                    )
-                    throw DecodingError.typeMismatch(Updates.self, error)
                 }
 
                 /// Schema of all properties of a TextWireframeUpdate.
@@ -1513,6 +1631,94 @@ public struct SRIncrementalSnapshotRecord: Codable {
                     ///   - isVisible: Whether this webview is visible or not.
                     ///   - shapeStyle: The style of this wireframe.
                     ///   - slotId: Unique Id of the slot containing this webview.
+                    ///   - width: The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+                    ///   - x: The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+                    ///   - y: The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+                    public init(
+                        border: SRShapeBorder? = nil,
+                        clip: SRContentClip? = nil,
+                        height: Int64? = nil,
+                        id: Int64,
+                        isVisible: Bool? = nil,
+                        shapeStyle: SRShapeStyle? = nil,
+                        slotId: String,
+                        width: Int64? = nil,
+                        x: Int64? = nil,
+                        y: Int64? = nil
+                    ) {
+                        self.border = border
+                        self.clip = clip
+                        self.height = height
+                        self.id = id
+                        self.isVisible = isVisible
+                        self.shapeStyle = shapeStyle
+                        self.slotId = slotId
+                        self.width = width
+                        self.x = x
+                        self.y = y
+                    }
+                }
+
+                /// Schema of all properties of an EmbeddedContentWireframeUpdate.
+                @_spi(Internal)
+                public struct EmbeddedContentWireframeUpdate: Codable {
+                    /// The border properties of this wireframe. The default value is null (no-border).
+                    public let border: SRShapeBorder?
+
+                    /// Schema of clipping information for a Wireframe.
+                    public let clip: SRContentClip?
+
+                    /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+                    public let height: Int64?
+
+                    /// Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+                    public let id: Int64
+
+                    /// Whether this embedded content is visible or not.
+                    public let isVisible: Bool?
+
+                    /// The style of this wireframe.
+                    public let shapeStyle: SRShapeStyle?
+
+                    /// Unique Id of the slot containing this embedded content.
+                    public let slotId: String
+
+                    /// The type of the wireframe.
+                    public let type: String = "embedded_content"
+
+                    /// The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
+                    public let width: Int64?
+
+                    /// The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+                    public let x: Int64?
+
+                    /// The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
+                    public let y: Int64?
+
+                    public enum CodingKeys: String, CodingKey {
+                        case border = "border"
+                        case clip = "clip"
+                        case height = "height"
+                        case id = "id"
+                        case isVisible = "isVisible"
+                        case shapeStyle = "shapeStyle"
+                        case slotId = "slotId"
+                        case type = "type"
+                        case width = "width"
+                        case x = "x"
+                        case y = "y"
+                    }
+
+                    /// Schema of all properties of an EmbeddedContentWireframeUpdate.
+                    ///
+                    /// - Parameters:
+                    ///   - border: The border properties of this wireframe. The default value is null (no-border).
+                    ///   - clip: Schema of clipping information for a Wireframe.
+                    ///   - height: The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
+                    ///   - id: Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.
+                    ///   - isVisible: Whether this embedded content is visible or not.
+                    ///   - shapeStyle: The style of this wireframe.
+                    ///   - slotId: Unique Id of the slot containing this embedded content.
                     ///   - width: The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.
                     ///   - x: The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
                     ///   - y: The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.
@@ -2863,6 +3069,11 @@ public enum SRWireframe: Codable {
     case imageWireframe(value: SRImageWireframe)
     case placeholderWireframe(value: SRPlaceholderWireframe)
     case webviewWireframe(value: SRWebviewWireframe)
+    case embeddedContentWireframe(value: SREmbeddedContentWireframe)
+
+    private enum DiscriminatorCodingKeys: String, CodingKey {
+        case discriminator = "type"
+    }
 
     // MARK: - Codable
 
@@ -2881,42 +3092,46 @@ public enum SRWireframe: Codable {
             try container.encode(value)
         case .webviewWireframe(let value):
             try container.encode(value)
+        case .embeddedContentWireframe(let value):
+            try container.encode(value)
         }
     }
 
     public init(from decoder: Decoder) throws {
-        // Decode enum case from associated value
+        // Decode enum case from discriminator
         let container = try decoder.singleValueContainer()
+        let discriminatorContainer = try decoder.container(keyedBy: DiscriminatorCodingKeys.self)
 
-        if let value = try? container.decode(SRShapeWireframe.self) {
-            self = .shapeWireframe(value: value)
+        switch try discriminatorContainer.decode(String.self, forKey: .discriminator) {
+        case "shape":
+            self = .shapeWireframe(value: try container.decode(SRShapeWireframe.self))
             return
-        }
-        if let value = try? container.decode(SRTextWireframe.self) {
-            self = .textWireframe(value: value)
+        case "text":
+            self = .textWireframe(value: try container.decode(SRTextWireframe.self))
             return
-        }
-        if let value = try? container.decode(SRImageWireframe.self) {
-            self = .imageWireframe(value: value)
+        case "image":
+            self = .imageWireframe(value: try container.decode(SRImageWireframe.self))
             return
-        }
-        if let value = try? container.decode(SRPlaceholderWireframe.self) {
-            self = .placeholderWireframe(value: value)
+        case "placeholder":
+            self = .placeholderWireframe(value: try container.decode(SRPlaceholderWireframe.self))
             return
-        }
-        if let value = try? container.decode(SRWebviewWireframe.self) {
-            self = .webviewWireframe(value: value)
+        case "webview":
+            self = .webviewWireframe(value: try container.decode(SRWebviewWireframe.self))
             return
+        case "embedded_content":
+            self = .embeddedContentWireframe(value: try container.decode(SREmbeddedContentWireframe.self))
+            return
+        default:
+            let error = DecodingError.Context(
+                codingPath: discriminatorContainer.codingPath + [DiscriminatorCodingKeys.discriminator],
+                debugDescription: """
+                Failed to decode `SRWireframe`.
+                Discriminator `type` did not match any known case.
+                """
+            )
+            throw DecodingError.dataCorrupted(error)
         }
-        let error = DecodingError.Context(
-            codingPath: container.codingPath,
-            debugDescription: """
-            Failed to decode `SRWireframe`.
-            Ran out of possibilities when trying to decode the value of associated type.
-            """
-        )
-        throw DecodingError.typeMismatch(SRWireframe.self, error)
     }
 }
 #endif
-// Generated from https://github.com/DataDog/rum-events-format/tree/1886a75e6c9dbc2390d7a4d8fd0ac97aac5de100
+// Generated from https://github.com/DataDog/rum-events-format/tree/d2f86dff0df3336f9b942f680281bd0b6c4d2788

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -22,6 +22,8 @@ extension SRWireframe: Diffable {
             return wireframe.id
         case .webviewWireframe(let wireframe):
             return wireframe.id
+        case .embeddedContentWireframe(let wireframe):
+            return wireframe.id
         }
     }
 
@@ -36,6 +38,8 @@ extension SRWireframe: Diffable {
         case let (.placeholderWireframe(this), .placeholderWireframe(other)):
             return this.hashValue != other.hashValue
         case let (.webviewWireframe(this), .webviewWireframe(other)):
+            return this.hashValue != other.hashValue
+        case let (.embeddedContentWireframe(this), .embeddedContentWireframe(other)):
             return this.hashValue != other.hashValue
         default:
             return true
@@ -53,6 +57,8 @@ extension SRWireframe: Diffable {
         case let (.placeholderWireframe(value)):
             return value.type
         case let (.webviewWireframe(value)):
+            return value.type
+        case let (.embeddedContentWireframe(value)):
             return value.type
         }
     }
@@ -102,6 +108,8 @@ extension SRWireframe: MutableWireframe {
         case .placeholderWireframe(let this):
             return try this.mutations(from: otherWireframe)
         case .webviewWireframe(let this):
+            return try this.mutations(from: otherWireframe)
+        case .embeddedContentWireframe(let this):
             return try this.mutations(from: otherWireframe)
         }
     }
@@ -234,6 +242,35 @@ extension SRWebviewWireframe: MutableWireframe {
         }
 
         return .webviewWireframeUpdate(
+            value: .init(
+                border: use(border, ifDifferentThan: other.border),
+                clip: use(clip, ifDifferentThan: other.clip),
+                height: use(height, ifDifferentThan: other.height),
+                id: id,
+                isVisible: use(isVisible, ifDifferentThan: other.isVisible),
+                shapeStyle: use(shapeStyle, ifDifferentThan: other.shapeStyle),
+                slotId: slotId,
+                width: use(width, ifDifferentThan: other.width),
+                x: use(x, ifDifferentThan: other.x),
+                y: use(y, ifDifferentThan: other.y)
+            )
+        )
+    }
+}
+
+extension SREmbeddedContentWireframe: MutableWireframe {
+    func mutations(from otherWireframe: SRWireframe) throws -> WireframeMutation {
+        guard case .embeddedContentWireframe(let other) = otherWireframe else {
+            throw WireframeMutationError.typeMismatch(
+                fromType: otherWireframe.type,
+                toType: type
+            )
+        }
+        guard other.id == id, other.slotId == slotId else {
+            throw WireframeMutationError.idMismatch
+        }
+
+        return .embeddedContentWireframeUpdate(
             value: .init(
                 border: use(border, ifDifferentThan: other.border),
                 clip: use(clip, ifDifferentThan: other.clip),

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -20,7 +20,8 @@ class DiffSRWireframes: XCTestCase {
             .shapeWireframe(value: .mockWith(id: randomID)),
             .textWireframe(value: .mockWith(id: randomID)),
             .imageWireframe(value: .mockWith(id: randomID)),
-            .placeholderWireframe(value: .mockWith(id: randomID))
+            .placeholderWireframe(value: .mockWith(id: randomID)),
+            .embeddedContentWireframe(value: .mockWith(id: randomID))
         ]
 
         wireframes.forEach { XCTAssertEqual($0.id, randomID) }
@@ -86,6 +87,25 @@ class DiffSRWireframes: XCTestCase {
         DDAssertReflectionEqual(result, otherWireframe)
     }
 
+    func testsWhenMergingMutationsToTheOriginalEmbeddedContentWireframe_itShouldProduceTheOtherOne() throws {
+        // Given
+        let slotID: String = .mockRandom()
+        let permanentID: String = .mockRandom()
+        let originalWireframe: SRWireframe = .embeddedContentWireframe(
+            value: .mockWith(id: .mockRandom(), permanentId: permanentID, slotId: slotID)
+        )
+        let otherWireframe: SRWireframe = .embeddedContentWireframe(
+            value: .mockRandomWith(id: originalWireframe.id, slotId: slotID, permanentId: permanentID)
+        )
+
+        // When
+        let mutations = try XCTUnwrap(otherWireframe.mutations(from: originalWireframe), "Failed to compute mutations")
+
+        // Then
+        let result = try XCTUnwrap(originalWireframe.merge(mutation: mutations), "Failed to merge mutations")
+        DDAssertReflectionEqual(result, otherWireframe)
+    }
+
     func testWhenComputingMutationsForWireframesWithDifferentID_itThrows() throws {
         let randomID: WireframeID = .mockRandom()
         let otherID: WireframeID = .mockRandom(otherThan: [randomID])
@@ -94,6 +114,7 @@ class DiffSRWireframes: XCTestCase {
         let wireframes: [(SRWireframe, SRWireframe)] = [
             (.shapeWireframe(value: .mockRandomWith(id: randomID)), .shapeWireframe(value: .mockRandomWith(id: otherID))),
             (.textWireframe(value: .mockRandomWith(id: randomID)), .textWireframe(value: .mockRandomWith(id: otherID))),
+            (.embeddedContentWireframe(value: .mockRandomWith(id: randomID)), .embeddedContentWireframe(value: .mockRandomWith(id: otherID))),
         ]
 
         // When
@@ -112,6 +133,7 @@ class DiffSRWireframes: XCTestCase {
         let wireframes: [(SRWireframe, SRWireframe)] = [
             (.shapeWireframe(value: .mockRandomWith(id: randomID)), .textWireframe(value: .mockRandomWith(id: randomID))),
             (.textWireframe(value: .mockRandomWith(id: randomID)), .shapeWireframe(value: .mockRandomWith(id: randomID))),
+            (.embeddedContentWireframe(value: .mockRandomWith(id: randomID)), .shapeWireframe(value: .mockRandomWith(id: randomID))),
         ]
 
         // When
@@ -126,6 +148,20 @@ class DiffSRWireframes: XCTestCase {
                     )
                 )
             }
+        }
+    }
+
+    func testWhenComputingMutationsForEmbeddedContentWireframesWithDifferentSlotID_itThrows() throws {
+        let randomID: WireframeID = .mockRandom()
+
+        // Given
+        let wireframeA: SRWireframe = .embeddedContentWireframe(value: .mockWith(id: randomID, slotId: "slot-a"))
+        let wireframeB: SRWireframe = .embeddedContentWireframe(value: .mockWith(id: randomID, slotId: "slot-b"))
+
+        // When
+        XCTAssertThrowsError(try wireframeB.mutations(from: wireframeA)) { error in
+            // Then
+            XCTAssertEqual(error as? WireframeMutationError, WireframeMutationError.idMismatch)
         }
     }
 
@@ -221,6 +257,7 @@ private typealias TextWireframeUpdate = SRIncrementalSnapshotRecord.Data.Mutatio
 private typealias ShapeWireframeUpdate = SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUpdate
 private typealias ImageWireframeUpdate = SRIncrementalSnapshotRecord.Data.MutationData.Updates.ImageWireframeUpdate
 private typealias PlaceholderWireframeUpdate = SRIncrementalSnapshotRecord.Data.MutationData.Updates.PlaceholderWireframeUpdate
+private typealias EmbeddedContentWireframeUpdate = SRIncrementalSnapshotRecord.Data.MutationData.Updates.EmbeddedContentWireframeUpdate
 
 extension SRWireframe {
     func merge(mutation: WireframeMutation) -> SRWireframe? {
@@ -233,6 +270,8 @@ extension SRWireframe {
             return .imageWireframe(value: merge(update: update, into: wireframe))
         case let (.placeholderWireframe(wireframe), .placeholderWireframeUpdate(update)):
             return .placeholderWireframe(value: merge(update: update, into: wireframe))
+        case let (.embeddedContentWireframe(wireframe), .embeddedContentWireframeUpdate(update)):
+            return .embeddedContentWireframe(value: merge(update: update, into: wireframe))
         default:
             return nil
         }
@@ -290,6 +329,22 @@ extension SRWireframe {
             height: update.height ?? wireframe.height,
             id: update.id,
             label: update.label ?? wireframe.label,
+            width: update.width ?? wireframe.width,
+            x: update.x ?? wireframe.x,
+            y: update.y ?? wireframe.y
+        )
+    }
+
+    private func merge(update: EmbeddedContentWireframeUpdate, into wireframe: SREmbeddedContentWireframe) -> SREmbeddedContentWireframe {
+        return SREmbeddedContentWireframe(
+            border: update.border ?? wireframe.border,
+            clip: update.clip ?? wireframe.clip,
+            height: update.height ?? wireframe.height,
+            id: update.id,
+            isVisible: update.isVisible ?? wireframe.isVisible,
+            permanentId: wireframe.permanentId,
+            shapeStyle: update.shapeStyle ?? wireframe.shapeStyle,
+            slotId: update.slotId,
             width: update.width ?? wireframe.width,
             x: update.x ?? wireframe.x,
             y: update.y ?? wireframe.y

--- a/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SnapshotProcessorTests.swift
@@ -644,6 +644,8 @@ extension SRWireframe {
             return value.permanentId
         case .webviewWireframe(let value):
             return value.permanentId
+        case .embeddedContentWireframe(let value):
+            return value.permanentId
         }
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
@@ -240,6 +240,7 @@ struct HeatmapIdentifierComputationTests {
             case .imageWireframe(let value): return value.permanentId
             case .placeholderWireframe(let value): return value.permanentId
             case .webviewWireframe(let value): return value.permanentId
+            case .embeddedContentWireframe(let value): return value.permanentId
             }
         }
         #expect(permanentId == "abc123")
@@ -295,6 +296,7 @@ struct HeatmapIdentifierComputationTests {
             case .imageWireframe(let value): return value.permanentId
             case .placeholderWireframe(let value): return value.permanentId
             case .webviewWireframe(let value): return value.permanentId
+            case .embeddedContentWireframe(let value): return value.permanentId
             }
         }
         #expect(permanentId == nil)

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/SRDataModelsMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/SRDataModelsMocks.swift
@@ -366,6 +366,71 @@ extension SRPlaceholderWireframe: AnyMockable, RandomMockable {
     }
 }
 
+extension SREmbeddedContentWireframe: AnyMockable, RandomMockable {
+    public static func mockAny() -> SREmbeddedContentWireframe {
+        return .mockWith()
+    }
+
+    public static func mockRandom() -> SREmbeddedContentWireframe {
+        return .mockRandomWith(id: .mockRandom())
+    }
+
+    @_spi(Internal)
+    public static func mockRandomWith(id: WireframeID) -> SREmbeddedContentWireframe {
+        return .mockRandomWith(id: id, slotId: .mockRandom())
+    }
+
+    @_spi(Internal)
+    public static func mockRandomWith(id: WireframeID, slotId: String) -> SREmbeddedContentWireframe {
+        return .mockRandomWith(id: id, slotId: slotId, permanentId: .mockRandom())
+    }
+
+    @_spi(Internal)
+    public static func mockRandomWith(id: WireframeID, slotId: String, permanentId: String?) -> SREmbeddedContentWireframe {
+        return SREmbeddedContentWireframe(
+            border: .mockRandom(),
+            clip: .mockRandom(),
+            height: .mockRandom(),
+            id: id,
+            isVisible: .mockRandom(),
+            permanentId: permanentId,
+            shapeStyle: .mockRandom(),
+            slotId: slotId,
+            width: .mockRandom(),
+            x: .mockRandom(),
+            y: .mockRandom()
+        )
+    }
+
+    public static func mockWith(
+        border: SRShapeBorder? = .mockAny(),
+        clip: SRContentClip? = .mockAny(),
+        height: Int64 = .mockAny(),
+        id: Int64 = .mockAny(),
+        isVisible: Bool? = .mockAny(),
+        permanentId: String? = .mockAny(),
+        shapeStyle: SRShapeStyle? = .mockAny(),
+        slotId: String = .mockAny(),
+        width: Int64 = .mockAny(),
+        x: Int64 = .mockAny(),
+        y: Int64 = .mockAny()
+    ) -> SREmbeddedContentWireframe {
+        return SREmbeddedContentWireframe(
+            border: border,
+            clip: clip,
+            height: height,
+            id: id,
+            isVisible: isVisible,
+            permanentId: permanentId,
+            shapeStyle: shapeStyle,
+            slotId: slotId,
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
 extension SRImageWireframe: AnyMockable, RandomMockable {
     public static func mockAny() -> SRImageWireframe {
         return SRImageWireframe(

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -770,6 +770,33 @@ public struct SRContentClip: Codable, Hashable
         case right = "right"
         case top = "top"
     public init(bottom: Int64? = nil,left: Int64? = nil,right: Int64? = nil,top: Int64? = nil)
+public struct SREmbeddedContentWireframe: Codable, Hashable
+    public let border: SRShapeBorder?
+    public let clip: SRContentClip?
+    public let height: Int64
+    public let id: Int64
+    public let isVisible: Bool?
+    public let permanentId: String?
+    public let shapeStyle: SRShapeStyle?
+    public let slotId: String
+    public let type: String = "embedded_content"
+    public let width: Int64
+    public let x: Int64
+    public let y: Int64
+    public enum CodingKeys: String, CodingKey
+        case border = "border"
+        case clip = "clip"
+        case height = "height"
+        case id = "id"
+        case isVisible = "isVisible"
+        case permanentId = "permanentId"
+        case shapeStyle = "shapeStyle"
+        case slotId = "slotId"
+        case type = "type"
+        case width = "width"
+        case x = "x"
+        case y = "y"
+    public init(border: SRShapeBorder? = nil,clip: SRContentClip? = nil,height: Int64,id: Int64,isVisible: Bool? = nil,permanentId: String? = nil,shapeStyle: SRShapeStyle? = nil,slotId: String,width: Int64,x: Int64,y: Int64)
 public struct SRFocusRecord: Codable
     public let data: Data
     public let slotId: String?
@@ -788,13 +815,15 @@ public struct SRFocusRecord: Codable
         public init(hasFocus: Bool)
 public struct SRFullSnapshotRecord: Codable
     public let data: Data
+    public let slotId: String?
     public let timestamp: Int64
     public let type: Int64 = 10
     public enum CodingKeys: String, CodingKey
         case data = "data"
+        case slotId = "slotId"
         case timestamp = "timestamp"
         case type = "type"
-    public init(data: Data,timestamp: Int64)
+    public init(data: Data,slotId: String? = nil,timestamp: Int64)
     public struct Data: Codable
         public let compositionTree: SRCompositionTree?
         public let wireframes: [SRWireframe]
@@ -835,13 +864,15 @@ public struct SRImageWireframe: Codable, Hashable
     public init(base64: String? = nil,border: SRShapeBorder? = nil,clip: SRContentClip? = nil,height: Int64,id: Int64,isEmpty: Bool? = nil,mimeType: String? = nil,permanentId: String? = nil,resourceId: String? = nil,shapeStyle: SRShapeStyle? = nil,width: Int64,x: Int64,y: Int64)
 public struct SRIncrementalSnapshotRecord: Codable
     public let data: Data
+    public let slotId: String?
     public let timestamp: Int64
     public let type: Int64 = 11
     public enum CodingKeys: String, CodingKey
         case data = "data"
+        case slotId = "slotId"
         case timestamp = "timestamp"
         case type = "type"
-    public init(data: Data,timestamp: Int64)
+    public init(data: Data,slotId: String? = nil,timestamp: Int64)
     public enum Data: Codable
         case mutationData(value: MutationData)
         case touchData(value: TouchData)
@@ -879,6 +910,7 @@ public struct SRIncrementalSnapshotRecord: Codable
                 case imageWireframeUpdate(value: ImageWireframeUpdate)
                 case placeholderWireframeUpdate(value: PlaceholderWireframeUpdate)
                 case webviewWireframeUpdate(value: WebviewWireframeUpdate)
+                case embeddedContentWireframeUpdate(value: EmbeddedContentWireframeUpdate)
                 public func encode(to encoder: Encoder) throws
                 public init(from decoder: Decoder) throws
                 public struct TextWireframeUpdate: Codable
@@ -986,6 +1018,31 @@ public struct SRIncrementalSnapshotRecord: Codable
                     public let shapeStyle: SRShapeStyle?
                     public let slotId: String
                     public let type: String = "webview"
+                    public let width: Int64?
+                    public let x: Int64?
+                    public let y: Int64?
+                    public enum CodingKeys: String, CodingKey
+                        case border = "border"
+                        case clip = "clip"
+                        case height = "height"
+                        case id = "id"
+                        case isVisible = "isVisible"
+                        case shapeStyle = "shapeStyle"
+                        case slotId = "slotId"
+                        case type = "type"
+                        case width = "width"
+                        case x = "x"
+                        case y = "y"
+                    public init(border: SRShapeBorder? = nil,clip: SRContentClip? = nil,height: Int64? = nil,id: Int64,isVisible: Bool? = nil,shapeStyle: SRShapeStyle? = nil,slotId: String,width: Int64? = nil,x: Int64? = nil,y: Int64? = nil)
+                public struct EmbeddedContentWireframeUpdate: Codable
+                    public let border: SRShapeBorder?
+                    public let clip: SRContentClip?
+                    public let height: Int64?
+                    public let id: Int64
+                    public let isVisible: Bool?
+                    public let shapeStyle: SRShapeStyle?
+                    public let slotId: String
+                    public let type: String = "embedded_content"
                     public let width: Int64?
                     public let x: Int64?
                     public let y: Int64?
@@ -1365,6 +1422,7 @@ public enum SRWireframe: Codable
     case imageWireframe(value: SRImageWireframe)
     case placeholderWireframe(value: SRPlaceholderWireframe)
     case webviewWireframe(value: SRWebviewWireframe)
+    case embeddedContentWireframe(value: SREmbeddedContentWireframe)
     public func encode(to encoder: Encoder) throws
     public init(from decoder: Decoder) throws
 public typealias WireframeID = NodeID

--- a/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
@@ -23,6 +23,7 @@ public class SRCodeDecorator: SwiftCodeDecorator {
                 "SRImageWireframe",
                 "SRPlaceholderWireframe",
                 "SRWebviewWireframe",
+                "SREmbeddedContentWireframe",
                 // For convenience, make fat `*Record` structures to be root types:
                 "SRFullSnapshotRecord",
                 "SRIncrementalSnapshotRecord",
@@ -97,6 +98,14 @@ public class SRCodeDecorator: SwiftCodeDecorator {
 
     override public func transform(associatedTypeEnum: SwiftAssociatedTypeEnum) throws -> SwiftAssociatedTypeEnum {
         var transformed = try super.transform(associatedTypeEnum: associatedTypeEnum)
+
+        if transformed.name == "SRWireframe" {
+            transformed = addDiscriminator("type", to: transformed, basedOn: associatedTypeEnum)
+        }
+
+        if transformed.name == "Updates", canAddDiscriminator("type", to: associatedTypeEnum) {
+            transformed = addDiscriminator("type", to: transformed, basedOn: associatedTypeEnum)
+        }
 
         if transformed.name == "SRCompositionLayerModifier" {
             transformed = addDiscriminator("type", to: transformed, basedOn: associatedTypeEnum)
@@ -254,6 +263,12 @@ public class SRCodeDecorator: SwiftCodeDecorator {
             }
             return value == codingKey
         }?.defaultValue
+    }
+
+    private func canAddDiscriminator(_ codingKey: String, to associatedTypeEnum: SwiftAssociatedTypeEnum) -> Bool {
+        !associatedTypeEnum.cases.isEmpty && associatedTypeEnum.cases.allSatisfy {
+            discriminatorValue(for: codingKey, in: $0.associatedType) != nil
+        }
     }
 }
 

--- a/tools/rum-models-generator/Tests/rum-models-generatorTests/SRCodeDecoratorTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generatorTests/SRCodeDecoratorTests.swift
@@ -9,6 +9,110 @@ import XCTest
 @testable import CodeDecoration
 
 final class SRCodeDecoratorTests: XCTestCase {
+    func testDecoratingWireframeSharedTypesAndDiscriminator() throws {
+        let wireframe = SwiftAssociatedTypeEnum(
+            name: "Wireframes",
+            comment: nil,
+            cases: [
+                SwiftAssociatedTypeEnum.Case(
+                    label: "ShapeWireframe",
+                    associatedType: Self.shapeWireframe(named: "ShapeWireframe")
+                ),
+                SwiftAssociatedTypeEnum.Case(
+                    label: "EmbeddedContentWireframe",
+                    associatedType: Self.embeddedContentWireframe(named: "EmbeddedContentWireframe")
+                )
+            ],
+            conformance: []
+        )
+
+        let actual = try SRCodeDecorator()
+            .decorate(code: GeneratedCode(swiftTypes: [wireframe]))
+
+        let typeNames = actual.swiftTypes.compactMap(\.typeName)
+        XCTAssertTrue(typeNames.contains("SRShapeWireframe"))
+        XCTAssertTrue(typeNames.contains("SREmbeddedContentWireframe"))
+        XCTAssertFalse(typeNames.contains("EmbeddedContentWireframe"))
+
+        let transformedWireframe = try XCTUnwrap(actual.swiftTypes.first { $0.typeName == "SRWireframe" } as? SwiftAssociatedTypeEnum)
+        XCTAssertEqual("type", transformedWireframe.discriminatorCodingKey)
+        XCTAssertEqual("shape", transformedWireframe.cases.first?.discriminatorValue as? String)
+        XCTAssertEqual("embedded_content", transformedWireframe.cases.dropFirst().first?.discriminatorValue as? String)
+        XCTAssertEqual(
+            "SREmbeddedContentWireframe",
+            (transformedWireframe.cases.dropFirst().first?.associatedType as? SwiftTypeReference)?.referencedTypeName
+        )
+    }
+
+    func testDecoratingWireframeUpdateMutationDiscriminator() throws {
+        let incrementalSnapshotRecord = SwiftStruct(
+            name: "MobileIncrementalSnapshotRecord",
+            comment: nil,
+            properties: [
+                Self.property(
+                    named: "data",
+                    type: SwiftAssociatedTypeEnum(
+                        name: "data",
+                        comment: nil,
+                        cases: [
+                            SwiftAssociatedTypeEnum.Case(
+                                label: "MutationData",
+                                associatedType: SwiftStruct(
+                                    name: "WireframeMutationData",
+                                    comment: nil,
+                                    properties: [
+                                        Self.property(
+                                            named: "source",
+                                            type: SwiftPrimitive<Int>(),
+                                            defaultValue: 2
+                                        ),
+                                        Self.property(
+                                            named: "updates",
+                                            type: SwiftArray(
+                                                element: SwiftAssociatedTypeEnum(
+                                                    name: "updates",
+                                                    comment: nil,
+                                                    cases: [
+                                                        SwiftAssociatedTypeEnum.Case(
+                                                            label: "WebviewWireframeUpdate",
+                                                            associatedType: Self.webviewWireframeUpdate()
+                                                        ),
+                                                        SwiftAssociatedTypeEnum.Case(
+                                                            label: "EmbeddedContentWireframeUpdate",
+                                                            associatedType: Self.embeddedContentWireframeUpdate()
+                                                        )
+                                                    ],
+                                                    conformance: []
+                                                )
+                                            )
+                                        )
+                                    ],
+                                    conformance: []
+                                )
+                            )
+                        ],
+                        conformance: []
+                    )
+                )
+            ],
+            conformance: []
+        )
+
+        let actual = try SRCodeDecorator()
+            .decorate(code: GeneratedCode(swiftTypes: [incrementalSnapshotRecord]))
+
+        let record = try XCTUnwrap(actual.swiftTypes.first { $0.typeName == "SRIncrementalSnapshotRecord" } as? SwiftStruct)
+        let data = try XCTUnwrap(record.properties.first { $0.name == "data" }?.type as? SwiftAssociatedTypeEnum)
+        let mutationData = try XCTUnwrap(data.cases.first?.associatedType as? SwiftStruct)
+        let updates = try XCTUnwrap(
+            (mutationData.properties.first { $0.name == "updates" }?.type as? SwiftArray)?.element as? SwiftAssociatedTypeEnum
+        )
+
+        XCTAssertEqual("type", updates.discriminatorCodingKey)
+        XCTAssertEqual("webview", updates.cases.first?.discriminatorValue as? String)
+        XCTAssertEqual("embedded_content", updates.cases.dropFirst().first?.discriminatorValue as? String)
+    }
+
     func testDecoratingShapeGradientSharedTypes() throws {
         let shapeWireframe = SwiftStruct(
             name: "ShapeWireframe",
@@ -239,6 +343,57 @@ final class SRCodeDecoratorTests: XCTestCase {
             mutability: .immutable,
             defaultValue: defaultValue,
             codingKey: .static(value: name)
+        )
+    }
+
+    private static func shapeWireframe(named name: String) -> SwiftStruct {
+        SwiftStruct(
+            name: name,
+            comment: nil,
+            properties: [
+                property(named: "id", type: SwiftPrimitive<Int>()),
+                property(named: "type", type: SwiftPrimitive<String>(), defaultValue: "shape")
+            ],
+            conformance: []
+        )
+    }
+
+    private static func embeddedContentWireframe(named name: String) -> SwiftStruct {
+        SwiftStruct(
+            name: name,
+            comment: nil,
+            properties: [
+                property(named: "id", type: SwiftPrimitive<Int>()),
+                property(named: "slotId", type: SwiftPrimitive<String>()),
+                property(named: "type", type: SwiftPrimitive<String>(), defaultValue: "embedded_content")
+            ],
+            conformance: []
+        )
+    }
+
+    private static func webviewWireframeUpdate() -> SwiftStruct {
+        SwiftStruct(
+            name: "WebviewWireframeUpdate",
+            comment: nil,
+            properties: [
+                property(named: "id", type: SwiftPrimitive<Int>()),
+                property(named: "slotId", type: SwiftPrimitive<String>()),
+                property(named: "type", type: SwiftPrimitive<String>(), defaultValue: "webview")
+            ],
+            conformance: []
+        )
+    }
+
+    private static func embeddedContentWireframeUpdate() -> SwiftStruct {
+        SwiftStruct(
+            name: "EmbeddedContentWireframeUpdate",
+            comment: nil,
+            properties: [
+                property(named: "id", type: SwiftPrimitive<Int>()),
+                property(named: "slotId", type: SwiftPrimitive<String>()),
+                property(named: "type", type: SwiftPrimitive<String>(), defaultValue: "embedded_content")
+            ],
+            conformance: []
         )
     }
 


### PR DESCRIPTION
### What and why?

Update Session Replay models with the latest schema changes in `rum-events-format`.

The main schema change is the new `embedded_content` wireframe. It generalizes the existing webview wireframe format so Session Replay payloads can represent embedded cross-platform SDK content. Flutter hybrid views are the first expected use case.

This PR is limited to model and infrastructure support. It does not add recording-time capture of embedded views.

### How?

The Session Replay models were regenerated from `rum-events-format` `master` commit `d2f86dff`.

The model generator now keeps `SREmbeddedContentWireframe` as a shared root model, like the other shared wireframe types.

The generator also decodes `SRWireframe` and wireframe update unions with the `type` discriminator. This is needed because `webview` and `embedded_content` have the same shape, so shape-based decoding is no longer reliable.

The SDK diffing code now handles embedded-content wireframes and produces embedded-content update mutations. It uses the same identity rule as webviews: both `id` and `slotId` must match.

Mocks, heatmap helpers, and snapshot rendering helpers were updated so tests can create and render the new generated enum case.

Capturing embedded-content wireframes is out of scope for this PR.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
