### PR TITLE
[RUM-9335] Fix missing application.id in "Session Ended" telemetry

### DIFF
--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunStep+Fixtures.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunStep+Fixtures.swift
@@ -56,7 +56,6 @@ extension AppRunStep {
             app.initializeSDK(sdkSetup ?? { _ in })
             app.enableRUM { rumConfig in
                 rumSetup?(&rumConfig)
-                rumConfig.sessionEndedSampleRate = 0 // TODO: RUM-9335 Enable "Session Ended" telemetry after fixing `application.id` value for session stop
                 rumConfig.telemetrySampleRate = 0
             }
         })

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMSessionEndedMetricIntegrationTests.swift
@@ -46,7 +46,9 @@ class RUMSessionEndedMetricIntegrationTests: XCTestCase {
         monitor.stopSession()
 
         // Then
-        let metricAttributes = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent()?.attributes)
+        let event = try XCTUnwrap(core.waitAndReturnSessionEndedMetricEvent())
+        XCTAssertEqual(event.application?.id, rumConfig.applicationID, "It must report `application.id` even though the session no longer exists")
+        let metricAttributes = try XCTUnwrap(event.attributes)
         XCTAssertTrue(metricAttributes.wasStopped)
     }
 

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -273,6 +273,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             TelemetryInterceptor(sessionEndedMetric: sessionEndedMetric),
             TelemetryReceiver(
                 featureScope: featureScope,
+                applicationID: configuration.applicationID,
                 dateProvider: configuration.dateProvider,
                 sampler: Sampler(samplingRate: configuration.telemetrySampleRate),
                 configurationExtraSampler: Sampler(samplingRate: configuration.configurationTelemetrySampleRate)

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -18,6 +18,9 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
     /// RUM feature scope.
     let featureScope: FeatureScope
+    /// The RUM application ID. It is known upfront, so telemetry can be attributed to the application
+    /// even when no RUM session exists (e.g. after the session expired or was stopped).
+    let applicationID: String
     let dateProvider: DateProvider
 
     /// Sampler for all telemetry events.
@@ -41,16 +44,19 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
     ///
     /// - Parameters:
     ///   - featureScope: RUM feature scope.
+    ///   - applicationID: The RUM application ID.
     ///   - dateProvider: Current device time provider.
     ///   - sampler: Telemetry events sampler.
     ///   - configurationExtraSampler: Extra sampler for configuration events (applied on top of `sampler`).
     init(
         featureScope: FeatureScope,
+        applicationID: String,
         dateProvider: DateProvider,
         sampler: Sampler,
         configurationExtraSampler: Sampler
     ) {
         self.featureScope = featureScope
+        self.applicationID = applicationID
         self.dateProvider = dateProvider
         self.sampler = sampler
         self.configurationExtraSampler = configurationExtraSampler
@@ -285,7 +291,7 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
             let event = TelemetryDebugEvent(
                 dd: .init(),
                 action: rum?.userActionID.map { .init(id: .string(value: $0)) },
-                application: rum.map { .init(id: $0.applicationID) },
+                application: .init(id: self.applicationID),
                 date: date.addingTimeInterval(context.serverTimeOffset).timeIntervalSince1970.dd.toInt64Milliseconds,
                 effectiveSampleRate: Double(effectiveSampleRate),
                 experimentalFeatures: nil,

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -498,7 +498,7 @@ class TelemetryReceiverTests: XCTestCase {
         let osMock: OperatingSystem = .mockRandom()
         featureScope.contextMock = .mockWith(device: deviceMock, os: osMock)
         featureScope.contextMock.set(additionalContext: rumContext)
-        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
+        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, applicationID: rumContext.applicationID)
 
         // When
         TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: mockRandomAttributes(), sampleRate: 100)
@@ -524,7 +524,7 @@ class TelemetryReceiverTests: XCTestCase {
         // Given
         let rumContext: RUMCoreContext = .mockRandom()
         featureScope.contextMock.set(additionalContext: rumContext)
-        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope)
+        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, applicationID: rumContext.applicationID)
         let sessionIDOverride = "session-id-override"
 
         // When
@@ -539,6 +539,20 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.view?.id, rumContext.viewID)
         XCTAssertEqual(event?.action?.id.stringValue, rumContext.userActionID)
         XCTAssertNil(event?.telemetry.telemetryInfo[SDKMetricFields.sessionIDOverrideKey], "It should delete `sessionIDOverrideKey` from metric attributes")
+    }
+
+    func testSendTelemetryMetricWithNoRUMContext() {
+        // Given
+        let applicationID: String = .mockRandom()
+        let receiver = TelemetryReceiver.mockWith(featureScope: featureScope, applicationID: applicationID)
+
+        // When: no RUM context exists, e.g. the session expired or was stopped
+        TelemetryMock(with: receiver).metric(name: .mockRandom(), attributes: mockRandomAttributes(), sampleRate: 100)
+
+        // Then
+        let event = featureScope.eventsWritten(ofType: TelemetryDebugEvent.self).first
+        XCTAssertEqual(event?.application?.id, applicationID, "It should attribute the metric to the RUM application even with no session")
+        XCTAssertNil(event?.session?.id, "It should not report a session ID when no session exists")
     }
 
     func testMethodCallTelemetryPropagatesAllData() throws {

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -1594,12 +1594,14 @@ extension TelemetryReceiver: AnyMockable {
 
     public static func mockWith(
         featureScope: FeatureScope = NOPFeatureScope(),
+        applicationID: String = .mockAny(),
         dateProvider: DateProvider = SystemDateProvider(),
         sampler: Sampler = .mockKeepAll(),
         configurationExtraSampler: Sampler = .mockKeepAll()
     ) -> Self {
         .init(
             featureScope: featureScope,
+            applicationID: applicationID,
             dateProvider: dateProvider,
             sampler: sampler,
             configurationExtraSampler: configurationExtraSampler


### PR DESCRIPTION
### What and why?

"Session Ended" telemetry was sometimes missing `application.id`. The metric is emitted at the exact moment a RUM session stops existing — after an inactivity timeout, or after `stopSession()` — and `TelemetryReceiver` derived `application.id` from the RUM session context, which is `nil` once there is no session.

This matters because SDK telemetry is consumed per RUM application: an event without `application.id` cannot be attributed to an app. The loss was also not random — it hit exactly the sessions that ended by timeout or by `stopSession()`, which biases any analysis of how sessions end. It additionally forced "Session Ended" telemetry to stay disabled in the integration test fixtures, now removed.

### How?

`TelemetryReceiver` now receives `applicationID` at init from `RUMFeature` and uses it directly, instead of reading it from the session context.

The RUM application ID is SDK configuration — known upfront, immutable for the life of the instance, and not session state. Sourcing it from a per-session context was the original modelling error. `CrashReportReceiver`, declared a few lines below in the same receiver list in `RUMFeature`, already takes `applicationID` at init for exactly the same reason: crash reports are also emitted when no session is active. `TelemetryReceiver` was the outlier.

`RUMCoreContext` is unchanged, so the modules that consume it (Logs, Trace, SessionReplay, Profiling, WebViewTracking, Flags, NetworkInstrumentation) are unaffected.

The neighbouring fields are deliberately left as they were: `session` and `action` are genuinely session state and must stay `nil` when no session exists. Only `application` becomes unconditional.

**Relation to #2324.** That PR added an `applicationIDOverride` mirroring `sessionIDOverride`, and was closed in favour of "a real fix than a workaround". An override exists to report a value that differs from the current one — necessary for `session.id`, because by emission time the context already holds the *new* session, but meaningless for `application.id`, which never changes. Injection is also harder to get wrong: a future metric cannot forget to set an attribute it does not need.


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
