### PR TITLE
Send full view event every 5 updates under viewUpdates flag

### DIFF
--- a/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
@@ -75,6 +75,11 @@ internal extension RUMViewEvent {
         let duration: Int64?
         /// Index of the view within its session (0 for the first view).
         let indexInSession: Int?
+        /// `true` when this full event is a delta baseline under the `viewUpdates` feature flag — i.e. it is
+        /// followed by `RUMViewUpdateEvent` deltas computed against it. Unlike legacy full-event snapshots,
+        /// `RUMViewEventsFilter` must keep every such event rather than collapsing same-view duplicates,
+        /// since dropping one would leave its dependent deltas unreconstructable.
+        let isDeltaBaseline: Bool?
 
         private enum CodingKeys: String, CodingKey {
             case id = "id"
@@ -82,14 +87,16 @@ internal extension RUMViewEvent {
             case hasAccessibility = "has_accessibility"
             case duration = "duration"
             case indexInSession = "index"
+            case isDeltaBaseline = "is_delta_baseline"
         }
 
-        init(id: String, documentVersion: Int64, hasAccessibility: Bool? = false, duration: Int64? = nil, indexInSession: Int? = nil) {
+        init(id: String, documentVersion: Int64, hasAccessibility: Bool? = false, duration: Int64? = nil, indexInSession: Int? = nil, isDeltaBaseline: Bool? = false) {
             self.id = id
             self.documentVersion = documentVersion
             self.hasAccessibility = hasAccessibility
             self.duration = duration
             self.indexInSession = indexInSession
+            self.isDeltaBaseline = isDeltaBaseline
         }
     }
 
@@ -99,13 +106,14 @@ internal extension RUMViewEvent {
 
     /// Creates `Metadata` from the given `RUMViewEvent`.
     /// - Returns: The `Metadata` for the given `RUMViewEvent`.
-    func metadata(viewIndexInSession: Int) -> Metadata {
+    func metadata(viewIndexInSession: Int, isDeltaBaseline: Bool = false) -> Metadata {
         return Metadata(
             id: view.id,
             documentVersion: dd.documentVersion,
             hasAccessibility: view.accessibility != nil,
             duration: view.timeSpent,
-            indexInSession: viewIndexInSession
+            indexInSession: viewIndexInSession,
+            isDeltaBaseline: isDeltaBaseline
         )
     }
 }

--- a/DatadogRUM/Sources/Feature/RUMViewEventsFilter.swift
+++ b/DatadogRUM/Sources/Feature/RUMViewEventsFilter.swift
@@ -86,6 +86,13 @@ internal struct RUMViewEventsFilter {
             return .skipInitialOneNs
         }
 
+        if viewMetadata.isDeltaBaseline == true {
+            // This full event is a delta baseline: `RUMViewUpdateEvent` deltas in this batch were computed
+            // against it, so it must be kept even if a newer full event for the same view also appears in
+            // the batch — unlike legacy full-event snapshots, it is not redundant.
+            return .keep
+        }
+
         guard seen.contains(viewMetadata.id) == false else {
             // If we've already seen an update for this view, we can skip the next one.
             return .skipRedundant

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -14,6 +14,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         static let minimumTimeSpentForRates = 1.0 // 1s
         /// Minimum duration of a view (1ns). Prevents negative durations and serves as placeholder value assigned when view starts.
         static let minimumTimeSpent: TimeInterval = 1e-9 // 1ns
+        /// Maximum number of consecutive `RUMViewUpdateEvent` deltas sent for a view under the `viewUpdates`
+        /// feature flag before a full `RUMViewEvent` is sent again, so the view state can be fully reconstructed
+        /// even if some update events are lost in transit.
+        static let maxConsecutiveViewUpdates: UInt = 115
     }
 
     // MARK: - Child Scopes
@@ -109,6 +113,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// The last full view event sent through the mapper, stored for `viewUpdates` projection.
     /// `nil` until the first event is written; non-`nil` after that.
     private var lastSentViewEvent: RUMViewEvent?
+
+    /// Number of consecutive `RUMViewUpdateEvent` deltas sent since `lastSentViewEvent` was last a full event.
+    /// Reset to `0` whenever a full `RUMViewEvent` is sent.
+    private var consecutiveViewUpdatesCount: UInt = 0
 
     /// Whether or not the current call to `process(command:)` should trigger a `sendViewEvent()` with an update.
     /// It can be toggled from inside `RUMResourceScope`/`RUMUserActionScope` callbacks, as they are called from processing `RUMCommand`s inside `process()`.
@@ -679,9 +687,12 @@ extension RUMViewScope {
         )
 
         if let event = dependencies.eventBuilder.build(from: viewEvent) {
-            if dependencies.featureFlags[.viewUpdates], let previousEvent = lastSentViewEvent {
+            if dependencies.featureFlags[.viewUpdates],
+               let previousEvent = lastSentViewEvent,
+               consecutiveViewUpdatesCount < Constants.maxConsecutiveViewUpdates {
                 let update = previousEvent.update(from: event)
                 lastSentViewEvent = event
+                consecutiveViewUpdatesCount += 1
                 writer.write(value: update, completion: completionHandler)
             } else {
                 writer.write(
@@ -697,6 +708,7 @@ extension RUMViewScope {
                 if dependencies.featureFlags[.viewUpdates],
                    viewIndexInSession != 0 || event.view.timeSpent > Constants.minimumTimeSpent.dd.toInt64Nanoseconds {
                     lastSentViewEvent = event
+                    consecutiveViewUpdatesCount = 0
                 }
             }
 

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -697,7 +697,10 @@ extension RUMViewScope {
             } else {
                 writer.write(
                     value: event,
-                    metadata: event.metadata(viewIndexInSession: viewIndexInSession),
+                    metadata: event.metadata(
+                        viewIndexInSession: viewIndexInSession,
+                        isDeltaBaseline: dependencies.featureFlags[.viewUpdates]
+                    ),
                     completion: completionHandler
                 )
                 // Only promote to baseline if the event will not be dropped by RUMViewEventsFilter.

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -16,8 +16,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         static let minimumTimeSpent: TimeInterval = 1e-9 // 1ns
         /// Maximum number of consecutive `RUMViewUpdateEvent` deltas sent for a view under the `viewUpdates`
         /// feature flag before a full `RUMViewEvent` is sent again, so the view state can be fully reconstructed
-        /// even if some update events are lost in transit.
-        static let maxConsecutiveViewUpdates: UInt = 115
+        /// even if some update events are lost in transit. Set to 5 to reconcile 50% of views on Org 2 and the Demo org.
+        static let maxConsecutiveViewUpdates: UInt = 5
     }
 
     // MARK: - Child Scopes

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -16,7 +16,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         static let minimumTimeSpent: TimeInterval = 1e-9 // 1ns
         /// Maximum number of consecutive `RUMViewUpdateEvent` deltas sent for a view under the `viewUpdates`
         /// feature flag before a full `RUMViewEvent` is sent again, so the view state can be fully reconstructed
-        /// even if some update events are lost in transit. Set to 5 to reconcile 50% of views on Org 2 and the Demo org.
+        /// even if some update events are lost in transit. Set to 5 to reconcile 50% of views.
         static let maxConsecutiveViewUpdates: UInt = 5
     }
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScope_Tests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScope_Tests.swift
@@ -426,6 +426,75 @@ class RUMViewScope_Tests: XCTestCase {
         XCTAssertEqual(lastUpdateFlags.featureFlagsInfo[flagName] as! String, flagFinalValue)
     }
 
+    // MARK: - Periodic Full View Event Resync
+
+    func testWhenConsecutiveUpdatesReachTheLimit_itResendsAFullViewEvent() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
+            parent: parent,
+            dependencies: .mockWith(featureFlags: ff),
+            identity: .mockViewIdentifier(),
+            path: .mockAny(),
+            name: .mockAny(),
+            customTimings: [:],
+            startTime: currentTime,
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: INVMetricMock(),
+            viewIndexInSession: 1
+        )
+
+        // First write is a full event and becomes the baseline (consecutiveViewUpdatesCount == 0).
+        XCTAssertTrue(scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()), context: context, writer: writer))
+
+        // Send `maxConsecutiveViewUpdates` updates — all deltas against the baseline.
+        for index in 0..<RUMViewScope.Constants.maxConsecutiveViewUpdates {
+            currentTime.addTimeInterval(1)
+            _ = scope.process(
+                command: RUMAddViewTimingCommand.mockWith(time: currentTime, timingName: "timing-\(index)"),
+                context: context,
+                writer: writer
+            )
+        }
+
+        XCTAssertEqual(writer.events(ofType: RUMViewEvent.self).count, 1, "Only the initial write should be a full event so far")
+        XCTAssertEqual(
+            writer.events(ofType: RUMViewUpdateEvent.self).count,
+            Int(RUMViewScope.Constants.maxConsecutiveViewUpdates),
+            "Every update up to the limit should be sent as a delta"
+        )
+
+        // The next update exceeds the limit — a full event should be resent instead of a delta.
+        currentTime.addTimeInterval(1)
+        _ = scope.process(
+            command: RUMAddViewTimingCommand.mockWith(time: currentTime, timingName: "timing-over-limit"),
+            context: context,
+            writer: writer
+        )
+
+        XCTAssertEqual(writer.events(ofType: RUMViewEvent.self).count, 2, "A full event should be resent once the consecutive update limit is reached")
+        XCTAssertEqual(
+            writer.events(ofType: RUMViewUpdateEvent.self).count,
+            Int(RUMViewScope.Constants.maxConsecutiveViewUpdates),
+            "The resync write must not also be counted as a delta"
+        )
+
+        // The following write should be a delta again, as the counter was reset by the resync.
+        currentTime.addTimeInterval(1)
+        _ = scope.process(
+            command: RUMAddViewTimingCommand.mockWith(time: currentTime, timingName: "timing-after-resync"),
+            context: context,
+            writer: writer
+        )
+
+        XCTAssertEqual(writer.events(ofType: RUMViewEvent.self).count, 2, "No extra full event expected right after a resync")
+        XCTAssertEqual(
+            writer.events(ofType: RUMViewUpdateEvent.self).count,
+            Int(RUMViewScope.Constants.maxConsecutiveViewUpdates) + 1,
+            "The write right after a resync should be a delta again"
+        )
+    }
+
     // MARK: - Custom Timings
 
     func testGivenActiveView_whenCustomTimingIsRegistered_itSendsUpdateEvents() throws {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScope_Tests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScope_Tests.swift
@@ -495,6 +495,49 @@ class RUMViewScope_Tests: XCTestCase {
         )
     }
 
+    func testWhenViewUpdatesIsEnabled_everyFullEventIsMarkedAsDeltaBaseline() throws {
+        // Every full `RUMViewEvent` written under `.viewUpdates` — the initial baseline and any later
+        // resync — must be marked `isDeltaBaseline` so `RUMViewEventsFilter` never collapses it as
+        // redundant, since deltas in the same upload batch may be diffed against it.
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
+            parent: parent,
+            dependencies: .mockWith(featureFlags: ff),
+            identity: .mockViewIdentifier(),
+            path: .mockAny(),
+            name: .mockAny(),
+            customTimings: [:],
+            startTime: currentTime,
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: INVMetricMock(),
+            viewIndexInSession: 1
+        )
+
+        XCTAssertTrue(scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: .mockViewIdentifier()), context: context, writer: writer))
+
+        for index in 0..<RUMViewScope.Constants.maxConsecutiveViewUpdates {
+            currentTime.addTimeInterval(1)
+            _ = scope.process(
+                command: RUMAddViewTimingCommand.mockWith(time: currentTime, timingName: "timing-\(index)"),
+                context: context,
+                writer: writer
+            )
+        }
+
+        // Triggers the resync (second full event).
+        currentTime.addTimeInterval(1)
+        _ = scope.process(
+            command: RUMAddViewTimingCommand.mockWith(time: currentTime, timingName: "timing-over-limit"),
+            context: context,
+            writer: writer
+        )
+
+        let fullEventMetadata = writer.metadata(ofType: RUMViewEvent.Metadata.self)
+        XCTAssertEqual(fullEventMetadata.count, 2, "Both the initial baseline and the resync should carry metadata")
+        XCTAssertTrue(fullEventMetadata.allSatisfy { $0.isDeltaBaseline == true }, "All full events under viewUpdates must be marked as delta baselines")
+    }
+
     // MARK: - Custom Timings
 
     func testGivenActiveView_whenCustomTimingIsRegistered_itSendsUpdateEvents() throws {

--- a/DatadogRUM/Tests/RUMViewEventsFilterTests.swift
+++ b/DatadogRUM/Tests/RUMViewEventsFilterTests.swift
@@ -217,6 +217,39 @@ final class RUMViewEventsFilterTests: XCTestCase {
         XCTAssertTrue(hasB2, "Event B.2 with accessibility should be kept")
     }
 
+    // MARK: - Delta baseline (viewUpdates) filtering
+
+    func testFilterKeepsAllDeltaBaselineEventsForTheSameView() throws {
+        // Two resync full events for the same view within one batch — e.g. the view emitted enough
+        // updates to hit `maxConsecutiveViewUpdates` twice before the batch was uploaded. Both are
+        // required baselines for the deltas computed against them and must NOT be collapsed like
+        // legacy full-event duplicates would be.
+        let events = [
+            try Event(data: "A.1", viewMetadata: .mock(id: "A", documentVersion: 1, isDeltaBaseline: true)),
+            try Event(data: "A.2", viewMetadata: nil), // delta against A.1
+            try Event(data: "A.7", viewMetadata: .mock(id: "A", documentVersion: 7, isDeltaBaseline: true)) // resync
+        ]
+
+        let actual = sut.filter(events: events)
+
+        XCTAssertEqual(actual, events, "Delta baseline events must never be collapsed — each is a required anchor for its own following deltas")
+    }
+
+    func testFilterStillCollapsesRedundantLegacyFullEventsWhenNotDeltaBaseline() throws {
+        // Legacy (non-viewUpdates) full-event snapshots remain subject to redundant-event collapsing.
+        let events = [
+            try Event(data: "A.1", viewMetadata: .mock(id: "A", documentVersion: 1, isDeltaBaseline: false)),
+            try Event(data: "A.2", viewMetadata: .mock(id: "A", documentVersion: 2, isDeltaBaseline: false))
+        ]
+
+        let actual = sut.filter(events: events)
+        let expected = [
+            try Event(data: "A.2", viewMetadata: .mock(id: "A", documentVersion: 2, isDeltaBaseline: false))
+        ]
+
+        XCTAssertEqual(actual, expected)
+    }
+
     // MARK: - Error handling and telemetry
 
     func testFilterWhenInvalidMetadata() throws {
@@ -272,9 +305,17 @@ extension RUMViewEvent.Metadata {
         documentVersion: Int64 = .mockAny(),
         duration: Int64? = nil,
         indexInSession: Int? = nil,
-        hasAccessibility: Bool? = nil
+        hasAccessibility: Bool? = nil,
+        isDeltaBaseline: Bool? = nil
     ) -> RUMViewEvent.Metadata {
-        return RUMViewEvent.Metadata(id: id, documentVersion: documentVersion, hasAccessibility: hasAccessibility, duration: duration, indexInSession: indexInSession)
+        return RUMViewEvent.Metadata(
+            id: id,
+            documentVersion: documentVersion,
+            hasAccessibility: hasAccessibility,
+            duration: duration,
+            indexInSession: indexInSession,
+            isDeltaBaseline: isDeltaBaseline
+        )
     }
 }
 


### PR DESCRIPTION
### What and why?

When the `viewUpdates` RUM feature flag is enabled, the view scope reports partial `RUMViewUpdateEvent` deltas instead of full `RUMViewEvent`s after the first event. As part of the partial view updates rollout, we need a backend correctness check that periodically compares a full view event against the aggregated deltas to catch drift or data loss in the update-aggregation pipeline, without paying the network/resource cost of comparing every single view.

A threshold of 5 updates was chosen to reconcile roughly 50% of views on Org 2 and the Demo org, giving us a much higher sampling rate for validating the update-aggregation pipeline during this phase of the rollout.

### How?

Added a `consecutiveViewUpdatesCount` counter on `RUMViewScope`, incremented each time a delta update is sent. Once it reaches `Constants.maxConsecutiveViewUpdates` (5), the scope falls back to sending a full `RUMViewEvent` and resets the counter.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs
