### PR TITLE
[RUM-17396] Standardize and sanitize error reporting for internal SDK telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,11 @@ CONTRIBUTING.md          ← General contribution guidelines
 
 docs/
 ├── ARCHITECTURE.md      ← Module structure, data flow, key abstractions, protocols,
-│                          error handling, thread safety, HTTP upload, dependencies
+│                          thread safety, HTTP upload, dependencies
 ├── CONVENTIONS.md       ← Naming, SwiftLint rules, conditional compilation,
 │                          generated models, file headers, commit/PR format
+├── ERROR_HANDLING.md    ← Customer-facing error safety + internal telemetry
+│                          error reporting (TelemetrySanitizableError)
 ├── DEVELOPMENT.md       ← Recipes for adding features/commands/providers,
 │                          RFC process, build & test quick reference
 ├── TESTING.md           ← Test conventions, mock infrastructure (.mockAny(),
@@ -50,6 +52,7 @@ Feature-specific docs (in each module directory):
 | Write or fix tests | `docs/TESTING.md` |
 | Check naming, lint, commit format | `docs/CONVENTIONS.md` |
 | Touch swizzling code | `docs/SWIZZLING.md` |
+| Report an error to internal telemetry | `docs/ERROR_HANDLING.md` |
 | Modify a fragile area | `docs/KNOWN_CONCERNS.md` |
 | Work on RUM specifically | `DatadogRUM/RUM_FEATURE.md` |
 | Work on Session Replay specifically | `DatadogSessionReplay/SESSION_REPLAY_FEATURE.md` |
@@ -71,6 +74,7 @@ Feature-specific docs (in each module directory):
 - **Do NOT name branches with `codex`.** Use repo branch naming conventions instead.
 - **Never mention AI assistant names** (Claude, ChatGPT, Cursor, Copilot, etc.) in commit messages, PR descriptions, code comments, or co-author tags.
 - **Never write or modify a swizzle without reading `docs/SWIZZLING.md` first.** Past incidents have caused production crashes.
+- **Never report a raw `Error` to internal telemetry.** `"\(error)"` can embed customer data (e.g. `EncodingError.invalidValue` embeds the offending value). Always go through `Telemetry.error(_:)`, which sanitizes via `TelemetrySanitizableError`; see `docs/ERROR_HANDLING.md`. Past incidents have leaked customer PII and auth tokens this way.
 
 ## Quick Reference
 

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1006,6 +1006,7 @@
 		D23039F8298D5236001A1FA3 /* InternalLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039CE298D5235001A1FA3 /* InternalLogger.swift */; };
 		D23039F9298D5236001A1FA3 /* CoreLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039CF298D5235001A1FA3 /* CoreLogger.swift */; };
 		D23039FA298D5236001A1FA3 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D0298D5235001A1FA3 /* Telemetry.swift */; };
+		6165D7353013888F0069D0E4 /* TelemetrySanitizableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */; };
 		D23039FB298D5236001A1FA3 /* URLRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D2298D5235001A1FA3 /* URLRequestBuilder.swift */; };
 		D23039FC298D5236001A1FA3 /* DataFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D3298D5235001A1FA3 /* DataFormat.swift */; };
 		D23039FD298D5236001A1FA3 /* DataCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D4298D5235001A1FA3 /* DataCompression.swift */; };
@@ -2959,6 +2960,7 @@
 		D23039CE298D5235001A1FA3 /* InternalLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalLogger.swift; sourceTree = "<group>"; };
 		D23039CF298D5235001A1FA3 /* CoreLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreLogger.swift; sourceTree = "<group>"; };
 		D23039D0298D5235001A1FA3 /* Telemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
+		6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySanitizableError.swift; sourceTree = "<group>"; };
 		D23039D2298D5235001A1FA3 /* URLRequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRequestBuilder.swift; sourceTree = "<group>"; };
 		D23039D3298D5235001A1FA3 /* DataFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataFormat.swift; sourceTree = "<group>"; };
 		D23039D4298D5235001A1FA3 /* DataCompression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCompression.swift; sourceTree = "<group>"; };
@@ -6482,6 +6484,7 @@
 				D23039CE298D5235001A1FA3 /* InternalLogger.swift */,
 				11EA5C322DC5077000E8DFA2 /* InternalLogger+objc.swift */,
 				D23039D0298D5235001A1FA3 /* Telemetry.swift */,
+				6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -8938,6 +8941,7 @@
 				D23039EE298D5236001A1FA3 /* FeatureMessageReceiver.swift in Sources */,
 				D23039DE298D5235001A1FA3 /* Writer.swift in Sources */,
 				D23039FA298D5236001A1FA3 /* Telemetry.swift in Sources */,
+				6165D7353013888F0069D0E4 /* TelemetrySanitizableError.swift in Sources */,
 				D23039FC298D5236001A1FA3 /* DataFormat.swift in Sources */,
 				D2160CED29C0E0E600FAA9A5 /* DatadogURLSessionHandler.swift in Sources */,
 				1166C5A52F76EC0B008E34BC /* OperationOptions.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1007,6 +1007,7 @@
 		D23039F9298D5236001A1FA3 /* CoreLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039CF298D5235001A1FA3 /* CoreLogger.swift */; };
 		D23039FA298D5236001A1FA3 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D0298D5235001A1FA3 /* Telemetry.swift */; };
 		6165D7353013888F0069D0E4 /* TelemetrySanitizableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */; };
+		6165D7373017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165D7363017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift */; };
 		D23039FB298D5236001A1FA3 /* URLRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D2298D5235001A1FA3 /* URLRequestBuilder.swift */; };
 		D23039FC298D5236001A1FA3 /* DataFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D3298D5235001A1FA3 /* DataFormat.swift */; };
 		D23039FD298D5236001A1FA3 /* DataCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D4298D5235001A1FA3 /* DataCompression.swift */; };
@@ -2961,6 +2962,7 @@
 		D23039CF298D5235001A1FA3 /* CoreLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreLogger.swift; sourceTree = "<group>"; };
 		D23039D0298D5235001A1FA3 /* Telemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySanitizableError.swift; sourceTree = "<group>"; };
+		6165D7363017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySanitizableErrorTests.swift; sourceTree = "<group>"; };
 		D23039D2298D5235001A1FA3 /* URLRequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRequestBuilder.swift; sourceTree = "<group>"; };
 		D23039D3298D5235001A1FA3 /* DataFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataFormat.swift; sourceTree = "<group>"; };
 		D23039D4298D5235001A1FA3 /* DataCompression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCompression.swift; sourceTree = "<group>"; };
@@ -6281,6 +6283,7 @@
 			isa = PBXGroup;
 			children = (
 				D21AE6BB29E5EDAF0064BF29 /* TelemetryTests.swift */,
+				6165D7363017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -9473,6 +9476,7 @@
 				61F3E3662BC595F600C7881E /* HTTPHeadersReaderTests.swift in Sources */,
 				D2EBEE3C29BA163E00B15732 /* B3HTTPHeadersWriterTests.swift in Sources */,
 				D21AE6BC29E5EDAF0064BF29 /* TelemetryTests.swift in Sources */,
+				6165D7373017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift in Sources */,
 				D2DA23A3298D58F400C6C7E6 /* AnyEncodableTests.swift in Sources */,
 				3CCECDAF2BC688120013C125 /* SpanIDGeneratorTests.swift in Sources */,
 				D263BCB429DB014900FA0E21 /* FixedWidthInteger+ConvenienceTests.swift in Sources */,

--- a/DatadogCore/Sources/Core/DataStore/DataStoreFileWriter.swift
+++ b/DatadogCore/Sources/Core/DataStore/DataStoreFileWriter.swift
@@ -26,7 +26,7 @@ extension DataStoreFileWritingError: TelemetrySanitizableError {
         }
         return TelemetrySanitizedError(
             kind: "DataStoreFileWritingError",
-            message: "\(kind)(\(sanitizeForTelemetry(wrapped).message))"
+            message: "\(kind)(\(TelemetrySanitizedError(sanitizing: wrapped).message))"
         )
     }
 }

--- a/DatadogCore/Sources/Core/DataStore/DataStoreFileWriter.swift
+++ b/DatadogCore/Sources/Core/DataStore/DataStoreFileWriter.swift
@@ -12,6 +12,25 @@ internal enum DataStoreFileWritingError: Error {
     case failedToEncodeData(Error)
 }
 
+extension DataStoreFileWritingError: TelemetrySanitizableError {
+    func sanitize() -> TelemetrySanitizedError {
+        let kind: String
+        let wrapped: Error
+        switch self {
+        case .failedToEncodeVersion(let error):
+            kind = "failedToEncodeVersion"
+            wrapped = error
+        case .failedToEncodeData(let error):
+            kind = "failedToEncodeData"
+            wrapped = error
+        }
+        return TelemetrySanitizedError(
+            kind: "DataStoreFileWritingError",
+            message: "\(kind)(\(sanitizeForTelemetry(wrapped).message))"
+        )
+    }
+}
+
 internal struct DataStoreFileWriter {
     let file: File
 

--- a/DatadogCore/Sources/Core/DataStore/FeatureDataStore.swift
+++ b/DatadogCore/Sources/Core/DataStore/FeatureDataStore.swift
@@ -50,7 +50,7 @@ internal final class FeatureDataStore: DataStore {
                 try self.write(data: value, forKey: key, version: version)
             } catch let error {
                 DD.logger.error("[Data Store] Error on setting `\(key)` value for `\(self.feature)`", error: error)
-                self.telemetry.error("[Data Store] Error on setting `\(key)` value for `\(self.feature)`", error: DDError(error: error))
+                self.telemetry.error("[Data Store] Error on setting `\(key)` value for `\(self.feature)`", error: error)
             }
         }
     }
@@ -67,7 +67,7 @@ internal final class FeatureDataStore: DataStore {
             } catch let error {
                 callback(.error(error))
                 DD.logger.error("[Data Store] Error on getting `\(key)` value for `\(self.feature)`", error: error)
-                self.telemetry.error("[Data Store] Error on getting `\(key)` value for `\(self.feature)`", error: DDError(error: error))
+                self.telemetry.error("[Data Store] Error on getting `\(key)` value for `\(self.feature)`", error: error)
             }
         }
     }
@@ -82,7 +82,7 @@ internal final class FeatureDataStore: DataStore {
                 try self.deleteData(forKey: key)
             } catch let error {
                 DD.logger.error("[Data Store] Error on deleting `\(key)` value for `\(self.feature)`", error: error)
-                self.telemetry.error("[Data Store] Error on deleting `\(key)` value for `\(self.feature)`", error: DDError(error: error))
+                self.telemetry.error("[Data Store] Error on deleting `\(key)` value for `\(self.feature)`", error: error)
             }
         }
     }
@@ -94,7 +94,7 @@ internal final class FeatureDataStore: DataStore {
                 try directory?.deleteAllFiles()
             } catch let error {
                 DD.logger.error("[Data Store] Error on clearing all data for `\(self.feature)`", error: error)
-                self.telemetry.error("[Data Store] Error on clearing all data for `\(self.feature)`", error: DDError(error: error))
+                self.telemetry.error("[Data Store] Error on clearing all data for `\(self.feature)`", error: error)
             }
         }
     }

--- a/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
+++ b/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 /// A block reader can read TLV formatted blocks from a data input.
 ///
@@ -148,6 +149,14 @@ internal final class TLVBlockReader<BlockType> where BlockType: RawRepresentable
         return try read(length: Int(length))
     }
 }
+extension TLVBlockError: TelemetrySanitizableError {
+    /// Every case only ever describes block types, sizes, limits and stream status codes - never the
+    /// raw bytes or decoded content of a block - so the full description is safe to report as-is.
+    func sanitize() -> TelemetrySanitizedError {
+        TelemetrySanitizedError(kind: "TLVBlockError", message: "\(self)")
+    }
+}
+
 extension TLVBlockError: CustomStringConvertible {
     var description: String {
         switch self {

--- a/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
+++ b/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
@@ -153,7 +153,7 @@ extension TLVBlockError: TelemetrySanitizableError {
     /// Every case only ever describes block types, sizes, limits and stream status codes - never the
     /// raw bytes or decoded content of a block - so the full description is safe to report as-is.
     func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(kind: "TLVBlockError", message: "\(self)")
+        TelemetrySanitizedError(describing: self)
     }
 }
 

--- a/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
+++ b/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
@@ -152,6 +152,11 @@ internal final class TLVBlockReader<BlockType> where BlockType: RawRepresentable
 extension TLVBlockError: TelemetrySanitizableError {
     /// Every case only ever describes block types, sizes, limits and stream status codes - never the
     /// raw bytes or decoded content of a block - so the full description is safe to report as-is.
+    /// `readOperationFailed`'s `streamError` is the one exception: it's an arbitrary, foreign `Error`
+    /// (typically an `NSError`), and `NSError.userInfo` content depends on the error's domain - some
+    /// domains keep it minimal, others (e.g. `NSCocoaErrorDomain` file errors) can include the file
+    /// path - so `description` routes it through `sanitizeForTelemetry(_:)` rather than assuming this
+    /// particular source is safe to interpolate directly.
     func sanitize() -> TelemetrySanitizedError {
         TelemetrySanitizedError(describing: self)
     }
@@ -161,7 +166,7 @@ extension TLVBlockError: CustomStringConvertible {
     var description: String {
         switch self {
         case .readOperationFailed(let status, let error):
-            let error = error.map { "\($0)" } ?? "(null)"
+            let error = error.map { sanitizeForTelemetry($0) }.map { "\($0.kind): \($0.message)" } ?? "(null)"
             return "DataBlock read operation failed with stream status: \(status.rawValue), error: \(error)"
         case .invalidDataType(let type):
             return "Invalid DataBlock type: \(type)"

--- a/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
+++ b/DatadogCore/Sources/Core/TLV/TLVBlockReader.swift
@@ -155,10 +155,10 @@ extension TLVBlockError: TelemetrySanitizableError {
     /// `readOperationFailed`'s `streamError` is the one exception: it's an arbitrary, foreign `Error`
     /// (typically an `NSError`), and `NSError.userInfo` content depends on the error's domain - some
     /// domains keep it minimal, others (e.g. `NSCocoaErrorDomain` file errors) can include the file
-    /// path - so `description` routes it through `sanitizeForTelemetry(_:)` rather than assuming this
-    /// particular source is safe to interpolate directly.
+    /// path - so `description` routes it through `TelemetrySanitizedError.init(sanitizing:)` rather than
+    /// assuming this particular source is safe to interpolate directly.
     func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(describing: self)
+        TelemetrySanitizedError(unsafelyDescribing: self)
     }
 }
 
@@ -166,7 +166,7 @@ extension TLVBlockError: CustomStringConvertible {
     var description: String {
         switch self {
         case .readOperationFailed(let status, let error):
-            let error = error.map { sanitizeForTelemetry($0) }.map { "\($0.kind): \($0.message)" } ?? "(null)"
+            let error = error.map { TelemetrySanitizedError(sanitizing: $0) }.map { "\($0.kind): \($0.message)" } ?? "(null)"
             return "DataBlock read operation failed with stream status: \(status.rawValue), error: \(error)"
         case .invalidDataType(let type):
             return "Invalid DataBlock type: \(type)"

--- a/DatadogCore/Tests/Datadog/Core/TLV/TLVBlockTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/TLV/TLVBlockTests.swift
@@ -64,4 +64,26 @@ class TLVBlockTests: XCTestCase {
             )
         }
     }
+
+    func testSanitizingReadOperationFailed_neverReportsRawStreamError() {
+        // Given
+        // `streamError`'s `userInfo` content depends on its domain - `NSCocoaErrorDomain` file errors,
+        // for instance, can include the file path via `NSFilePathErrorKey` - so it must go through the
+        // same central `NSError` sanitization as any other foreign error, not be interpolated directly
+        // into `TLVBlockError`'s description.
+        let sensitiveFilePath = "/var/mobile/Containers/session-\(String.mockRandom(length: 16))/file.dat"
+        let streamError = NSError(
+            domain: NSCocoaErrorDomain,
+            code: 260,
+            userInfo: [NSFilePathErrorKey: sensitiveFilePath]
+        )
+        let error = TLVBlockError.readOperationFailed(streamStatus: .error, streamError: streamError)
+
+        // When
+        let sanitized = error.sanitize()
+
+        // Then
+        XCTAssertFalse(sanitized.message.contains(sensitiveFilePath))
+        XCTAssertTrue(sanitized.message.contains("domain: \(NSCocoaErrorDomain), code: 260"))
+    }
 }

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -712,7 +712,7 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 2)
 
         let error = try XCTUnwrap(telemetry.messages.firstError(), "An error should be send to `telemetry`.")
-        XCTAssertEqual(error.message, #"Data upload finished with error - Error Domain=abc Code=0 "(null)""#)
+        XCTAssertEqual(error.message, "Data upload finished with error - abc (0)")
 
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
         XCTAssertEqual(metric.attributes["failure"] as? String, "\(nserror.code)")
@@ -753,7 +753,7 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 2)
 
         let error = try XCTUnwrap(telemetry.messages.firstError(), "An error should be send to `telemetry`.")
-        XCTAssertEqual(error.message, #"Failed to initiate 'some-feature' data upload - Failed to prepare upload"#)
+        XCTAssertEqual(error.message, "Failed to initiate 'some-feature' data upload - Unrecognized error type: ErrorMock")
 
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
         XCTAssertEqual(metric.attributes["failure"] as? String, "invalid")

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -712,7 +712,7 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 2)
 
         let error = try XCTUnwrap(telemetry.messages.firstError(), "An error should be send to `telemetry`.")
-        XCTAssertEqual(error.message, "Data upload finished with error - abc (0)")
+        XCTAssertEqual(error.message, "Data upload finished with error - domain: abc, code: 0")
 
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
         XCTAssertEqual(metric.attributes["failure"] as? String, "\(nserror.code)")

--- a/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -753,7 +753,7 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 2)
 
         let error = try XCTUnwrap(telemetry.messages.firstError(), "An error should be send to `telemetry`.")
-        XCTAssertEqual(error.message, "Failed to initiate 'some-feature' data upload - Unrecognized error type: ErrorMock")
+        XCTAssertEqual(error.message, "Failed to initiate 'some-feature' data upload - ErrorMock does not conform to TelemetrySanitizableError — reporting type name only")
 
         let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "upload_quality"), "An upload quality metric should be send to `telemetry`.")
         XCTAssertEqual(metric.attributes["failure"] as? String, "invalid")

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -327,22 +327,30 @@ extension Telemetry {
 
     /// Collect execution error.
     ///
+    /// - Note: Not exposed publicly — a `DDError` built outside this file may carry a raw,
+    ///   unsanitized error description. Callers should use `error(_ error: Error, ...)`
+    ///   instead, which is the single choke point for future error sanitization.
+    ///
     /// - Parameters:
     ///   - error: The error.
     ///   - file: The current file name.
     ///   - line: The line number in file.
-    public func error(_ error: DDError, file: String = #fileID, line: Int = #line) {
+    func error(_ error: DDError, file: String = #fileID, line: Int = #line) {
         self.error(error.message, kind: error.type, stack: error.stack, file: file, line: line)
     }
 
     /// Collect execution error.
+    ///
+    /// - Note: Not exposed publicly — a `DDError` built outside this file may carry a raw,
+    ///   unsanitized error description. Callers should use `error(_ message: String, error: Error, ...)`
+    ///   instead, which is the single choke point for future error sanitization.
     ///
     /// - Parameters:
     ///   - message: The error message.
     ///   - error: The error.
     ///   - file: The current file name.
     ///   - line: The line number in file.
-    public func error(_ message: String, error: DDError, file: String = #fileID, line: Int = #line) {
+    func error(_ message: String, error: DDError, file: String = #fileID, line: Int = #line) {
         self.error("\(message) - \(error.message)", kind: error.type, stack: error.stack, file: file, line: line)
     }
 

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -329,7 +329,7 @@ extension Telemetry {
     ///
     /// - Note: Not exposed publicly — accepts only `TelemetrySanitizedError`, so a raw, unsanitized
     ///   error description can never reach this sink. Callers should use `error(_ error: Error, ...)`
-    ///   instead, which sanitizes the error via `makeTelemetrySafe(_:)` before forwarding here.
+    ///   instead, which sanitizes the error via `sanitizeForTelemetry(_:)` before forwarding here.
     ///
     /// - Parameters:
     ///   - error: The sanitized error.
@@ -344,7 +344,7 @@ extension Telemetry {
     /// - Note: Not exposed publicly — accepts only `TelemetrySanitizedError`, so a raw, unsanitized
     ///   error description can never reach this sink. Callers should use
     ///   `error(_ message: String, error: Error, ...)` instead, which sanitizes the error via
-    ///   `makeTelemetrySafe(_:)` before forwarding here.
+    ///   `sanitizeForTelemetry(_:)` before forwarding here.
     ///
     /// - Parameters:
     ///   - message: The error message.
@@ -366,7 +366,7 @@ extension Telemetry {
     ///   - file: The current file name.
     ///   - line: The line number in file.
     public func error(_ error: Error, file: String = #fileID, line: Int = #line) {
-        self.error(makeTelemetrySafe(error), file: file, line: line)
+        self.error(sanitizeForTelemetry(error), file: file, line: line)
     }
 
     /// Collect execution error.
@@ -381,7 +381,7 @@ extension Telemetry {
     ///   - file: The current file name.
     ///   - line: The line number in file.
     public func error(_ message: String, error: Error, file: String = #fileID, line: Int = #line) {
-        self.error(message, error: makeTelemetrySafe(error), file: file, line: line)
+        self.error(message, error: sanitizeForTelemetry(error), file: file, line: line)
     }
 
     /// Report a Configuration Telemetry.

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -321,7 +321,7 @@ extension Telemetry {
             id: "\(file):\(line):\(message)",
             message: message,
             kind: kind ?? "\(file)",
-            stack: stack ?? "\(file):\(line)"
+            stack: stack.map { "\(file):\(line)\n\($0)" } ?? "\(file):\(line)"
         )
     }
 

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -327,44 +327,53 @@ extension Telemetry {
 
     /// Collect execution error.
     ///
-    /// - Note: Not exposed publicly — a `DDError` built outside this file may carry a raw,
-    ///   unsanitized error description. Callers should use `error(_ error: Error, ...)`
-    ///   instead, which is the single choke point for future error sanitization.
+    /// - Note: Not exposed publicly — accepts only `TelemetrySanitizedError`, so a raw, unsanitized
+    ///   error description can never reach this sink. Callers should use `error(_ error: Error, ...)`
+    ///   instead, which sanitizes the error via `makeTelemetrySafe(_:)` before forwarding here.
     ///
     /// - Parameters:
-    ///   - error: The error.
+    ///   - error: The sanitized error.
     ///   - file: The current file name.
     ///   - line: The line number in file.
-    func error(_ error: DDError, file: String = #fileID, line: Int = #line) {
-        self.error(error.message, kind: error.type, stack: error.stack, file: file, line: line)
+    func error(_ error: TelemetrySanitizedError, file: String = #fileID, line: Int = #line) {
+        self.error(error.message, kind: error.kind, stack: error.stack, file: file, line: line)
     }
 
     /// Collect execution error.
     ///
-    /// - Note: Not exposed publicly — a `DDError` built outside this file may carry a raw,
-    ///   unsanitized error description. Callers should use `error(_ message: String, error: Error, ...)`
-    ///   instead, which is the single choke point for future error sanitization.
+    /// - Note: Not exposed publicly — accepts only `TelemetrySanitizedError`, so a raw, unsanitized
+    ///   error description can never reach this sink. Callers should use
+    ///   `error(_ message: String, error: Error, ...)` instead, which sanitizes the error via
+    ///   `makeTelemetrySafe(_:)` before forwarding here.
     ///
     /// - Parameters:
     ///   - message: The error message.
-    ///   - error: The error.
+    ///   - error: The sanitized error.
     ///   - file: The current file name.
     ///   - line: The line number in file.
-    func error(_ message: String, error: DDError, file: String = #fileID, line: Int = #line) {
-        self.error("\(message) - \(error.message)", kind: error.type, stack: error.stack, file: file, line: line)
+    func error(_ message: String, error: TelemetrySanitizedError, file: String = #fileID, line: Int = #line) {
+        self.error("\(message) - \(error.message)", kind: error.kind, stack: error.stack, file: file, line: line)
     }
 
     /// Collect execution error.
+    ///
+    /// - Note: If `error` conforms to `TelemetrySanitizableError`, its own sanitized context is reported.
+    ///   Otherwise, it falls back to Telemetry's default sanitization, which may drop most contextual
+    ///   information to avoid leaking sensitive data.
     ///
     /// - Parameters:
     ///   - error: The error.
     ///   - file: The current file name.
     ///   - line: The line number in file.
     public func error(_ error: Error, file: String = #fileID, line: Int = #line) {
-        self.error(DDError(error: error), file: file, line: line)
+        self.error(makeTelemetrySafe(error), file: file, line: line)
     }
 
     /// Collect execution error.
+    ///
+    /// - Note: If `error` conforms to `TelemetrySanitizableError`, its own sanitized context is reported.
+    ///   Otherwise, it falls back to Telemetry's default sanitization, which may drop most contextual
+    ///   information to avoid leaking sensitive data.
     ///
     /// - Parameters:
     ///   - message: The error message.
@@ -372,7 +381,7 @@ extension Telemetry {
     ///   - file: The current file name.
     ///   - line: The line number in file.
     public func error(_ message: String, error: Error, file: String = #fileID, line: Int = #line) {
-        self.error(message, error: DDError(error: error), file: file, line: line)
+        self.error(message, error: makeTelemetrySafe(error), file: file, line: line)
     }
 
     /// Report a Configuration Telemetry.

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -329,7 +329,8 @@ extension Telemetry {
     ///
     /// - Note: Not exposed publicly — accepts only `TelemetrySanitizedError`, so a raw, unsanitized
     ///   error description can never reach this sink. Callers should use `error(_ error: Error, ...)`
-    ///   instead, which sanitizes the error via `sanitizeForTelemetry(_:)` before forwarding here.
+    ///   instead, which sanitizes the error via `TelemetrySanitizedError.init(sanitizing:)` before
+    ///   forwarding here.
     ///
     /// - Parameters:
     ///   - error: The sanitized error.
@@ -344,7 +345,7 @@ extension Telemetry {
     /// - Note: Not exposed publicly — accepts only `TelemetrySanitizedError`, so a raw, unsanitized
     ///   error description can never reach this sink. Callers should use
     ///   `error(_ message: String, error: Error, ...)` instead, which sanitizes the error via
-    ///   `sanitizeForTelemetry(_:)` before forwarding here.
+    ///   `TelemetrySanitizedError.init(sanitizing:)` before forwarding here.
     ///
     /// - Parameters:
     ///   - message: The error message.
@@ -366,7 +367,7 @@ extension Telemetry {
     ///   - file: The current file name.
     ///   - line: The line number in file.
     public func error(_ error: Error, file: String = #fileID, line: Int = #line) {
-        self.error(sanitizeForTelemetry(error), file: file, line: line)
+        self.error(TelemetrySanitizedError(sanitizing: error), file: file, line: line)
     }
 
     /// Collect execution error.
@@ -381,7 +382,7 @@ extension Telemetry {
     ///   - file: The current file name.
     ///   - line: The line number in file.
     public func error(_ message: String, error: Error, file: String = #fileID, line: Int = #line) {
-        self.error(message, error: sanitizeForTelemetry(error), file: file, line: line)
+        self.error(message, error: TelemetrySanitizedError(sanitizing: error), file: file, line: line)
     }
 
     /// Report a Configuration Telemetry.

--- a/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
+++ b/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
@@ -1,0 +1,115 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An error that knows how to sanitize itself for telemetry sent to Datadog's own org.
+///
+/// By default, errors reported to telemetry go through strict sanitization that discards most
+/// contextual information to avoid leaking sensitive data. This protocol is an opt-in mechanism:
+/// conforming types report a richer, but still safe, sanitized context instead of the default fallback.
+///
+/// - Important: Do not retroactively conform a type you don't own (e.g. `NSError`, `URLError`) to this
+///   protocol - a conformance is a single, global fact about a (Type, Protocol) pair, so a second,
+///   conflicting conformance declared elsewhere would be silently discarded. For some foreign types
+///   (e.g. `EncodingError`, `DecodingError`, `NSError`), `Telemetry` instead applies its own internal
+///   sanitization with sensible defaults, handled centrally in `makeTelemetrySafe(_:)`.
+public protocol TelemetrySanitizableError {
+    func sanitize() -> TelemetrySanitizedError
+}
+
+/// A sanitized, telemetry-safe description of an error - safe to forward to Datadog's internal telemetry.
+public struct TelemetrySanitizedError {
+    public var kind: String
+    public let message: String
+    public var stack: String?
+
+    public init(kind: String, message: String, stack: String? = nil) {
+        self.kind = kind
+        self.message = message
+        self.stack = stack
+    }
+}
+
+/// Returns a `TelemetrySanitizedError` describing `error`, safe to forward to internal telemetry.
+///
+/// If `error` conforms to `TelemetrySanitizableError`, its own `sanitize()` is used as-is. Otherwise, it
+/// falls back to Telemetry's default sanitization: common types (`EncodingError`, `DecodingError`,
+/// `NSError`) get a safe, dedicated summary, while everything else is stripped down to its type name.
+func makeTelemetrySafe(_ error: Error) -> TelemetrySanitizedError {
+    if let sanitizable = error as? TelemetrySanitizableError {
+        return sanitizable.sanitize()
+    }
+    if let encodingError = error as? EncodingError {
+        return sanitize(encodingError)
+    }
+    if let decodingError = error as? DecodingError {
+        return sanitize(decodingError)
+    }
+    if isNSErrorOrItsSubclass(error) {
+        let nsError = error as NSError
+        return TelemetrySanitizedError(kind: "\(type(of: nsError))", message: "\(nsError.domain) (\(nsError.code))")
+    }
+    let kind = "\(type(of: error))"
+    return TelemetrySanitizedError(
+        kind: kind,
+        message: "Unrecognized error type: \(kind)",
+        stack: "Implement TelemetrySanitizableError on \(kind) to report richer, safe context."
+    )
+}
+
+/// Sanitizes `EncodingError` for telemetry - only `context.debugDescription`/`codingPath`, never the raw
+/// offending value that `EncodingError.invalidValue(_:_:)` embeds as its first associated value.
+private func sanitize(_ error: EncodingError) -> TelemetrySanitizedError {
+    let context: EncodingError.Context
+    let kind: String
+    switch error {
+    case .invalidValue(_, let ctx):
+        context = ctx
+        kind = "EncodingError.invalidValue"
+    @unknown default:
+        context = EncodingError.Context(codingPath: [], debugDescription: "unknown EncodingError case")
+        kind = "EncodingError"
+    }
+    return TelemetrySanitizedError(
+        kind: kind,
+        message: context.debugDescription,
+        stack: describe(codingPath: context.codingPath)
+    )
+}
+
+/// Sanitizes `DecodingError` for telemetry - only `context.debugDescription`/`codingPath`, never the raw
+/// offending value that several `DecodingError` cases embed as their first associated value.
+private func sanitize(_ error: DecodingError) -> TelemetrySanitizedError {
+    let context: DecodingError.Context
+    let kind: String
+    switch error {
+    case .typeMismatch(_, let ctx):
+        context = ctx
+        kind = "DecodingError.typeMismatch"
+    case .valueNotFound(_, let ctx):
+        context = ctx
+        kind = "DecodingError.valueNotFound"
+    case .keyNotFound(_, let ctx):
+        context = ctx
+        kind = "DecodingError.keyNotFound"
+    case .dataCorrupted(let ctx):
+        context = ctx
+        kind = "DecodingError.dataCorrupted"
+    @unknown default:
+        context = DecodingError.Context(codingPath: [], debugDescription: "unknown DecodingError case")
+        kind = "DecodingError"
+    }
+    return TelemetrySanitizedError(
+        kind: kind,
+        message: context.debugDescription,
+        stack: describe(codingPath: context.codingPath)
+    )
+}
+
+private func describe(codingPath: [CodingKey]) -> String? {
+    codingPath.isEmpty ? nil : codingPath.map { $0.stringValue }.joined(separator: ".")
+}

--- a/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
+++ b/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
@@ -16,7 +16,7 @@ import Foundation
 ///   protocol - a conformance is a single, global fact about a (Type, Protocol) pair, so a second,
 ///   conflicting conformance declared elsewhere would be silently discarded. For some foreign types
 ///   (e.g. `EncodingError`, `DecodingError`, `NSError`), `Telemetry` instead applies its own internal
-///   sanitization with sensible defaults, handled centrally in `sanitizeForTelemetry(_:)`.
+///   sanitization with sensible defaults, handled centrally in `TelemetrySanitizedError.init(sanitizing:)`.
 public protocol TelemetrySanitizableError {
     func sanitize() -> TelemetrySanitizedError
 }
@@ -33,40 +33,44 @@ public struct TelemetrySanitizedError {
         self.stack = stack
     }
 
-    /// Describes `error` by its type name and default string interpolation.
+    /// Describes `error` by its type name and default string interpolation, without any sanitization.
     ///
-    /// - Important: Only use this when `error`'s default `"\(error)"` description is known to be
-    ///   safe - e.g. an enum whose cases carry no customer data. Never use it for a type that might
-    ///   wrap arbitrary or customer-supplied values.
-    public init(describing error: Error) {
+    /// - Important: `unsafely` means what it says - only use this when `error`'s default `"\(error)"`
+    ///   description is known to be safe (e.g. an enum whose cases carry no customer data). Never use it
+    ///   for a type that might wrap arbitrary or customer-supplied values; use `init(sanitizing:)` instead.
+    public init(unsafelyDescribing error: Error) {
         self.init(kind: "\(type(of: error))", message: "\(error)")
     }
-}
 
-/// Returns a `TelemetrySanitizedError` describing `error`, safe to forward to internal telemetry.
-///
-/// If `error` conforms to `TelemetrySanitizableError`, its own `sanitize()` is used as-is. Otherwise, it
-/// falls back to Telemetry's default sanitization: common types (`EncodingError`, `DecodingError`,
-/// `NSError`) get a safe, dedicated summary, while everything else is stripped down to its type name.
-public func sanitizeForTelemetry(_ error: Error) -> TelemetrySanitizedError {
-    if let sanitizable = error as? TelemetrySanitizableError {
-        return sanitizable.sanitize()
+    /// Sanitizes `error`, safe to forward to internal telemetry.
+    ///
+    /// If `error` conforms to `TelemetrySanitizableError`, its own `sanitize()` is used as-is. Otherwise, it
+    /// falls back to Telemetry's default sanitization: common types (`EncodingError`, `DecodingError`,
+    /// `NSError`) get a safe, dedicated summary, while everything else is stripped down to its type name.
+    public init(sanitizing error: Error) {
+        if let sanitizable = error as? TelemetrySanitizableError {
+            self = sanitizable.sanitize()
+            return
+        }
+        if let encodingError = error as? EncodingError {
+            self = sanitize(encodingError)
+            return
+        }
+        if let decodingError = error as? DecodingError {
+            self = sanitize(decodingError)
+            return
+        }
+        if isNSErrorOrItsSubclass(error) {
+            self = sanitize(error as NSError)
+            return
+        }
+        let kind = "\(type(of: error))"
+        self.init(
+            kind: kind,
+            message: "\(kind) does not conform to TelemetrySanitizableError — reporting type name only",
+            stack: "Implement TelemetrySanitizableError on \(kind) to report richer, safe context."
+        )
     }
-    if let encodingError = error as? EncodingError {
-        return sanitize(encodingError)
-    }
-    if let decodingError = error as? DecodingError {
-        return sanitize(decodingError)
-    }
-    if isNSErrorOrItsSubclass(error) {
-        return sanitize(error as NSError)
-    }
-    let kind = "\(type(of: error))"
-    return TelemetrySanitizedError(
-        kind: kind,
-        message: "\(kind) does not conform to TelemetrySanitizableError — reporting type name only",
-        stack: "Implement TelemetrySanitizableError on \(kind) to report richer, safe context."
-    )
 }
 
 /// Sanitizes `EncodingError` for telemetry - only the failing case and how deeply nested the offending

--- a/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
+++ b/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
@@ -32,6 +32,15 @@ public struct TelemetrySanitizedError {
         self.message = message
         self.stack = stack
     }
+
+    /// Describes `error` by its type name and default string interpolation.
+    ///
+    /// - Important: Only use this when `error`'s default `"\(error)"` description is known to be
+    ///   safe - e.g. an enum whose cases carry no customer data. Never use it for a type that might
+    ///   wrap arbitrary or customer-supplied values.
+    public init(describing error: Error) {
+        self.init(kind: "\(type(of: error))", message: "\(error)")
+    }
 }
 
 /// Returns a `TelemetrySanitizedError` describing `error`, safe to forward to internal telemetry.

--- a/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
+++ b/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
@@ -69,8 +69,11 @@ public func sanitizeForTelemetry(_ error: Error) -> TelemetrySanitizedError {
     )
 }
 
-/// Sanitizes `EncodingError` for telemetry - only `context.debugDescription`/`codingPath`, never the raw
-/// offending value that `EncodingError.invalidValue(_:_:)` embeds as its first associated value.
+/// Sanitizes `EncodingError` for telemetry - only the failing case and how deeply nested the offending
+/// value was. Never `context.debugDescription` or `codingPath`: `EncodingError.Context` is a plain struct
+/// that whatever `Encodable` threw the error gets to fill in - including a customer-supplied `Encodable`
+/// wrapped in `AnyEncodable` (e.g. a custom RUM attribute) - so both fields must be treated as untrusted,
+/// not just the value `invalidValue(_:_:)` embeds as its first associated value.
 private func sanitize(_ error: EncodingError) -> TelemetrySanitizedError {
     let context: EncodingError.Context
     let kind: String
@@ -84,38 +87,42 @@ private func sanitize(_ error: EncodingError) -> TelemetrySanitizedError {
     }
     return TelemetrySanitizedError(
         kind: kind,
-        message: context.debugDescription,
-        stack: describe(codingPath: context.codingPath)
+        message: "value could not be encoded",
+        stack: describe(depthOf: context.codingPath)
     )
 }
 
-/// Sanitizes `DecodingError` for telemetry - only `context.debugDescription`/`codingPath`, never the raw
-/// offending value that several `DecodingError` cases embed as their first associated value.
+/// Sanitizes `DecodingError` for telemetry - only the failing case and how deeply nested the offending
+/// value was. Never `context.debugDescription` or `codingPath`: `DecodingError.Context` is a plain struct
+/// that whatever `Decodable` threw the error gets to fill in, so both fields must be treated as untrusted,
+/// not just the raw value some `DecodingError` cases embed as their first associated value.
 private func sanitize(_ error: DecodingError) -> TelemetrySanitizedError {
     let context: DecodingError.Context
     let kind: String
+    let message: String
     switch error {
     case .typeMismatch(_, let ctx):
         context = ctx
         kind = "DecodingError.typeMismatch"
+        message = "decoded value had an unexpected type"
     case .valueNotFound(_, let ctx):
         context = ctx
         kind = "DecodingError.valueNotFound"
+        message = "expected value was missing"
     case .keyNotFound(_, let ctx):
         context = ctx
         kind = "DecodingError.keyNotFound"
+        message = "expected key was missing"
     case .dataCorrupted(let ctx):
         context = ctx
         kind = "DecodingError.dataCorrupted"
+        message = "data was corrupted"
     @unknown default:
         context = DecodingError.Context(codingPath: [], debugDescription: "unknown DecodingError case")
         kind = "DecodingError"
+        message = "unknown decoding failure"
     }
-    return TelemetrySanitizedError(
-        kind: kind,
-        message: context.debugDescription,
-        stack: describe(codingPath: context.codingPath)
-    )
+    return TelemetrySanitizedError(kind: kind, message: message, stack: describe(depthOf: context.codingPath))
 }
 
 /// Sanitizes `NSError` for telemetry - only `domain`/`code`, never `userInfo`, which can carry
@@ -124,6 +131,13 @@ private func sanitize(_ error: NSError) -> TelemetrySanitizedError {
     TelemetrySanitizedError(kind: "\(type(of: error))", message: "domain: \(error.domain), code: \(error.code)")
 }
 
-private func describe(codingPath: [CodingKey]) -> String? {
-    codingPath.isEmpty ? nil : codingPath.map { $0.stringValue }.joined(separator: ".")
+/// Describes how deeply nested the offending value was, without naming any of the coding keys along the
+/// way - a key can be a dynamic, customer-supplied name (e.g. a custom attribute or an HTTP header name
+/// encoded through a `[String: Any]` container), so reporting `codingPath` verbatim would risk the same
+/// class of leak this sanitizer exists to prevent.
+private func describe(depthOf codingPath: [CodingKey]) -> String? {
+    guard !codingPath.isEmpty else {
+        return nil
+    }
+    return codingPath.count == 1 ? "1 level deep" : "\(codingPath.count) levels deep"
 }

--- a/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
+++ b/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
@@ -16,7 +16,7 @@ import Foundation
 ///   protocol - a conformance is a single, global fact about a (Type, Protocol) pair, so a second,
 ///   conflicting conformance declared elsewhere would be silently discarded. For some foreign types
 ///   (e.g. `EncodingError`, `DecodingError`, `NSError`), `Telemetry` instead applies its own internal
-///   sanitization with sensible defaults, handled centrally in `makeTelemetrySafe(_:)`.
+///   sanitization with sensible defaults, handled centrally in `sanitizeForTelemetry(_:)`.
 public protocol TelemetrySanitizableError {
     func sanitize() -> TelemetrySanitizedError
 }
@@ -39,7 +39,7 @@ public struct TelemetrySanitizedError {
 /// If `error` conforms to `TelemetrySanitizableError`, its own `sanitize()` is used as-is. Otherwise, it
 /// falls back to Telemetry's default sanitization: common types (`EncodingError`, `DecodingError`,
 /// `NSError`) get a safe, dedicated summary, while everything else is stripped down to its type name.
-func makeTelemetrySafe(_ error: Error) -> TelemetrySanitizedError {
+public func sanitizeForTelemetry(_ error: Error) -> TelemetrySanitizedError {
     if let sanitizable = error as? TelemetrySanitizableError {
         return sanitizable.sanitize()
     }

--- a/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
+++ b/DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift
@@ -50,13 +50,12 @@ public func sanitizeForTelemetry(_ error: Error) -> TelemetrySanitizedError {
         return sanitize(decodingError)
     }
     if isNSErrorOrItsSubclass(error) {
-        let nsError = error as NSError
-        return TelemetrySanitizedError(kind: "\(type(of: nsError))", message: "\(nsError.domain) (\(nsError.code))")
+        return sanitize(error as NSError)
     }
     let kind = "\(type(of: error))"
     return TelemetrySanitizedError(
         kind: kind,
-        message: "Unrecognized error type: \(kind)",
+        message: "\(kind) does not conform to TelemetrySanitizableError — reporting type name only",
         stack: "Implement TelemetrySanitizableError on \(kind) to report richer, safe context."
     )
 }
@@ -108,6 +107,12 @@ private func sanitize(_ error: DecodingError) -> TelemetrySanitizedError {
         message: context.debugDescription,
         stack: describe(codingPath: context.codingPath)
     )
+}
+
+/// Sanitizes `NSError` for telemetry - only `domain`/`code`, never `userInfo`, which can carry
+/// customer-supplied data (e.g. `NSLocalizedDescriptionKey`).
+private func sanitize(_ error: NSError) -> TelemetrySanitizedError {
+    TelemetrySanitizedError(kind: "\(type(of: error))", message: "domain: \(error.domain), code: \(error.code)")
 }
 
 private func describe(codingPath: [CodingKey]) -> String? {

--- a/DatadogInternal/Sources/Utils/DDError.swift
+++ b/DatadogInternal/Sources/Utils/DDError.swift
@@ -43,7 +43,7 @@ extension DDError {
     }
 }
 
-private func isNSErrorOrItsSubclass(_ error: Error) -> Bool {
+internal func isNSErrorOrItsSubclass(_ error: Error) -> Bool {
     var mirror: Mirror? = Mirror(reflecting: error)
 
     while mirror != nil {

--- a/DatadogInternal/Sources/Utils/Reflector.swift
+++ b/DatadogInternal/Sources/Utils/Reflector.swift
@@ -307,6 +307,6 @@ extension Reflector.Error: TelemetrySanitizableError {
     /// `subjectType`/`paths` only ever reference the SDK's own `Reflection` types and property names,
     /// never user data, so the full description is safe to report as-is.
     public func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(kind: "Reflector.Error", message: "\(self)")
+        TelemetrySanitizedError(describing: self)
     }
 }

--- a/DatadogInternal/Sources/Utils/Reflector.swift
+++ b/DatadogInternal/Sources/Utils/Reflector.swift
@@ -302,3 +302,11 @@ extension Reflector.Lazy {
         reflect = { reflection }
     }
 }
+
+extension Reflector.Error: TelemetrySanitizableError {
+    /// `subjectType`/`paths` only ever reference the SDK's own `Reflection` types and property names,
+    /// never user data, so the full description is safe to report as-is.
+    public func sanitize() -> TelemetrySanitizedError {
+        TelemetrySanitizedError(kind: "Reflector.Error", message: "\(self)")
+    }
+}

--- a/DatadogInternal/Sources/Utils/Reflector.swift
+++ b/DatadogInternal/Sources/Utils/Reflector.swift
@@ -307,6 +307,6 @@ extension Reflector.Error: TelemetrySanitizableError {
     /// `subjectType`/`paths` only ever reference the SDK's own `Reflection` types and property names,
     /// never user data, so the full description is safe to report as-is.
     public func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(describing: self)
+        TelemetrySanitizedError(unsafelyDescribing: self)
     }
 }

--- a/DatadogInternal/Tests/Telemetry/TelemetrySanitizableErrorTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetrySanitizableErrorTests.swift
@@ -1,0 +1,161 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogInternal
+
+/// Direct unit tests for `sanitizeForTelemetry(_:)` - the central fallback used by `Telemetry.error(_:)`
+/// to sanitize any `Error` before it is forwarded to Datadog's internal telemetry.
+///
+/// These tests construct `EncodingError`/`DecodingError` cases directly rather than forging them through
+/// a real `JSONEncoder`/`JSONDecoder` failure - `TelemetryTests.swift` covers that end-to-end path.
+class TelemetrySanitizableErrorTests: XCTestCase {
+    // MARK: - `TelemetrySanitizableError` conformance
+
+    func testSanitizingConformingError_returnsItsOwnSanitizedOutputAsIs() {
+        struct SanitizableError: Error, TelemetrySanitizableError {
+            let secret = "should never reach telemetry"
+
+            func sanitize() -> TelemetrySanitizedError {
+                TelemetrySanitizedError(kind: "custom-kind", message: "custom-message", stack: "custom-stack")
+            }
+        }
+
+        let sanitized = sanitizeForTelemetry(SanitizableError())
+
+        XCTAssertEqual(sanitized.kind, "custom-kind")
+        XCTAssertEqual(sanitized.message, "custom-message")
+        XCTAssertEqual(sanitized.stack, "custom-stack")
+    }
+
+    // MARK: - `EncodingError`
+
+    func testSanitizingEncodingErrorInvalidValue_neverReportsTheRawOffendingValue() {
+        // Given
+        // The raw offending value is `EncodingError.invalidValue(_:_:)`'s first associated value - the one
+        // that leaks in full when an `EncodingError` is described via `"\(error)"`.
+        let sensitiveValue = "sensitive-value-\(String.mockRandom(length: 16))"
+        let error = EncodingError.invalidValue(
+            sensitiveValue,
+            EncodingError.Context(codingPath: [], debugDescription: "cannot encode value")
+        )
+
+        // When
+        let sanitized = sanitizeForTelemetry(error)
+
+        // Then
+        XCTAssertEqual(sanitized.kind, "EncodingError.invalidValue")
+        XCTAssertEqual(sanitized.message, "cannot encode value")
+        XCTAssertNil(sanitized.stack, "stack must be nil when codingPath is empty")
+        XCTAssertFalse(sanitized.message.contains(sensitiveValue))
+    }
+
+    func testSanitizingEncodingErrorInvalidValue_withNonEmptyCodingPath_reportsItAsStack() {
+        // Given
+        let error = EncodingError.invalidValue(
+            "value",
+            EncodingError.Context(codingPath: [DynamicCodingKey("foo"), DynamicCodingKey("bar")], debugDescription: "cannot encode value")
+        )
+
+        // When
+        let sanitized = sanitizeForTelemetry(error)
+
+        // Then
+        XCTAssertEqual(sanitized.stack, "foo.bar")
+    }
+
+    // MARK: - `DecodingError`
+
+    func testSanitizingDecodingErrorTypeMismatch() {
+        let error = DecodingError.typeMismatch(
+            Int.self,
+            DecodingError.Context(codingPath: [], debugDescription: "expected Int, found a string")
+        )
+
+        let sanitized = sanitizeForTelemetry(error)
+
+        XCTAssertEqual(sanitized.kind, "DecodingError.typeMismatch")
+        XCTAssertEqual(sanitized.message, "expected Int, found a string")
+        XCTAssertNil(sanitized.stack)
+    }
+
+    func testSanitizingDecodingErrorValueNotFound() {
+        let error = DecodingError.valueNotFound(
+            String.self,
+            DecodingError.Context(codingPath: [DynamicCodingKey("foo")], debugDescription: "expected value, found null")
+        )
+
+        let sanitized = sanitizeForTelemetry(error)
+
+        XCTAssertEqual(sanitized.kind, "DecodingError.valueNotFound")
+        XCTAssertEqual(sanitized.message, "expected value, found null")
+        XCTAssertEqual(sanitized.stack, "foo")
+    }
+
+    func testSanitizingDecodingErrorKeyNotFound() {
+        let error = DecodingError.keyNotFound(
+            DynamicCodingKey("foo"),
+            DecodingError.Context(codingPath: [], debugDescription: "key not found")
+        )
+
+        let sanitized = sanitizeForTelemetry(error)
+
+        XCTAssertEqual(sanitized.kind, "DecodingError.keyNotFound")
+        XCTAssertEqual(sanitized.message, "key not found")
+        XCTAssertNil(sanitized.stack)
+    }
+
+    func testSanitizingDecodingErrorDataCorrupted() {
+        let error = DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [DynamicCodingKey("foo"), DynamicCodingKey("bar")], debugDescription: "data corrupted")
+        )
+
+        let sanitized = sanitizeForTelemetry(error)
+
+        XCTAssertEqual(sanitized.kind, "DecodingError.dataCorrupted")
+        XCTAssertEqual(sanitized.message, "data corrupted")
+        XCTAssertEqual(sanitized.stack, "foo.bar")
+    }
+
+    // MARK: - `NSError`
+
+    func testSanitizingNSError_reportsOnlyDomainAndCode() {
+        // Given
+        // `userInfo` can carry customer-supplied data (e.g. `NSLocalizedDescriptionKey`), so it must
+        // never be reported - only `domain`/`code`.
+        let error = NSError(
+            domain: "custom-domain",
+            code: 10,
+            userInfo: [NSLocalizedDescriptionKey: "sensitive description"]
+        )
+
+        // When
+        let sanitized = sanitizeForTelemetry(error)
+
+        // Then
+        XCTAssertEqual(sanitized.kind, "NSError")
+        XCTAssertEqual(sanitized.message, "custom-domain (10)")
+        XCTAssertNil(sanitized.stack)
+    }
+
+    // MARK: - Unrecognized error types
+
+    func testSanitizingUnrecognizedError_reportsOnlyItsTypeName() {
+        // Given
+        struct CustomError: Error {
+            let secret = "should never reach telemetry"
+        }
+
+        // When
+        let sanitized = sanitizeForTelemetry(CustomError())
+
+        // Then
+        XCTAssertEqual(sanitized.kind, "CustomError")
+        XCTAssertEqual(sanitized.message, "Unrecognized error type: CustomError")
+        XCTAssertEqual(sanitized.stack, "Implement TelemetrySanitizableError on CustomError to report richer, safe context.")
+    }
+}

--- a/DatadogInternal/Tests/Telemetry/TelemetrySanitizableErrorTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetrySanitizableErrorTests.swift
@@ -138,7 +138,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sanitized.kind, "NSError")
-        XCTAssertEqual(sanitized.message, "custom-domain (10)")
+        XCTAssertEqual(sanitized.message, "domain: custom-domain, code: 10")
         XCTAssertNil(sanitized.stack)
     }
 
@@ -155,7 +155,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sanitized.kind, "CustomError")
-        XCTAssertEqual(sanitized.message, "Unrecognized error type: CustomError")
+        XCTAssertEqual(sanitized.message, "CustomError does not conform to TelemetrySanitizableError — reporting type name only")
         XCTAssertEqual(sanitized.stack, "Implement TelemetrySanitizableError on CustomError to report richer, safe context.")
     }
 }

--- a/DatadogInternal/Tests/Telemetry/TelemetrySanitizableErrorTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetrySanitizableErrorTests.swift
@@ -10,9 +10,6 @@ import TestUtilities
 
 /// Direct unit tests for `sanitizeForTelemetry(_:)` - the central fallback used by `Telemetry.error(_:)`
 /// to sanitize any `Error` before it is forwarded to Datadog's internal telemetry.
-///
-/// These tests construct `EncodingError`/`DecodingError` cases directly rather than forging them through
-/// a real `JSONEncoder`/`JSONDecoder` failure - `TelemetryTests.swift` covers that end-to-end path.
 class TelemetrySanitizableErrorTests: XCTestCase {
     // MARK: - `TelemetrySanitizableError` conformance
 
@@ -34,99 +31,159 @@ class TelemetrySanitizableErrorTests: XCTestCase {
 
     // MARK: - `EncodingError`
 
-    func testSanitizingEncodingErrorInvalidValue_neverReportsTheRawOffendingValue() {
+    private func forgeEncodingError<T: Encodable>(encoding value: T, file: StaticString = #filePath, line: UInt = #line) -> EncodingError {
+        do {
+            _ = try JSONEncoder().encode(value)
+            XCTFail("Expected encoding to fail", file: file, line: line)
+            fatalError("Expected encoding to fail")
+        } catch let error as EncodingError {
+            return error
+        } catch {
+            XCTFail("Expected an EncodingError, got \(error)", file: file, line: line)
+            fatalError("Expected an EncodingError, got \(error)")
+        }
+    }
+
+    func testSanitizingEncodingErrorInvalidValue_forTopLevelNonConformingFloat_neverReportsFoundationsDebugDescription() {
         // Given
-        // The raw offending value is `EncodingError.invalidValue(_:_:)`'s first associated value - the one
-        // that leaks in full when an `EncodingError` is described via `"\(error)"`.
-        let sensitiveValue = "sensitive-value-\(String.mockRandom(length: 16))"
-        let error = EncodingError.invalidValue(
-            sensitiveValue,
-            EncodingError.Context(codingPath: [], debugDescription: "cannot encode value")
-        )
+        let error = forgeEncodingError(encoding: Double.nan)
 
         // When
         let sanitized = sanitizeForTelemetry(error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "EncodingError.invalidValue")
-        XCTAssertEqual(sanitized.message, "cannot encode value")
+        XCTAssertEqual(sanitized.message, "value could not be encoded")
         XCTAssertNil(sanitized.stack, "stack must be nil when codingPath is empty")
-        XCTAssertFalse(sanitized.message.contains(sensitiveValue))
     }
 
-    func testSanitizingEncodingErrorInvalidValue_withNonEmptyCodingPath_reportsItAsStack() {
+    func testSanitizingEncodingErrorInvalidValue_forNestedNonConformingFloat_reportsCodingPathDepthOnly() {
         // Given
-        let error = EncodingError.invalidValue(
-            "value",
-            EncodingError.Context(codingPath: [DynamicCodingKey("foo"), DynamicCodingKey("bar")], debugDescription: "cannot encode value")
-        )
+        struct Model: Encodable { let value: Double }
+        let error = forgeEncodingError(encoding: Model(value: .infinity))
 
         // When
         let sanitized = sanitizeForTelemetry(error)
 
         // Then
-        XCTAssertEqual(sanitized.stack, "foo.bar")
+        XCTAssertEqual(sanitized.kind, "EncodingError.invalidValue")
+        XCTAssertEqual(sanitized.message, "value could not be encoded")
+        XCTAssertEqual(sanitized.stack, "1 level deep", "codingPath must be reported as depth, never the literal key name")
+    }
+
+    func testSanitizingEncodingErrorInvalidValue_forDeeplyNestedNonConformingFloat_reportsCodingPathDepthOnly() {
+        // Given
+        struct Inner: Encodable { let value: Double }
+        struct Outer: Encodable { let inner: Inner }
+        let error = forgeEncodingError(encoding: Outer(inner: Inner(value: .infinity)))
+
+        // When
+        let sanitized = sanitizeForTelemetry(error)
+
+        // Then
+        XCTAssertEqual(sanitized.kind, "EncodingError.invalidValue")
+        XCTAssertEqual(sanitized.message, "value could not be encoded")
+        XCTAssertEqual(sanitized.stack, "2 levels deep", "codingPath must be reported as depth, never the literal key names")
     }
 
     // MARK: - `DecodingError`
 
-    func testSanitizingDecodingErrorTypeMismatch() {
-        let error = DecodingError.typeMismatch(
-            Int.self,
-            DecodingError.Context(codingPath: [], debugDescription: "expected Int, found a string")
-        )
+    private struct Response: Decodable { let count: Int }
+    private struct NestedResponse: Decodable { let inner: Response }
 
+    private func forgeDecodingError<T: Decodable>(decoding json: String, as type: T.Type, file: StaticString = #filePath, line: UInt = #line) -> DecodingError {
+        do {
+            _ = try JSONDecoder().decode(type, from: Data(json.utf8))
+            XCTFail("Expected decoding to fail", file: file, line: line)
+            fatalError("Expected decoding to fail")
+        } catch let error as DecodingError {
+            return error
+        } catch {
+            XCTFail("Expected a DecodingError, got \(error)", file: file, line: line)
+            fatalError("Expected a DecodingError, got \(error)")
+        }
+    }
+
+    private func forgeDecodingError(decoding json: String, file: StaticString = #filePath, line: UInt = #line) -> DecodingError {
+        forgeDecodingError(decoding: json, as: Response.self, file: file, line: line)
+    }
+
+    func testSanitizingDecodingErrorTypeMismatch() {
+        // Given
+        let sensitiveValue = "sensitive-value-\(String.mockRandom(length: 16))"
+        let error = forgeDecodingError(decoding: "{\"count\": \"\(sensitiveValue)\"}")
+
+        // When
         let sanitized = sanitizeForTelemetry(error)
 
+        // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.typeMismatch")
-        XCTAssertEqual(sanitized.message, "expected Int, found a string")
-        XCTAssertNil(sanitized.stack)
+        XCTAssertEqual(sanitized.message, "decoded value had an unexpected type")
+        XCTAssertEqual(sanitized.stack, "1 level deep", "codingPath must be reported as depth, never the literal key name")
+        XCTAssertFalse(sanitized.message.contains(sensitiveValue))
+        XCTAssertFalse((sanitized.stack ?? "").contains(sensitiveValue))
+    }
+
+    func testSanitizingDecodingErrorTypeMismatch_whenDeeplyNested_reportsCodingPathDepthOnly() {
+        // Given
+        let sensitiveValue = "sensitive-value-\(String.mockRandom(length: 16))"
+        let error = forgeDecodingError(decoding: "{\"inner\": {\"count\": \"\(sensitiveValue)\"}}", as: NestedResponse.self)
+
+        // When
+        let sanitized = sanitizeForTelemetry(error)
+
+        // Then
+        XCTAssertEqual(sanitized.kind, "DecodingError.typeMismatch")
+        XCTAssertEqual(sanitized.message, "decoded value had an unexpected type")
+        XCTAssertEqual(sanitized.stack, "2 levels deep", "codingPath must be reported as depth, never the literal key names")
+        XCTAssertFalse((sanitized.stack ?? "").contains(sensitiveValue))
     }
 
     func testSanitizingDecodingErrorValueNotFound() {
-        let error = DecodingError.valueNotFound(
-            String.self,
-            DecodingError.Context(codingPath: [DynamicCodingKey("foo")], debugDescription: "expected value, found null")
-        )
+        // Given
+        let error = forgeDecodingError(decoding: "{\"count\": null}")
 
+        // When
         let sanitized = sanitizeForTelemetry(error)
 
+        // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.valueNotFound")
-        XCTAssertEqual(sanitized.message, "expected value, found null")
-        XCTAssertEqual(sanitized.stack, "foo")
+        XCTAssertEqual(sanitized.message, "expected value was missing")
+        XCTAssertEqual(sanitized.stack, "1 level deep")
     }
 
     func testSanitizingDecodingErrorKeyNotFound() {
-        let error = DecodingError.keyNotFound(
-            DynamicCodingKey("foo"),
-            DecodingError.Context(codingPath: [], debugDescription: "key not found")
-        )
+        // Given
+        let error = forgeDecodingError(decoding: "{}")
 
+        // When
         let sanitized = sanitizeForTelemetry(error)
 
+        // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.keyNotFound")
-        XCTAssertEqual(sanitized.message, "key not found")
-        XCTAssertNil(sanitized.stack)
+        XCTAssertEqual(sanitized.message, "expected key was missing")
+        XCTAssertNil(sanitized.stack, "codingPath is empty when the missing key is at the top level")
     }
 
     func testSanitizingDecodingErrorDataCorrupted() {
-        let error = DecodingError.dataCorrupted(
-            DecodingError.Context(codingPath: [DynamicCodingKey("foo"), DynamicCodingKey("bar")], debugDescription: "data corrupted")
-        )
+        // Given
+        let sensitiveValue = "sensitive-payload-\(String.mockRandom(length: 16))"
+        let error = forgeDecodingError(decoding: "{\"count\": 1, \"extra\": \"\(sensitiveValue)\" not-valid-json-after-this")
 
+        // When
         let sanitized = sanitizeForTelemetry(error)
 
+        // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.dataCorrupted")
-        XCTAssertEqual(sanitized.message, "data corrupted")
-        XCTAssertEqual(sanitized.stack, "foo.bar")
+        XCTAssertEqual(sanitized.message, "data was corrupted")
+        XCTAssertNil(sanitized.stack)
+        XCTAssertFalse(sanitized.message.contains(sensitiveValue))
     }
 
     // MARK: - `NSError`
 
     func testSanitizingNSError_reportsOnlyDomainAndCode() {
         // Given
-        // `userInfo` can carry customer-supplied data (e.g. `NSLocalizedDescriptionKey`), so it must
-        // never be reported - only `domain`/`code`.
         let error = NSError(
             domain: "custom-domain",
             code: 10,

--- a/DatadogInternal/Tests/Telemetry/TelemetrySanitizableErrorTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetrySanitizableErrorTests.swift
@@ -8,8 +8,8 @@ import XCTest
 import TestUtilities
 @testable import DatadogInternal
 
-/// Direct unit tests for `sanitizeForTelemetry(_:)` - the central fallback used by `Telemetry.error(_:)`
-/// to sanitize any `Error` before it is forwarded to Datadog's internal telemetry.
+/// Direct unit tests for `TelemetrySanitizedError.init(sanitizing:)` - the central fallback used by
+/// `Telemetry.error(_:)` to sanitize any `Error` before it is forwarded to Datadog's internal telemetry.
 class TelemetrySanitizableErrorTests: XCTestCase {
     // MARK: - `TelemetrySanitizableError` conformance
 
@@ -22,7 +22,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
             }
         }
 
-        let sanitized = sanitizeForTelemetry(SanitizableError())
+        let sanitized = TelemetrySanitizedError(sanitizing: SanitizableError())
 
         XCTAssertEqual(sanitized.kind, "custom-kind")
         XCTAssertEqual(sanitized.message, "custom-message")
@@ -49,7 +49,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         let error = forgeEncodingError(encoding: Double.nan)
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "EncodingError.invalidValue")
@@ -63,7 +63,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         let error = forgeEncodingError(encoding: Model(value: .infinity))
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "EncodingError.invalidValue")
@@ -78,7 +78,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         let error = forgeEncodingError(encoding: Outer(inner: Inner(value: .infinity)))
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "EncodingError.invalidValue")
@@ -114,7 +114,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         let error = forgeDecodingError(decoding: "{\"count\": \"\(sensitiveValue)\"}")
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.typeMismatch")
@@ -130,7 +130,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         let error = forgeDecodingError(decoding: "{\"inner\": {\"count\": \"\(sensitiveValue)\"}}", as: NestedResponse.self)
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.typeMismatch")
@@ -144,7 +144,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         let error = forgeDecodingError(decoding: "{\"count\": null}")
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.valueNotFound")
@@ -157,7 +157,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         let error = forgeDecodingError(decoding: "{}")
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.keyNotFound")
@@ -171,7 +171,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         let error = forgeDecodingError(decoding: "{\"count\": 1, \"extra\": \"\(sensitiveValue)\" not-valid-json-after-this")
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "DecodingError.dataCorrupted")
@@ -191,7 +191,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         )
 
         // When
-        let sanitized = sanitizeForTelemetry(error)
+        let sanitized = TelemetrySanitizedError(sanitizing: error)
 
         // Then
         XCTAssertEqual(sanitized.kind, "NSError")
@@ -208,7 +208,7 @@ class TelemetrySanitizableErrorTests: XCTestCase {
         }
 
         // When
-        let sanitized = sanitizeForTelemetry(CustomError())
+        let sanitized = TelemetrySanitizedError(sanitizing: CustomError())
 
         // Then
         XCTAssertEqual(sanitized.kind, "CustomError")

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -78,10 +78,10 @@ class TelemetryTests: XCTestCase {
         // so it falls back to the type-name-only default - its raw associated values must never leak into telemetry.
         let errors = telemetry.messages.compactMap({ $0.asError })
         XCTAssertEqual(telemetry.messages.count, 2)
-        XCTAssertEqual(errors[0].message, "Unrecognized error type: SwiftError")
+        XCTAssertEqual(errors[0].message, "SwiftError does not conform to TelemetrySanitizableError — reporting type name only")
         XCTAssertEqual(errors[0].kind, "SwiftError")
         XCTAssertEqual(errors[0].stack, "\(moduleName())/File.swift:1\nImplement TelemetrySanitizableError on SwiftError to report richer, safe context.")
-        XCTAssertEqual(errors[1].message, "custom message - Unrecognized error type: SwiftError")
+        XCTAssertEqual(errors[1].message, "custom message - SwiftError does not conform to TelemetrySanitizableError — reporting type name only")
         XCTAssertEqual(errors[1].kind, "SwiftError")
         XCTAssertEqual(errors[1].stack, "\(moduleName())/File.swift:2\nImplement TelemetrySanitizableError on SwiftError to report richer, safe context.")
     }
@@ -202,10 +202,10 @@ class TelemetryTests: XCTestCase {
         // `"\(file):\(line)"` default - the call site above, not the error's own stack.
         let errors = telemetry.messages.compactMap({ $0.asError })
         XCTAssertEqual(telemetry.messages.count, 2)
-        XCTAssertEqual(errors[0].message, "custom-domain (10)")
+        XCTAssertEqual(errors[0].message, "domain: custom-domain, code: 10")
         XCTAssertEqual(errors[0].kind, "NSError")
         XCTAssertEqual(errors[0].stack, "\(moduleName())/File.swift:1")
-        XCTAssertEqual(errors[1].message, "custom message - custom-domain (10)")
+        XCTAssertEqual(errors[1].message, "custom message - domain: custom-domain, code: 10")
         XCTAssertEqual(errors[1].kind, "NSError")
         XCTAssertEqual(errors[1].stack, "\(moduleName())/File.swift:2")
     }

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -151,6 +151,36 @@ class TelemetryTests: XCTestCase {
         XCTAssertFalse("\(error)".contains(attributeValue), "error must not capture raw attribute values: \(error)")
     }
 
+    // `DecodingError` doesn't conform to `TelemetrySanitizableError`, so it goes through
+    // `sanitizeForTelemetry(_:)`'s dedicated `DecodingError` branch - only `context.debugDescription`/
+    // `codingPath` must be reported, never the raw decoded value.
+    func testSendingErrorTelemetry_withDecodingError() throws {
+        // Given
+        struct Response: Decodable { let count: Int }
+        let sensitiveValue = "sensitive-value-\(String.mockRandom(length: 16))"
+        let json = "{\"count\": \"\(sensitiveValue)\"}".data(using: .utf8)! // `count` should be an `Int`, not a `String`
+
+        let decodingError: DecodingError
+        do {
+            _ = try JSONDecoder().decode(Response.self, from: json)
+            XCTFail("Decoding a type-mismatched value should fail")
+            fatalError("Decoding a type-mismatched value should fail")
+        } catch let error as DecodingError {
+            decodingError = error
+        } catch {
+            XCTFail("Expected a DecodingError, got \(error)")
+            fatalError("Expected a DecodingError, got \(error)")
+        }
+
+        // When
+        telemetry.error("failed to decode response", error: decodingError)
+
+        // Then
+        let error = try XCTUnwrap(telemetry.messages.compactMap({ $0.asError }).first)
+        XCTAssertEqual(error.kind, "DecodingError.typeMismatch")
+        XCTAssertFalse("\(error)".contains(sensitiveValue), "error must not capture raw decoded values: \(error)")
+    }
+
     func testSendingErrorTelemetry_withNSError() throws {
         // Given
         let nsError = NSError(

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -41,7 +41,7 @@ class TelemetryTests: XCTestCase {
         XCTAssertEqual(error.id, "\(moduleName())/File.swift:1:error message")
         XCTAssertEqual(error.message, "error message")
         XCTAssertEqual(error.kind, "error.kind")
-        XCTAssertEqual(error.stack, "error.stack")
+        XCTAssertEqual(error.stack, "\(moduleName())/File.swift:1\nerror.stack")
         XCTAssertEqual(telemetry.messages.count, 1)
     }
 
@@ -68,8 +68,10 @@ class TelemetryTests: XCTestCase {
         let swiftError = SwiftError()
 
         // When
+        #sourceLocation(file: "File.swift", line: 1)
         telemetry.error(swiftError)
         telemetry.error("custom message", error: swiftError)
+        #sourceLocation()
 
         // Then
         // `SwiftError` doesn't conform to `TelemetrySanitizableError`, isn't `EncodingError`/`DecodingError`/`NSError`,
@@ -78,10 +80,10 @@ class TelemetryTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 2)
         XCTAssertEqual(errors[0].message, "Unrecognized error type: SwiftError")
         XCTAssertEqual(errors[0].kind, "SwiftError")
-        XCTAssertEqual(errors[0].stack, "Implement TelemetrySanitizableError on SwiftError to report richer, safe context.")
+        XCTAssertEqual(errors[0].stack, "\(moduleName())/File.swift:1\nImplement TelemetrySanitizableError on SwiftError to report richer, safe context.")
         XCTAssertEqual(errors[1].message, "custom message - Unrecognized error type: SwiftError")
         XCTAssertEqual(errors[1].kind, "SwiftError")
-        XCTAssertEqual(errors[1].stack, "Implement TelemetrySanitizableError on SwiftError to report richer, safe context.")
+        XCTAssertEqual(errors[1].stack, "\(moduleName())/File.swift:2\nImplement TelemetrySanitizableError on SwiftError to report richer, safe context.")
     }
 
     func testSendingErrorTelemetry_withSanitizableSwiftError() throws {
@@ -96,8 +98,10 @@ class TelemetryTests: XCTestCase {
         let error = SanitizableSwiftError()
 
         // When
+        #sourceLocation(file: "File.swift", line: 1)
         telemetry.error(error)
         telemetry.error("custom message", error: error)
+        #sourceLocation()
 
         // Then
         // Conforming to `TelemetrySanitizableError` opts out of the default fallback - `sanitize()`'s
@@ -106,10 +110,10 @@ class TelemetryTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 2)
         XCTAssertEqual(errors[0].message, "sanitized message")
         XCTAssertEqual(errors[0].kind, "SanitizableSwiftError")
-        XCTAssertEqual(errors[0].stack, "sanitized stack")
+        XCTAssertEqual(errors[0].stack, "\(moduleName())/File.swift:1\nsanitized stack")
         XCTAssertEqual(errors[1].message, "custom message - sanitized message")
         XCTAssertEqual(errors[1].kind, "SanitizableSwiftError")
-        XCTAssertEqual(errors[1].stack, "sanitized stack")
+        XCTAssertEqual(errors[1].stack, "\(moduleName())/File.swift:2\nsanitized stack")
     }
 
     // RUM-17396: `AnyEncodable`'s `encode(to:)` falls back to a `default:` branch for values
@@ -156,8 +160,10 @@ class TelemetryTests: XCTestCase {
         )
 
         // When
+        #sourceLocation(file: "File.swift", line: 1)
         telemetry.error(nsError)
         telemetry.error("custom message", error: nsError)
+        #sourceLocation()
 
         // Then
         // `NSError`'s `userInfo` can carry customer-supplied data (e.g. `NSLocalizedDescriptionKey`), so
@@ -168,10 +174,10 @@ class TelemetryTests: XCTestCase {
         XCTAssertEqual(telemetry.messages.count, 2)
         XCTAssertEqual(errors[0].message, "custom-domain (10)")
         XCTAssertEqual(errors[0].kind, "NSError")
-        XCTAssertEqual(errors[0].stack, "\(moduleName())/TelemetryTests.swift:159")
+        XCTAssertEqual(errors[0].stack, "\(moduleName())/File.swift:1")
         XCTAssertEqual(errors[1].message, "custom message - custom-domain (10)")
         XCTAssertEqual(errors[1].kind, "NSError")
-        XCTAssertEqual(errors[1].stack, "\(moduleName())/TelemetryTests.swift:160")
+        XCTAssertEqual(errors[1].stack, "\(moduleName())/File.swift:2")
     }
 
     func testSendingErrorTelemetry_withSanitizableNSError() throws {
@@ -187,18 +193,20 @@ class TelemetryTests: XCTestCase {
         let error = SanitizableNSError(domain: "custom-domain", code: 10, userInfo: [NSLocalizedDescriptionKey: "error description"])
 
         // When
+        #sourceLocation(file: "File.swift", line: 1)
         telemetry.error(error)
         telemetry.error("custom message", error: error)
+        #sourceLocation()
 
         // Then
         let errors = telemetry.messages.compactMap({ $0.asError })
         XCTAssertEqual(telemetry.messages.count, 2)
         XCTAssertEqual(errors[0].message, "sanitized message")
         XCTAssertEqual(errors[0].kind, "SanitizableNSError")
-        XCTAssertEqual(errors[0].stack, "sanitized stack")
+        XCTAssertEqual(errors[0].stack, "\(moduleName())/File.swift:1\nsanitized stack")
         XCTAssertEqual(errors[1].message, "custom message - sanitized message")
         XCTAssertEqual(errors[1].kind, "SanitizableNSError")
-        XCTAssertEqual(errors[1].stack, "sanitized stack")
+        XCTAssertEqual(errors[1].stack, "\(moduleName())/File.swift:2\nsanitized stack")
     }
 
     // MARK: - Configuration Telemetry

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -152,7 +152,7 @@ class TelemetryTests: XCTestCase {
     }
 
     // `DecodingError` doesn't conform to `TelemetrySanitizableError`, so it goes through
-    // `sanitizeForTelemetry(_:)`'s dedicated `DecodingError` branch - only `context.debugDescription`/
+    // `TelemetrySanitizedError.init(sanitizing:)`'s dedicated `DecodingError` branch - only `context.debugDescription`/
     // `codingPath` must be reported, never the raw decoded value.
     func testSendingErrorTelemetry_withDecodingError() throws {
         // Given

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -72,14 +72,44 @@ class TelemetryTests: XCTestCase {
         telemetry.error("custom message", error: swiftError)
 
         // Then
+        // `SwiftError` doesn't conform to `TelemetrySanitizableError`, isn't `EncodingError`/`DecodingError`/`NSError`,
+        // so it falls back to the type-name-only default - its raw associated values must never leak into telemetry.
         let errors = telemetry.messages.compactMap({ $0.asError })
         XCTAssertEqual(telemetry.messages.count, 2)
-        XCTAssertEqual(errors[0].message, #"SwiftError(description: "error description")"#)
+        XCTAssertEqual(errors[0].message, "Unrecognized error type: SwiftError")
         XCTAssertEqual(errors[0].kind, "SwiftError")
-        XCTAssertEqual(errors[0].stack, #"SwiftError(description: "error description")"#)
-        XCTAssertEqual(errors[1].message, #"custom message - SwiftError(description: "error description")"#)
+        XCTAssertEqual(errors[0].stack, "Implement TelemetrySanitizableError on SwiftError to report richer, safe context.")
+        XCTAssertEqual(errors[1].message, "custom message - Unrecognized error type: SwiftError")
         XCTAssertEqual(errors[1].kind, "SwiftError")
-        XCTAssertEqual(errors[1].stack, #"SwiftError(description: "error description")"#)
+        XCTAssertEqual(errors[1].stack, "Implement TelemetrySanitizableError on SwiftError to report richer, safe context.")
+    }
+
+    func testSendingErrorTelemetry_withSanitizableSwiftError() throws {
+        // Given
+        struct SanitizableSwiftError: Error, TelemetrySanitizableError {
+            let secret = "should never reach telemetry"
+
+            func sanitize() -> TelemetrySanitizedError {
+                TelemetrySanitizedError(kind: "SanitizableSwiftError", message: "sanitized message", stack: "sanitized stack")
+            }
+        }
+        let error = SanitizableSwiftError()
+
+        // When
+        telemetry.error(error)
+        telemetry.error("custom message", error: error)
+
+        // Then
+        // Conforming to `TelemetrySanitizableError` opts out of the default fallback - `sanitize()`'s
+        // output is reported as-is.
+        let errors = telemetry.messages.compactMap({ $0.asError })
+        XCTAssertEqual(telemetry.messages.count, 2)
+        XCTAssertEqual(errors[0].message, "sanitized message")
+        XCTAssertEqual(errors[0].kind, "SanitizableSwiftError")
+        XCTAssertEqual(errors[0].stack, "sanitized stack")
+        XCTAssertEqual(errors[1].message, "custom message - sanitized message")
+        XCTAssertEqual(errors[1].kind, "SanitizableSwiftError")
+        XCTAssertEqual(errors[1].stack, "sanitized stack")
     }
 
     // RUM-17396: `AnyEncodable`'s `encode(to:)` falls back to a `default:` branch for values
@@ -130,14 +160,45 @@ class TelemetryTests: XCTestCase {
         telemetry.error("custom message", error: nsError)
 
         // Then
+        // `NSError`'s `userInfo` can carry customer-supplied data (e.g. `NSLocalizedDescriptionKey`), so
+        // only its domain/code are reported - never `userInfo` or the default `"\(nsError)"` description.
+        // `TelemetrySanitizedError.stack` is nil here, so `Telemetry.error` falls back to its own
+        // `"\(file):\(line)"` default - the call site above, not the error's own stack.
         let errors = telemetry.messages.compactMap({ $0.asError })
         XCTAssertEqual(telemetry.messages.count, 2)
-        XCTAssertEqual(errors[0].message, "error description")
-        XCTAssertEqual(errors[0].kind, "custom-domain - 10")
-        XCTAssertEqual(errors[0].stack, #"Error Domain=custom-domain Code=10 "error description" UserInfo={NSLocalizedDescription=error description}"#)
-        XCTAssertEqual(errors[1].message, "custom message - error description")
-        XCTAssertEqual(errors[1].kind, "custom-domain - 10")
-        XCTAssertEqual(errors[1].stack, #"Error Domain=custom-domain Code=10 "error description" UserInfo={NSLocalizedDescription=error description}"#)
+        XCTAssertEqual(errors[0].message, "custom-domain (10)")
+        XCTAssertEqual(errors[0].kind, "NSError")
+        XCTAssertEqual(errors[0].stack, "\(moduleName())/TelemetryTests.swift:159")
+        XCTAssertEqual(errors[1].message, "custom message - custom-domain (10)")
+        XCTAssertEqual(errors[1].kind, "NSError")
+        XCTAssertEqual(errors[1].stack, "\(moduleName())/TelemetryTests.swift:160")
+    }
+
+    func testSendingErrorTelemetry_withSanitizableNSError() throws {
+        // Given
+        // A dedicated `NSError` subclass declaring its own `TelemetrySanitizableError` conformance -
+        // not a retroactive `extension NSError: TelemetrySanitizableError`, which the protocol's docs warn
+        // against since it would be a single, global fact about the (NSError, TelemetrySanitizableError) pair.
+        final class SanitizableNSError: NSError, TelemetrySanitizableError {
+            func sanitize() -> TelemetrySanitizedError {
+                TelemetrySanitizedError(kind: "SanitizableNSError", message: "sanitized message", stack: "sanitized stack")
+            }
+        }
+        let error = SanitizableNSError(domain: "custom-domain", code: 10, userInfo: [NSLocalizedDescriptionKey: "error description"])
+
+        // When
+        telemetry.error(error)
+        telemetry.error("custom message", error: error)
+
+        // Then
+        let errors = telemetry.messages.compactMap({ $0.asError })
+        XCTAssertEqual(telemetry.messages.count, 2)
+        XCTAssertEqual(errors[0].message, "sanitized message")
+        XCTAssertEqual(errors[0].kind, "SanitizableNSError")
+        XCTAssertEqual(errors[0].stack, "sanitized stack")
+        XCTAssertEqual(errors[1].message, "custom message - sanitized message")
+        XCTAssertEqual(errors[1].kind, "SanitizableNSError")
+        XCTAssertEqual(errors[1].stack, "sanitized stack")
     }
 
     // MARK: - Configuration Telemetry

--- a/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
+++ b/DatadogInternal/Tests/Telemetry/TelemetryTests.swift
@@ -82,6 +82,41 @@ class TelemetryTests: XCTestCase {
         XCTAssertEqual(errors[1].stack, #"SwiftError(description: "error description")"#)
     }
 
+    // RUM-17396: `AnyEncodable`'s `encode(to:)` falls back to a `default:` branch for values
+    // it cannot cast to a supported shape (e.g. a dictionary with non-`String` keys), throwing
+    // an `EncodingError` whose default Swift description embeds the whole raw offending value.
+    // If such an error reaches `Telemetry.error`, that raw value must be dropped before it is
+    // sent through internal telemetry.
+    func testSendingErrorTelemetry_doesNotCaptureRawAttributeValueFromAnyEncodableEncodingError() throws {
+        // Given
+        // Forge `AnyEncodable`'s encoding error by encoding an unsupported value.
+        func forgeAnyEncodableEncodingError(capturing attributeValue: String) -> Error {
+            struct CustomKey: Hashable {
+                func hash(into hasher: inout Hasher) { hasher.combine(42) }
+            }
+            let unsupportedEncodable = [CustomKey(): attributeValue]
+            let encodable = AnyEncodable(unsupportedEncodable)
+            do {
+                _ = try JSONEncoder().encode(encodable)
+                XCTFail("Encoding with custom key should fail")
+                fatalError("Encoding with custom key should fail")
+            } catch {
+                return error
+            }
+        }
+
+        let attributeValue = "attribute-value-\(String.mockRandom(length: 16))"
+        let encodingError = forgeAnyEncodableEncodingError(capturing: attributeValue)
+        XCTAssertTrue("\(encodingError)".contains(attributeValue), "the forged error captures the raw attribute value")
+
+        // When
+        telemetry.error("failed to encode attribute", error: encodingError)
+
+        // Then
+        let error = try XCTUnwrap(telemetry.messages.compactMap({ $0.asError }).first)
+        XCTAssertFalse("\(error)".contains(attributeValue), "error must not capture raw attribute values: \(error)")
+    }
+
     func testSendingErrorTelemetry_withNSError() throws {
         // Given
         let nsError = NSError(

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -73,7 +73,9 @@ class TelemetryReceiverTests: XCTestCase {
         )
 
         // When
+        #sourceLocation(file: "File.swift", line: 1)
         TelemetryMock(with: receiver).error("Oops", kind: "OutOfMemory", stack: "a\nhay\nneedle\nstack")
+        #sourceLocation()
 
         // Then
         let event = featureScope.eventsWritten(ofType: TelemetryErrorEvent.self).first
@@ -83,7 +85,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.source, .ios)
         XCTAssertEqual(event?.telemetry.message, "Oops")
         XCTAssertEqual(event?.telemetry.error?.kind, "OutOfMemory")
-        XCTAssertEqual(event?.telemetry.error?.stack, "a\nhay\nneedle\nstack")
+        XCTAssertEqual(event?.telemetry.error?.stack, "\(moduleName())/File.swift:1\na\nhay\nneedle\nstack")
         XCTAssertEqual(event?.effectiveSampleRate, 100)
     }
 

--- a/DatadogSessionReplay/Sources/Processor/Builders/RecordsBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/Builders/RecordsBuilder.swift
@@ -70,7 +70,7 @@ internal class RecordsBuilder {
             return try createIncrementalSnapshotRecord(from: snapshot, newWireframes: wireframes, lastWireframes: lastWireframes)
         } catch {
             // In case of any trouble, fallback to FSR which is always possible:
-            telemetry.error("[SR] Failed to create incremental record", error: DDError(error: error))
+            telemetry.error("[SR] Failed to create incremental record", error: error)
             return createFullSnapshotRecord(from: snapshot, wireframes: wireframes)
         }
     }

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -80,7 +80,7 @@ extension WireframeMutationError: TelemetrySanitizableError {
     /// Both cases only ever describe the SDK's own wireframe kind names (e.g. "shape", "text"),
     /// never customer content, so the full description is safe to report as-is.
     func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(describing: self)
+        TelemetrySanitizedError(unsafelyDescribing: self)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -80,7 +80,7 @@ extension WireframeMutationError: TelemetrySanitizableError {
     /// Both cases only ever describe the SDK's own wireframe kind names (e.g. "shape", "text"),
     /// never customer content, so the full description is safe to report as-is.
     func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(kind: "WireframeMutationError", message: "\(self)")
+        TelemetrySanitizedError(describing: self)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -6,6 +6,7 @@
 
 #if os(iOS)
 import Foundation
+import DatadogInternal
 
 // MARK: - `Diffable` Conformance
 
@@ -73,6 +74,14 @@ internal enum WireframeMutationError: Error, Equatable {
     case idMismatch
     /// Indicates an attempt of computing mutation for wireframes that have different type.
     case typeMismatch(fromType: String, toType: String)
+}
+
+extension WireframeMutationError: TelemetrySanitizableError {
+    /// Both cases only ever describe the SDK's own wireframe kind names (e.g. "shape", "text"),
+    /// never customer content, so the full description is safe to report as-is.
+    func sanitize() -> TelemetrySanitizedError {
+        TelemetrySanitizedError(kind: "WireframeMutationError", message: "\(self)")
+    }
 }
 
 internal protocol MutableWireframe {

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -116,7 +116,7 @@ extension Data {
 extension Data.SerializationError: TelemetrySanitizableError {
     /// The only case, `invalidData`, carries no associated value, so the full description is safe to report as-is.
     func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(kind: "Data.SerializationError", message: "\(self)")
+        TelemetrySanitizedError(describing: self)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -113,6 +113,13 @@ extension Data {
     }
 }
 
+extension Data.SerializationError: TelemetrySanitizableError {
+    /// The only case, `invalidData`, carries no associated value, so the full description is safe to report as-is.
+    func sanitize() -> TelemetrySanitizedError {
+        TelemetrySanitizedError(kind: "Data.SerializationError", message: "\(self)")
+    }
+}
+
 extension TimeInterval {
     func asData() -> Data {
         return Swift.withUnsafeBytes(of: self) {

--- a/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
+++ b/DatadogSessionReplay/Sources/Writers/ResourcesWriter.swift
@@ -116,7 +116,7 @@ extension Data {
 extension Data.SerializationError: TelemetrySanitizableError {
     /// The only case, `invalidData`, carries no associated value, so the full description is safe to report as-is.
     func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(describing: self)
+        TelemetrySanitizedError(unsafelyDescribing: self)
     }
 }
 

--- a/DatadogSessionReplay/Tests/Processor/Builders/RecordsBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Builders/RecordsBuilderTests.swift
@@ -107,7 +107,7 @@ class RecordsBuilderTests: XCTestCase {
             telemetry.description,
             """
             Telemetry logs:
-             - [error] [SR] Failed to create incremental record - typeMismatch(fromType: "shape", toType: "text"), kind: WireframeMutationError, stack: typeMismatch(fromType: "shape", toType: "text")
+             - [error] [SR] Failed to create incremental record - typeMismatch(fromType: "shape", toType: "text"), kind: WireframeMutationError, stack: DatadogSessionReplay/RecordsBuilder.swift:73
             """
         )
     }

--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -132,7 +132,7 @@ class RecordingCoordinatorTests: XCTestCase {
 
         // Then
         let error = telemetry.messages.firstError()
-        XCTAssertEqual(error?.message, "[SR] Failed to take snapshot - Unrecognized error type: ErrorMock")
+        XCTAssertEqual(error?.message, "[SR] Failed to take snapshot - ErrorMock does not conform to TelemetrySanitizableError — reporting type name only")
         XCTAssertEqual(error?.kind, "ErrorMock")
         XCTAssertEqual(error?.stack, "DatadogSessionReplay/RecordingCoordinator.swift:176\nImplement TelemetrySanitizableError on ErrorMock to report richer, safe context.")
     }
@@ -152,7 +152,7 @@ class RecordingCoordinatorTests: XCTestCase {
 
         // Then
         let error = telemetry.messages.firstError()
-        XCTAssertEqual(error?.message, "[SR] Failed to take snapshot due to Objective-C runtime exception - Unrecognized error type: ErrorMock")
+        XCTAssertEqual(error?.message, "[SR] Failed to take snapshot due to Objective-C runtime exception - ErrorMock does not conform to TelemetrySanitizableError — reporting type name only")
         XCTAssertEqual(error?.kind, "ErrorMock")
         XCTAssertEqual(error?.stack, "DatadogSessionReplay/RecordingCoordinator.swift:169\nImplement TelemetrySanitizableError on ErrorMock to report richer, safe context.")
         XCTAssertFalse(scheduler.isRunning)

--- a/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/RecordingCoordinatorTests.swift
@@ -132,9 +132,9 @@ class RecordingCoordinatorTests: XCTestCase {
 
         // Then
         let error = telemetry.messages.firstError()
-        XCTAssertEqual(error?.message, "[SR] Failed to take snapshot - snapshot creation error")
+        XCTAssertEqual(error?.message, "[SR] Failed to take snapshot - Unrecognized error type: ErrorMock")
         XCTAssertEqual(error?.kind, "ErrorMock")
-        XCTAssertEqual(error?.stack, "snapshot creation error")
+        XCTAssertEqual(error?.stack, "DatadogSessionReplay/RecordingCoordinator.swift:176\nImplement TelemetrySanitizableError on ErrorMock to report richer, safe context.")
     }
 
     func test_whenCapturingSnapshotFails_withObjCRuntimeException_itSendsErrorTelemetry() {
@@ -152,9 +152,9 @@ class RecordingCoordinatorTests: XCTestCase {
 
         // Then
         let error = telemetry.messages.firstError()
-        XCTAssertEqual(error?.message, "[SR] Failed to take snapshot due to Objective-C runtime exception - snapshot creation error")
+        XCTAssertEqual(error?.message, "[SR] Failed to take snapshot due to Objective-C runtime exception - Unrecognized error type: ErrorMock")
         XCTAssertEqual(error?.kind, "ErrorMock")
-        XCTAssertEqual(error?.stack, "snapshot creation error")
+        XCTAssertEqual(error?.stack, "DatadogSessionReplay/RecordingCoordinator.swift:169\nImplement TelemetrySanitizableError on ErrorMock to report richer, safe context.")
         XCTAssertFalse(scheduler.isRunning)
     }
 

--- a/DatadogWebViewTracking/Tests/MessageEmitterTests.swift
+++ b/DatadogWebViewTracking/Tests/MessageEmitterTests.swift
@@ -147,6 +147,6 @@ class MessageEmitterTests: XCTestCase {
         // Then
         XCTAssertEqual(dd.logger.errorLog?.message, "Encountered an error when receiving web view event")
         XCTAssertEqual(dd.logger.errorLog?.error?.message, #"invalidMessage(description: "123")"#)
-        XCTAssertEqual(telemetry.messages.first?.asError?.message, #"Encountered an error when receiving web view event - invalidMessage(description: "123")"#)
+        XCTAssertEqual(telemetry.messages.first?.asError?.message, "Encountered an error when receiving web view event - Unrecognized error type: WebViewMessageError")
     }
 }

--- a/DatadogWebViewTracking/Tests/MessageEmitterTests.swift
+++ b/DatadogWebViewTracking/Tests/MessageEmitterTests.swift
@@ -147,6 +147,6 @@ class MessageEmitterTests: XCTestCase {
         // Then
         XCTAssertEqual(dd.logger.errorLog?.message, "Encountered an error when receiving web view event")
         XCTAssertEqual(dd.logger.errorLog?.error?.message, #"invalidMessage(description: "123")"#)
-        XCTAssertEqual(telemetry.messages.first?.asError?.message, "Encountered an error when receiving web view event - Unrecognized error type: WebViewMessageError")
+        XCTAssertEqual(telemetry.messages.first?.asError?.message, "Encountered an error when receiving web view event - WebViewMessageError does not conform to TelemetrySanitizableError — reporting type name only")
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,14 +171,9 @@ Defined in `DatadogInternal/Sources/Models/RUM/RUMCoreContext.swift`. Key fields
 
 Set by `Monitor.swift` after each command via `featureScope.set(context:)`. Consumed by any receiver that calls `context.additionalContext(ofType: RUMCoreContext.self)`.
 
-## Error Handling Strategy
+## Error Handling
 
-The SDK must **never throw exceptions** to customer code:
-
-- **NOP implementations**: `NOPMonitor`, `NOPDatadogCore` silently accept all API calls when SDK is not initialized or a feature is disabled.
-- **Validation at boundaries**: Invalid input is logged via `DD.logger` and ignored.
-- **Upload backoff**: Upload failures trigger exponential backoff and retry. Network errors are logged but never crash.
-- **User callback safety**: Exceptions in user-provided callbacks (e.g., event mappers) are caught and logged — original event is sent.
+See `docs/ERROR_HANDLING.md` for customer-facing error safety and internal telemetry error reporting conventions.
 
 ## Thread Safety Rules
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -1,0 +1,62 @@
+# Error Handling in dd-sdk-ios
+
+This document covers two distinct concerns that both fall under "error handling" but must not be conflated:
+
+1. **Customer-Facing Error Safety** — the SDK must never crash or throw into a customer's app.
+2. **Internal Telemetry Error Reporting** — when the SDK reports its own internal errors to Datadog for debugging, it must never leak customer data in the process.
+
+---
+
+## Customer-Facing Error Safety
+
+The SDK must **never throw exceptions** to customer code:
+
+- **NOP implementations**: `NOPMonitor`, `NOPDatadogCore` silently accept all API calls when the SDK is not initialized or a feature is disabled.
+- **Validation at boundaries**: Invalid input is logged via `DD.logger` and ignored.
+- **Objective-C exception safety**: Code that can trigger an Objective-C exception outside Swift's error model (e.g. Session Replay's view-tree snapshotting in `LayerRecorder`, `ImageSnapshotter`) wraps the call with `ObjcException.rethrow`, converting it into a catchable Swift `ObjcException` (`DatadogInternal/Sources/Utils/DDError.swift`).
+
+## Internal Telemetry Error Reporting
+
+The SDK reports its own internal errors (encoding failures, storage corruption, unexpected state) to Datadog's internal SDK telemetry via `Telemetry.error(...)`, so engineers can debug issues in production without customer involvement. This channel is **not** customer-facing, but it is still Datadog-internal infrastructure that can — if handled carelessly — end up carrying whatever data the failing operation happened to touch (HTTP headers, encoded attribute values, decoded payloads, etc.).
+
+**Never build a telemetry error message from an error's raw, default description.** Swift's default string interpolation of an `Error` (`"\(error)"`) is unsafe for some error types — `EncodingError.invalidValue`, for example, embeds the *entire offending value* in its description. An encoding failure on an attribute dictionary can therefore forward its raw contents (session tokens, PII, etc.) straight into telemetry.
+
+### The safe path
+
+- `Telemetry.error(_ error: Error, ...)` is the only entry point for reporting an `Error` to telemetry. It routes every error through `sanitizeForTelemetry(_:)` (`DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift`) before anything reaches the wire.
+- **Default behavior is anonymous**: an error that doesn't opt in is reduced to just its type name (`"\(type(of: error))"`).
+- A handful of well-known Foundation/Swift types already get a safe, dedicated summary: `EncodingError`/`DecodingError` (coding path + `debugDescription` only, never the offending value), `NSError` (`domain`/`code` only, never `userInfo`, which can carry customer-supplied strings like `NSLocalizedDescriptionKey`).
+- Every reported error carries a `#fileID:#line` call-site reference in `stack`, so messages stay traceable back to the reporting code even in the fully-anonymized default case.
+
+### Opting in to richer context
+
+A type can conform to `TelemetrySanitizableError` to describe itself more richly — but only when every piece of information exposed is known-safe:
+
+```swift
+struct FileWriteError: Error, TelemetrySanitizableError {
+    let path: String
+    let underlyingData: Data
+
+    func sanitize() -> TelemetrySanitizedError {
+        TelemetrySanitizedError(
+            kind: "FileWriteError",
+            message: "Failed to write \(underlyingData.count) bytes into \(directoryName(path))"
+        )
+    }
+}
+```
+
+For an enum whose cases carry no associated values, or only associated values that are already known-safe (SDK-internal type/size/kind names — never customer content), `TelemetrySanitizedError(describing:)` is a shorthand for `TelemetrySanitizedError(kind: "\(type(of: error))", message: "\(error)")`:
+
+```swift
+extension TLVBlockError: TelemetrySanitizableError {
+    func sanitize() -> TelemetrySanitizedError {
+        TelemetrySanitizedError(describing: self)
+    }
+}
+```
+
+**Before conforming a type to `TelemetrySanitizableError`, audit every case and every associated value it can carry.** If a type wraps arbitrary or customer-supplied content (e.g. `WebViewMessageError`, which carries the raw WebView message body), it must **not** conform — let it fall through to the safe, anonymous default instead.
+
+- Do not retroactively conform a type you don't own (`NSError`, `URLError`, etc.) to `TelemetrySanitizableError` — a conformance is a single, global fact about a `(Type, Protocol)` pair, so a conflicting conformance declared elsewhere would be silently discarded. For foreign types, extend `sanitizeForTelemetry(_:)` centrally instead.
+- The internal `Telemetry.error(_ error: TelemetrySanitizedError, ...)` / `Telemetry.error(_ message: String, error: TelemetrySanitizedError, ...)` overloads only accept an already-sanitized error — there is no code path that can forward a raw, unsanitized error description to the sink.

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -23,9 +23,9 @@ The SDK reports its own internal errors (encoding failures, storage corruption, 
 
 ### The safe path
 
-- `Telemetry.error(_ error: Error, ...)` is the only entry point for reporting an `Error` to telemetry. It routes every error through `sanitizeForTelemetry(_:)` (`DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift`) before anything reaches the wire.
+- `Telemetry.error(_ error: Error, ...)` is the only entry point for reporting an `Error` to telemetry. It routes every error through `TelemetrySanitizedError(sanitizing: error)` (`DatadogInternal/Sources/Telemetry/TelemetrySanitizableError.swift`) before anything reaches the wire.
 - **Default behavior is anonymous**: an error that doesn't opt in is reduced to just its type name (`"\(type(of: error))"`).
-- A handful of well-known Foundation/Swift types already get a safe, dedicated summary: `EncodingError`/`DecodingError` (coding path + `debugDescription` only, never the offending value), `NSError` (`domain`/`code` only, never `userInfo`, which can carry customer-supplied strings like `NSLocalizedDescriptionKey`).
+- A handful of well-known Foundation/Swift types already get a safe, dedicated summary: `EncodingError`/`DecodingError` (the failing case and how deeply nested the offending value was — never `context.debugDescription` or `codingPath`'s literal key names), `NSError` (`domain`/`code` only, never `userInfo`).
 - Every reported error carries a `#fileID:#line` call-site reference in `stack`, so messages stay traceable back to the reporting code even in the fully-anonymized default case.
 
 ### Opting in to richer context
@@ -46,17 +46,17 @@ struct FileWriteError: Error, TelemetrySanitizableError {
 }
 ```
 
-For an enum whose cases carry no associated values, or only associated values that are already known-safe (SDK-internal type/size/kind names — never customer content), `TelemetrySanitizedError(describing:)` is a shorthand for `TelemetrySanitizedError(kind: "\(type(of: error))", message: "\(error)")`:
+For an enum whose cases carry no associated values, or only associated values that are already known-safe (SDK-internal type/size/kind names — never customer content), `TelemetrySanitizedError(unsafelyDescribing:)` is a shorthand for `TelemetrySanitizedError(kind: "\(type(of: error))", message: "\(error)")`. The `unsafely` prefix is a deliberate stop sign, like `unsafelyUnwrapped` — it means no sanitization happens, so the caller is vouching for the type's `description`:
 
 ```swift
 extension TLVBlockError: TelemetrySanitizableError {
     func sanitize() -> TelemetrySanitizedError {
-        TelemetrySanitizedError(describing: self)
+        TelemetrySanitizedError(unsafelyDescribing: self)
     }
 }
 ```
 
-**Before conforming a type to `TelemetrySanitizableError`, audit every case and every associated value it can carry.** If a type wraps arbitrary or customer-supplied content (e.g. `WebViewMessageError`, which carries the raw WebView message body), it must **not** conform — let it fall through to the safe, anonymous default instead.
+**Before conforming a type to `TelemetrySanitizableError`, audit every case and every associated value it can carry.** If a type wraps arbitrary or customer-supplied content (e.g. `WebViewMessageError`, which carries the raw WebView message body), it must **not** conform — let it fall through to the safe, anonymous default instead. If a case wraps another, foreign `Error` (e.g. `TLVBlockError.readOperationFailed`'s `streamError`), don't interpolate it directly either — route it through `TelemetrySanitizedError(sanitizing:)` and only embed the result's `kind`/`message`.
 
-- Do not retroactively conform a type you don't own (`NSError`, `URLError`, etc.) to `TelemetrySanitizableError` — a conformance is a single, global fact about a `(Type, Protocol)` pair, so a conflicting conformance declared elsewhere would be silently discarded. For foreign types, extend `sanitizeForTelemetry(_:)` centrally instead.
+- Do not retroactively conform a type you don't own (`NSError`, `URLError`, etc.) to `TelemetrySanitizableError` — a conformance is a single, global fact about a `(Type, Protocol)` pair, so a conflicting conformance declared elsewhere would be silently discarded. For foreign types, extend `TelemetrySanitizedError.init(sanitizing:)` centrally instead.
 - The internal `Telemetry.error(_ error: TelemetrySanitizedError, ...)` / `Telemetry.error(_ message: String, error: TelemetrySanitizedError, ...)` overloads only accept an already-sanitized error — there is no code path that can forward a raw, unsanitized error description to the sink.


### PR DESCRIPTION
### What and why?

📦 This PR standardizes how errors are reported to internal SDK telemetry: their content is sanitized, and a `#fileID:#line` call-site reference is now consistently attached to every reported error.

**Before**, `Telemetry.error(...)` treated every error the same way, composing its `message` from Swift's default string interpolation (`"\(error)"`). This is unsafe for some error types: `EncodingError.invalidValue`, for example, embeds the *entire* offending value in its description — so an encoding failure on an attribute dictionary could forward its raw contents (e.g. HTTP header values). The `#fileID:#line` call-site reference was only added to the `stack` when an error reported none of its own; a custom `stack` fully overrode it.

**After**, `Telemetry.error(...)` has a single, standardized, safe-by-default path for every error. By default, an error is reduced to just its type name (`"\(type(of: error))"`). A type can opt in to richer context by conforming to `TelemetrySanitizableError`, and a few well-known Foundation/Swift types (`EncodingError`, `DecodingError`, `NSError`) already get a safe, dedicated summary out of the box. The `#fileID:#line` call site is now always present in the `stack`, so every reported error stays traceable back to where it was reported, regardless of sanitization path.

Example:
```swift
struct FileWriteError: Error {
    let path: String
    let underlyingData: Data
}

// Telemetry.error(fileWriteError) reports, by default:
// - kind:    "FileWriteError"
// - message: "FileWriteError does not conform to TelemetrySanitizableError — reporting type name only"
// - stack:   "MyModule/MyFile.swift:42"
```
Conforming to `TelemetrySanitizableError` lets a type opt in to richer, but still explicitly safe, formatting:

```swift
struct FileWriteError: Error, TelemetrySanitizableError {
    let path: String
    let underlyingData: Data

    func sanitize() -> TelemetrySanitizedError {
        TelemetrySanitizedError(
            kind: "FileWriteError",
            message: "Failed to write \(underlyingData.count) bytes into \(directoryName(path))"
        )
    }
}

// Telemetry.error(fileWriteError) now reports:
// - kind:    "FileWriteError"
// - message: "Failed to write 412 bytes into v2/rum/authorised/"
// - stack:   "MyModule/MyFile.swift:42"
```

### How?

- Introduces `TelemetrySanitizableError` (`DatadogInternal`) — an opt-in protocol letting a type describe its own safe, richer telemetry context (`kind`/`message`/`stack`).
- Centralizes the default behavior in `TelemetrySanitizedError(sanitizing:)`: anonymous by default — any error not opting in is reduced to its type name, with dedicated safe summaries for well-known foreign types:
  - `EncodingError`/`DecodingError` report only the failing case and how deeply nested the offending value was (e.g. `"2 levels deep"`) — never `context.debugDescription` or the literal `codingPath` key names. `Context` is a plain struct that whatever `Encodable`/`Decodable` throws the error gets to fill in, including a customer-supplied one (e.g. a custom RUM attribute's own `encode(to:)`), and a coding key can itself be a dynamic, customer-supplied name — so neither field can be trusted, regardless of which Foundation/Swift version generated it.
  - `NSError` reports only `domain`/`code`, never `userInfo`, whose content depends on the error's domain and isn't guaranteed to stay free of things like file paths.
- `TelemetrySanitizedError(unsafelyDescribing:)` (renamed from `describing:`) is the explicit opt-in for types whose full `"\(error)"` description is already known-safe (e.g. `TLVBlockError`, whose cases only ever describe block types/sizes/limits) — the `unsafely` prefix is a deliberate stop sign, like `unsafelyUnwrapped`. A case that wraps another, foreign `Error` (e.g. `TLVBlockError.readOperationFailed`'s `streamError`) doesn't get this treatment: it's routed through `TelemetrySanitizedError(sanitizing:)` first, so it gets the same central sanitization as any other reported error, and only its `kind`/`message` are embedded.
- Opts in the SDK's own internal error types where the extra context is already known-safe (`Reflector.Error`, `TLVBlockError`, `DataStoreFileWritingError`, SessionReplay's `WireframeMutationError`) so telemetry doesn't lose useful debugging signal — while deliberately leaving out types that wrap raw customer content (e.g. `WebViewMessageError`, which carries the raw WebView message body).
- Guarantees every error message carries a `stack` starting with the `Telemetry.error(...)` call site (`file:line`) — whether or not the error itself (or its `TelemetrySanitizableError.sanitize()`) contributes anything beyond that, so messages remain traceable back to the reporting code even in the fully-anonymized default case.
- Full direct unit coverage of `TelemetrySanitizedError(sanitizing:)` (`TelemetrySanitizableErrorTests.swift`) — `EncodingError`/`DecodingError` cases are forged through real `JSONEncoder`/`JSONDecoder` failures (including nested cases, 2+ levels deep), not hand-constructed `Context` values, so the tests exercise what Foundation actually generates rather than an assumption about it — plus integration-level coverage through the real `Telemetry.error(...)` API (`TelemetryTests.swift`).
- Extracts error handling out of `ARCHITECTURE.md` into a dedicated `docs/ERROR_HANDLING.md`, documenting this convention (customer-facing error safety + internal telemetry error reporting) so it's discoverable by anyone — human or AI agent — writing code in this repo going forward. Wired into `AGENTS.md`'s documentation map, "Where to Look First" table, and Critical Rules.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — internal-only fix, no customer-facing behavior change
- [ ] Add Objective-C interface for public APIs — `TelemetrySanitizableError`/`TelemetrySanitizedError` are public but internal-telemetry-only, not part of the customer-facing Obj-C surface
- [ ] Run `make api-surface` when adding new APIs — TODO before opening, per skill checklist
