### PR TITLE
RUM-17800 Add URL disallow-list to RUM network instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add an experimental Core Animation recording pipeline for Session Replay, available through the `compositionTreeRecording` feature flag. See [#3127][]
+- [FEATURE] Add `disallowList` to `RUM.Configuration.URLSessionTracking` to exclude URLs from automatic RUM resource tracking, with `*` wildcard support. [#3097][]
 - [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
 
 # 3.15.0 / 05-08-2026
@@ -1223,6 +1224,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3109]: https://github.com/DataDog/dd-sdk-ios/pull/3109
 [#3074]: https://github.com/DataDog/dd-sdk-ios/pull/3074
 [#3127]: https://github.com/DataDog/dd-sdk-ios/pull/3127
+[#3097]: https://github.com/DataDog/dd-sdk-ios/pull/3097
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		261255872E2167E40015042B /* BaggageHeaderMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255862E2167E40015042B /* BaggageHeaderMerger.swift */; };
 		2612558B2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */; };
 		261255952E2167F10015042B /* HeaderProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255932E2167F10015042B /* HeaderProcessorTests.swift */; };
+		479539F3F9AC61238ACF3D6C /* DisallowListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B9C6954A07274919E80B5E /* DisallowListTests.swift */; };
 		265496D42D81C5B10094B6E2 /* RUMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265496D22D81C5AE0094B6E2 /* RUMAccount.swift */; };
 		266BFA5E2D6F4E31003041A5 /* AccountInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266BFA5D2D6F4E2A003041A5 /* AccountInfoPublisherTests.swift */; };
 		2671348E2D688AD60048CB54 /* AccountInfoPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2671348C2D688ACD0048CB54 /* AccountInfoPublisher.swift */; };
@@ -1208,6 +1209,7 @@
 		D29D1CCE2F6067AB0085574B /* UIScrollViewSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001012A000003000A0001 /* UIScrollViewSwizzler.swift */; };
 		D29D1CCF2F6067BF0085574B /* UIScrollViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001012A000005000A0001 /* UIScrollViewHandler.swift */; };
 		D29D1CD02F6067D20085574B /* HeaderProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255902E2167E40015042B /* HeaderProcessor.swift */; };
+		1D6C3C99D788AF6D8ED50979 /* DisallowList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */; };
 		D29D1CD12F6068820085574B /* DataStoreAsyncMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119F75F32F438C2100845833 /* DataStoreAsyncMock.swift */; };
 		D29D3A272F3E2D5C00863C5C /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; };
 		D29D3A282F3E2D5C00863C5C /* DatadogFlags.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C2ED2E784B3C00B1DA80 /* DatadogFlags.framework */; };
@@ -2082,7 +2084,9 @@
 		261255862E2167E40015042B /* BaggageHeaderMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggageHeaderMerger.swift; sourceTree = "<group>"; };
 		261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggageHeaderMergerTests.swift; sourceTree = "<group>"; };
 		261255902E2167E40015042B /* HeaderProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderProcessor.swift; sourceTree = "<group>"; };
+		1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisallowList.swift; sourceTree = "<group>"; };
 		261255932E2167F10015042B /* HeaderProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderProcessorTests.swift; sourceTree = "<group>"; };
+		66B9C6954A07274919E80B5E /* DisallowListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisallowListTests.swift; sourceTree = "<group>"; };
 		265496D22D81C5AE0094B6E2 /* RUMAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAccount.swift; sourceTree = "<group>"; };
 		266BFA5D2D6F4E2A003041A5 /* AccountInfoPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoPublisherTests.swift; sourceTree = "<group>"; };
 		2671348C2D688ACD0048CB54 /* AccountInfoPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoPublisher.swift; sourceTree = "<group>"; };
@@ -3838,12 +3842,28 @@
 			path = HeaderCapture;
 			sourceTree = "<group>";
 		};
+		F36014A6B87B685CB54DD26F /* DisallowList */ = {
+			isa = PBXGroup;
+			children = (
+				1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */,
+			);
+			path = DisallowList;
+			sourceTree = "<group>";
+		};
 		261255972E2167F10015042B /* HeaderCapture */ = {
 			isa = PBXGroup;
 			children = (
 				261255932E2167F10015042B /* HeaderProcessorTests.swift */,
 			);
 			path = HeaderCapture;
+			sourceTree = "<group>";
+		};
+		F5627932F2D7852661CA308B /* DisallowList */ = {
+			isa = PBXGroup;
+			children = (
+				66B9C6954A07274919E80B5E /* DisallowListTests.swift */,
+			);
+			path = DisallowList;
 			sourceTree = "<group>";
 		};
 		3C4CF9932C47BE10006DE1C0 /* MemoryWarnings */ = {
@@ -5094,6 +5114,7 @@
 			isa = PBXGroup;
 			children = (
 				261255972E2167F10015042B /* HeaderCapture */,
+				F5627932F2D7852661CA308B /* DisallowList */,
 				261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */,
 				D2BCB12129D34A5F00737A9A /* URLSessionRUMResourcesHandlerTests.swift */,
 			);
@@ -5251,6 +5272,7 @@
 			isa = PBXGroup;
 			children = (
 				261255962E2167E40015042B /* HeaderCapture */,
+				F36014A6B87B685CB54DD26F /* DisallowList */,
 				261255862E2167E40015042B /* BaggageHeaderMerger.swift */,
 				D2BCB11E29D30AF000737A9A /* URLSessionRUMResourcesHandler.swift */,
 			);
@@ -9282,6 +9304,7 @@
 				962900242D8351AB008DFE39 /* TopLevelReflector.swift in Sources */,
 				6194B9332BB451DB00179430 /* FatalAppHangsHandler.swift in Sources */,
 				D29D1CD02F6067D20085574B /* HeaderProcessor.swift in Sources */,
+				1D6C3C99D788AF6D8ED50979 /* DisallowList.swift in Sources */,
 				D29A9F6229DD85BB005C54A4 /* WebViewEventReceiver.swift in Sources */,
 				265496D42D81C5B10094B6E2 /* RUMAccount.swift in Sources */,
 				D253EE962B988CA90010B589 /* ViewCache.swift in Sources */,
@@ -9426,6 +9449,7 @@
 				D29A9FB329DDB483005C54A4 /* RUMScopeTests.swift in Sources */,
 				2612558B2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */,
 				261255952E2167F10015042B /* HeaderProcessorTests.swift in Sources */,
+				479539F3F9AC61238ACF3D6C /* DisallowListTests.swift in Sources */,
 				A7E6EA852D314A9B00997201 /* AnonymousIdentifierManagerTests.swift in Sources */,
 				D29A9FAE29DDB483005C54A4 /* SessionReplayDependencyTests.swift in Sources */,
 				61C713B62A3C600400FA735A /* RUMMonitorProtocol+ConvenienceTests.swift in Sources */,

--- a/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
@@ -143,6 +143,24 @@ class DDRUMConfigurationTests: XCTestCase {
         DDAssertReflectionEqual(swift.urlSessionTracking, .init(trackResourceHeaders: .custom([.defaults, .matchHeaders(["x-request-id"])])))
     }
 
+    func testSetDDRUMURLSessionTrackingWithDisallowList() {
+        let tracking = objc_URLSessionTracking()
+
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, RUM.Configuration.URLSessionTracking())
+
+        tracking.setDisallowList(["https://foo.com/"])
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(swift.urlSessionTracking, .init(disallowList: ["https://foo.com/"]))
+
+        tracking.setDisallowList(["https://bar.com/*", "https://*.foo.com/*"])
+        objc.setURLSessionTracking(tracking)
+        DDAssertReflectionEqual(
+            swift.urlSessionTracking,
+            .init(disallowList: ["https://bar.com/*", "https://*.foo.com/*"])
+        )
+    }
+
     func testSetDDRUMURLSessionTrackingWithResourceAttributesProvider() {
         let tracking = objc_URLSessionTracking()
 

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-10
 sdk_version: 3.14.0
-verified_against_commit: 9f1eaa9f9
+verified_against_commit: c10bc4f57
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-04
+last_updated: 2026-08-10
 sdk_version: 3.14.0
-verified_against_commit: cc8c93bb3
+verified_against_commit: 9f1eaa9f9
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift
@@ -89,7 +89,11 @@ RUM.enable(
             //   .disabled - No header capture
             //   .defaults - Capture predefined common headers (cache-control, content-type, etag, etc.)
             //   .custom([rules]) - Capture headers by custom rules
-            trackResourceHeaders: .defaults
+            trackResourceHeaders: .defaults,
+            // Optional: Exclude specific URLs from RUM resource tracking.
+            // Plain strings match exactly; `*` matches any characters (multiple allowed).
+            // For a first-party host this also drops the APM span.
+            disallowList: ["https://api.example.com/health", "https://*.internal.example.com/*"]
         ),
         
         // Track user frustrations (error taps following errors)
@@ -243,6 +247,7 @@ Requires configuration to be set, otherwise disabled by default:
 - **Action tracking**: `uiKitActionsPredicate`, `swiftUIActionsPredicate` *(SwiftUI: experimental, behavior differs on iOS 17 vs iOS 18+)*
 - **Resource tracking**: `urlSessionTracking` (automatic), optionally call `URLSessionInstrumentation.enableDurationBreakdown(with: .init(delegateClass: YourSessionDelegate.self))` for detailed timing
 - **Header capture**: `urlSessionTracking.trackResourceHeaders` — `.disabled` (default), `.defaults` (common headers), or `.custom([rules])`
+- **Resource disallow list**: `urlSessionTracking.disallowList` — URL patterns excluded from RUM resource tracking (`*` wildcards)
 
 ### Performance Monitoring
 - **Long tasks**: `longTaskThreshold` (default: 0.1s)

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-12
 sdk_version: 3.15.0
-verified_against_commit: 0d28d8157
+verified_against_commit: dc80cf268
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,6 +1,6 @@
 ---
-last_updated: 2026-08-10
-sdk_version: 3.14.0
+last_updated: 2026-08-12
+sdk_version: 3.15.0
 verified_against_commit: c10bc4f57
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
@@ -92,7 +92,6 @@ RUM.enable(
             trackResourceHeaders: .defaults,
             // Optional: Exclude specific URLs from RUM resource tracking.
             // Plain strings match exactly; `*` matches any characters (multiple allowed).
-            // For a first-party host this also drops the APM span.
             disallowList: ["https://api.example.com/health", "https://*.internal.example.com/*"]
         ),
         

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-12
 sdk_version: 3.15.0
-verified_against_commit: c10bc4f57
+verified_against_commit: 0d28d8157
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift

--- a/DatadogRUM/Sources/Instrumentation/Resources/DisallowList/DisallowList.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/DisallowList/DisallowList.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// A struct that represents the disallow-list of URL patterns excluded from RUM resource tracking, configured via
+/// `RUM.Configuration.URLSessionTracking.disallowList`.
+///
+/// A plain string matches the URL exactly, while a string containing a single `*` is compiled into a wildcard
+/// match. Patterns with more than one `*` are invalid and dropped with a warning.
+internal struct DisallowList {
+    private let patterns: [String]
+
+    var isEmpty: Bool { patterns.isEmpty }
+
+    init(_ patterns: [String]) {
+        self.patterns = patterns.compactMap { pattern in
+            switch pattern.filter({ $0 == "*" }).count {
+            case 0:
+                return "^" + NSRegularExpression.escapedPattern(for: pattern) + "$"
+            case 1 where pattern != "*":
+                let parts = pattern.split(separator: "*", maxSplits: 1, omittingEmptySubsequences: false).map(String.init)
+                return "^" + NSRegularExpression.escapedPattern(for: parts[0]) + ".*" + NSRegularExpression.escapedPattern(for: parts[1]) + "$"
+            default:
+                DD.logger.warn("The disallow-list pattern '\(pattern)' is not valid and will be ignored.")
+                return nil
+            }
+        }
+    }
+
+    func isDisallowed(url: URL?) -> Bool {
+        guard let url = url, !patterns.isEmpty else {
+            return false
+        }
+        let urlString = url.absoluteString
+        return patterns.contains { urlString.range(of: $0, options: .regularExpression) != nil }
+    }
+}

--- a/DatadogRUM/Sources/Instrumentation/Resources/DisallowList/DisallowList.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/DisallowList/DisallowList.swift
@@ -10,8 +10,9 @@ import DatadogInternal
 /// A struct that represents the disallow-list of URL patterns excluded from RUM resource tracking, configured via
 /// `RUM.Configuration.URLSessionTracking.disallowList`.
 ///
-/// A plain string matches the URL exactly, while a string containing a single `*` is compiled into a wildcard
-/// match. Patterns with more than one `*` are invalid and dropped with a warning.
+/// A plain string matches the URL exactly, while `*` matches any sequence of characters. A pattern may contain
+/// multiple `*` wildcards (e.g. `https://example.com/api/*/operations/*`). Patterns with no literal content
+/// (e.g. `*`) are invalid and dropped with a warning.
 internal struct DisallowList {
     private let patterns: [String]
 
@@ -19,16 +20,14 @@ internal struct DisallowList {
 
     init(_ patterns: [String]) {
         self.patterns = patterns.compactMap { pattern in
-            switch pattern.filter({ $0 == "*" }).count {
-            case 0:
-                return "^" + NSRegularExpression.escapedPattern(for: pattern) + "$"
-            case 1 where pattern != "*":
-                let parts = pattern.split(separator: "*", maxSplits: 1, omittingEmptySubsequences: false).map(String.init)
-                return "^" + NSRegularExpression.escapedPattern(for: parts[0]) + ".*" + NSRegularExpression.escapedPattern(for: parts[1]) + "$"
-            default:
+            let segments = pattern.components(separatedBy: "*")
+            // Reject patterns with no literal content (e.g. `*`, `**`) - they would disallow every URL.
+            guard segments.contains(where: { !$0.isEmpty }) else {
                 DD.logger.warn("The disallow-list pattern '\(pattern)' is not valid and will be ignored.")
                 return nil
             }
+            let escaped = segments.map { NSRegularExpression.escapedPattern(for: $0) }
+            return "^" + escaped.joined(separator: ".*") + "$"
         }
     }
 

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -59,8 +59,6 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
         distributedTracing?.firstPartyHosts ?? .init()
     }
 
-    private var disallowedInterceptionIDs = Set<UUID>()
-
     // MARK: - Initialization
 
     init(
@@ -90,6 +88,10 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
     // MARK: - DatadogURLSessionHandler
 
     func modify(request: URLRequest, headerTypes: Set<DatadogInternal.TracingHeaderType>, networkContext: NetworkContext?) -> (URLRequest, TraceContext?, URLSessionHandlerCapturedState?) {
+        guard !isDisallowed(url: request.url) else {
+            return (request, nil, nil)
+        }
+
         let (modifiedRequest, traceContext, _) = distributedTracing?.modify(
             request: request,
             headerTypes: headerTypes,
@@ -104,13 +106,12 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
     }
 
     func interceptionDidStart(interception: DatadogInternal.URLSessionTaskInterception, capturedStates: [any URLSessionHandlerCapturedState]) {
-        let url = interception.request.url?.absoluteString ?? "unknown_url"
-        interception.register(origin: "rum")
-
-        if disallowList?.isDisallowed(url: interception.request.url) == true {
-            disallowedInterceptionIDs.insert(interception.identifier)
+        guard !isDisallowed(url: interception.request.url) else {
             return
         }
+
+        let url = interception.request.url?.absoluteString ?? "unknown_url"
+        interception.register(origin: "rum")
 
         // Check if GraphQL was detected in the captured states
         if let capturedState = capturedStates.compactMap({ $0 as? RUMURLSessionHandlerCapturedState }).first,
@@ -132,7 +133,7 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
     }
 
     func interceptionDidComplete(interception: DatadogInternal.URLSessionTaskInterception) {
-        if disallowedInterceptionIDs.remove(interception.identifier) != nil {
+        guard !isDisallowed(url: interception.request.url) else {
             return
         }
 
@@ -236,6 +237,10 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
                 )
             )
         }
+    }
+
+    private func isDisallowed(url: URL?) -> Bool {
+        disallowList?.isDisallowed(url: url) == true
     }
 
     /// Extracts GraphQL errors from JSON response if present and returns them as a JSON string.

--- a/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -51,11 +51,15 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
     let telemetry: Telemetry
     /// Header processor for capturing HTTP headers.
     let headerProcessor: HeaderProcessor?
+    /// The disallow-list of URLs excluded from RUM resource tracking.
+    let disallowList: DisallowList?
 
     /// First party hosts defined by the user.
     var firstPartyHosts: FirstPartyHosts {
         distributedTracing?.firstPartyHosts ?? .init()
     }
+
+    private var disallowedInterceptionIDs = Set<UUID>()
 
     // MARK: - Initialization
 
@@ -64,12 +68,14 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
         rumAttributesProvider: RUM.ResourceAttributesProvider?,
         distributedTracing: DistributedTracing?,
         headerProcessor: HeaderProcessor?,
+        disallowList: DisallowList?,
         telemetry: Telemetry
     ) {
         self.dateProvider = dateProvider
         self.rumAttributesProvider = rumAttributesProvider
         self.distributedTracing = distributedTracing
         self.headerProcessor = headerProcessor
+        self.disallowList = disallowList
         self.telemetry = telemetry
     }
 
@@ -101,6 +107,11 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
         let url = interception.request.url?.absoluteString ?? "unknown_url"
         interception.register(origin: "rum")
 
+        if disallowList?.isDisallowed(url: interception.request.url) == true {
+            disallowedInterceptionIDs.insert(interception.identifier)
+            return
+        }
+
         // Check if GraphQL was detected in the captured states
         if let capturedState = capturedStates.compactMap({ $0 as? RUMURLSessionHandlerCapturedState }).first,
            capturedState.hasGraphQLHeaders {
@@ -121,6 +132,10 @@ internal final class URLSessionRUMResourcesHandler: DatadogURLSessionHandlerSupp
     }
 
     func interceptionDidComplete(interception: DatadogInternal.URLSessionTaskInterception) {
+        if disallowedInterceptionIDs.remove(interception.identifier) != nil {
+            return
+        }
+
         guard let subscriber = subscriber else {
             return DD.logger.warn(
                 """

--- a/DatadogRUM/Sources/RUM+Internal.swift
+++ b/DatadogRUM/Sources/RUM+Internal.swift
@@ -79,11 +79,16 @@ extension InternalExtension where ExtendedType == RUM {
             }
         }()
 
+        let disallowList: DisallowList? = configuration.disallowList.isEmpty
+            ? nil
+            : DisallowList(configuration.disallowList)
+
         let urlSessionHandler = URLSessionRUMResourcesHandler(
             dateProvider: rumConfiguration.dateProvider,
             rumAttributesProvider: configuration.resourceAttributesProvider,
             distributedTracing: distributedTracing,
             headerProcessor: headerProcessor,
+            disallowList: disallowList,
             telemetry: core.telemetry
         )
 

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -527,6 +527,10 @@ public class objc_URLSessionTracking: NSObject {
     public func setTrackResourceHeaders(_ trackResourceHeaders: objc_TrackResourceHeaders) {
         swiftConfig.trackResourceHeaders = trackResourceHeaders.swiftType
     }
+
+    public func setDisallowList(_ disallowList: [String]) {
+        swiftConfig.disallowList = disallowList
+    }
 }
 
 @objc(DDRUMHeaderCaptureRule)

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -380,6 +380,19 @@ extension RUM {
             /// Default: `.disabled`.
             public var trackResourceHeaders: TrackResourceHeaders = .disabled
 
+            /// URL patterns disallowed from automatic RUM resource tracking.
+            ///
+            /// Requests whose URL matches any of the given patterns will not produce a RUM Resource event.
+            /// This only affects RUM Resource tracking - any associated distributed trace (APM span) for the
+            /// same request is unaffected.
+            ///
+            /// Patterns are plain strings matched against the full resource URL. A pattern containing a single
+            /// `*` wildcard matches any characters in its place (e.g. `"https://example.com/*/private"`);
+            /// a pattern without `*` must match the URL exactly.
+            ///
+            /// Default: `[]`.
+            public var disallowList: [String] = []
+
             /// Private init to avoid `invalid redeclaration of synthesized memberwise init(...:)` in extension.
             private init() {}
         }
@@ -511,14 +524,17 @@ extension RUM.Configuration.URLSessionTracking {
     ///   - firstPartyHostsTracing: Distributed tracing configuration for particular first-party hosts.
     ///   - resourceAttributesProvider: Custom attributes provider for intercepted RUM resources.
     ///   - trackResourceHeaders: Configuration for capturing HTTP headers. Default: `.disabled`.
+    ///   - disallowList: URL patterns disallowed from automatic RUM resource tracking. Default: `[]`.
     public init(
         firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,
         resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,
-        trackResourceHeaders: TrackResourceHeaders = .disabled
+        trackResourceHeaders: TrackResourceHeaders = .disabled,
+        disallowList: [String] = []
     ) {
         self.firstPartyHostsTracing = firstPartyHostsTracing
         self.resourceAttributesProvider = resourceAttributesProvider
         self.trackResourceHeaders = trackResourceHeaders
+        self.disallowList = disallowList
     }
 }
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -382,8 +382,8 @@ extension RUM {
 
             /// URL patterns disallowed from automatic RUM resource tracking.
             ///
-            /// Matching requests produce no RUM Resource. Any associated distributed trace (APM span) for the
-            /// same request is unaffected.
+            /// Matching requests produce no RUM Resource, and no associated APM span. The disallow list takes
+            /// priority over first-party hosts tracing.
             ///
             /// A pattern matches the full URL: plain strings match exactly, `*` matches any characters (multiple
             /// allowed). Patterns with no literal (e.g. `"*"`) are ignored.

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -382,8 +382,8 @@ extension RUM {
 
             /// URL patterns disallowed from automatic RUM resource tracking.
             ///
-            /// Matching requests produce no RUM Resource, and no associated APM span. The disallow list takes
-            /// priority over first-party hosts tracing.
+            /// Matching requests produce no RUM Resource, and no APM span reconstructed from a RUM Resource.
+            /// The disallow list takes priority over RUM first-party hosts tracing.
             ///
             /// A pattern matches the full URL: plain strings match exactly, `*` matches any characters (multiple
             /// allowed). Patterns with no literal (e.g. `"*"`) are ignored.

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -382,8 +382,8 @@ extension RUM {
 
             /// URL patterns disallowed from automatic RUM resource tracking.
             ///
-            /// Matching requests produce no RUM Resource. For a first-party host, this also drops its APM span,
-            /// which is reconstructed on the backend from the Resource.
+            /// Matching requests produce no RUM Resource. Any associated distributed trace (APM span) for the
+            /// same request is unaffected.
             ///
             /// A pattern matches the full URL: plain strings match exactly, `*` matches any characters (multiple
             /// allowed). Patterns with no literal (e.g. `"*"`) are ignored.

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -382,13 +382,11 @@ extension RUM {
 
             /// URL patterns disallowed from automatic RUM resource tracking.
             ///
-            /// Requests whose URL matches any of the given patterns will not produce a RUM Resource event.
-            /// This only affects RUM Resource tracking - any associated distributed trace (APM span) for the
-            /// same request is unaffected.
+            /// Matching requests produce no RUM Resource. For a first-party host, this also drops its APM span,
+            /// which is reconstructed on the backend from the Resource.
             ///
-            /// Patterns are plain strings matched against the full resource URL. A pattern containing a single
-            /// `*` wildcard matches any characters in its place (e.g. `"https://example.com/*/private"`);
-            /// a pattern without `*` must match the URL exactly.
+            /// A pattern matches the full URL: plain strings match exactly, `*` matches any characters (multiple
+            /// allowed). Patterns with no literal (e.g. `"*"`) are ignored.
             ///
             /// Default: `[]`.
             public var disallowList: [String] = []

--- a/DatadogRUM/Tests/Instrumentation/Resources/DisallowList/DisallowListTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/DisallowList/DisallowListTests.swift
@@ -71,6 +71,26 @@ class DisallowListTests: XCTestCase {
         XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/resourceXjson")))
     }
 
+    func testWhenPatternContainsMultipleWildcards_itDisallowsMatchingURLs() {
+        // Given
+        let disallowList = DisallowList(["https://example.com/*/foo/*"])
+
+        // Then
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/bar/foo/baz")))
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/a/b/foo/c")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/bar/baz")))
+    }
+
+    func testWhenPatternMatchesDuplicatedPathSegments_itDisallowsBothVariants() {
+        // Given - e.g. excluding operation endpoints across duplicated /api/v2 and /api/ui paths
+        let disallowList = DisallowList(["https://example.com/api/*/operations/*"])
+
+        // Then
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/api/v2/operations/list")))
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/api/ui/operations/123")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/api/v2/users/list")))
+    }
+
     // MARK: - Invalid Patterns
 
     func testWhenPatternIsBareWildcard_itIsIgnoredWithoutMatchingEveryURL() {
@@ -82,13 +102,13 @@ class DisallowListTests: XCTestCase {
         XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/")))
     }
 
-    func testWhenPatternContainsMultipleWildcards_itIsIgnored() {
+    func testWhenPatternIsOnlyWildcards_itIsIgnoredWithoutMatchingEveryURL() {
         // Given
-        let disallowList = DisallowList(["https://example.com/*/foo/*"])
+        let disallowList = DisallowList(["**"])
 
         // Then
         XCTAssertTrue(disallowList.isEmpty)
-        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/bar/foo/baz")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/")))
     }
 
     // MARK: - Multiple Patterns

--- a/DatadogRUM/Tests/Instrumentation/Resources/DisallowList/DisallowListTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/DisallowList/DisallowListTests.swift
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogRUM
+
+class DisallowListTests: XCTestCase {
+    // MARK: - Empty Patterns
+
+    func testWhenNoPatternsAreConfigured_itDoesNotDisallowAnyURL() {
+        // Given
+        let disallowList = DisallowList([])
+
+        // Then
+        XCTAssertTrue(disallowList.isEmpty)
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/")))
+    }
+
+    func testWhenURLIsNil_itDoesNotDisallowIt() {
+        // Given
+        let disallowList = DisallowList(["https://example.com/"])
+
+        // Then
+        XCTAssertFalse(disallowList.isDisallowed(url: nil))
+    }
+
+    // MARK: - Exact
+
+    func testWhenExactPatternMatches_itDisallowsTheURL() {
+        // Given
+        let disallowList = DisallowList(["https://example.com/resource"])
+
+        // Then
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/resource")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/resource/other")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/")))
+    }
+
+    // MARK: - Wildcard
+
+    func testWhenWildcardPatternMatches_itDisallowsTheURL() {
+        // Given
+        let disallowList = DisallowList(["https://example.com/*/private"])
+
+        // Then
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/foo/private")))
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/foo/bar/private")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/foo/private/extra")))
+    }
+
+    func testWhenWildcardPatternIsAtTheEnd_itDisallowsAnyURLWithThatPrefix() {
+        // Given
+        let disallowList = DisallowList(["https://example.com/private/*"])
+
+        // Then
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/private/resource")))
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/private/")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/public/resource")))
+    }
+
+    func testWhenWildcardPatternContainsLiteralRegexCharacters_itEscapesThemAsLiterals() {
+        // Given
+        let disallowList = DisallowList(["https://example.com/*.json"])
+
+        // Then
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://example.com/resource.json")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/resourceXjson")))
+    }
+
+    // MARK: - Invalid Patterns
+
+    func testWhenPatternIsBareWildcard_itIsIgnoredWithoutMatchingEveryURL() {
+        // Given
+        let disallowList = DisallowList(["*"])
+
+        // Then
+        XCTAssertTrue(disallowList.isEmpty)
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/")))
+    }
+
+    func testWhenPatternContainsMultipleWildcards_itIsIgnored() {
+        // Given
+        let disallowList = DisallowList(["https://example.com/*/foo/*"])
+
+        // Then
+        XCTAssertTrue(disallowList.isEmpty)
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://example.com/bar/foo/baz")))
+    }
+
+    // MARK: - Multiple Patterns
+
+    func testWhenMultiplePatternsAreConfigured_itDisallowsURLsMatchingAny() {
+        // Given
+        let disallowList = DisallowList(
+            [
+                "https://a.com/",
+                "https://b.com/private/*",
+                "https://c.com/*/secret"
+            ]
+        )
+
+        // Then
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://a.com/")))
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://b.com/private/resource")))
+        XCTAssertTrue(disallowList.isDisallowed(url: URL(string: "https://c.com/foo/secret")))
+        XCTAssertFalse(disallowList.isDisallowed(url: URL(string: "https://d.com/")))
+    }
+}

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -17,6 +17,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         rumAttributesProvider: RUM.ResourceAttributesProvider? = nil,
         distributedTracing: DistributedTracing? = nil,
         headerProcessor: HeaderProcessor? = nil,
+        disallowList: DisallowList? = nil,
         telemetry: Telemetry = NOPTelemetry()
     ) -> URLSessionRUMResourcesHandler {
         let handler = URLSessionRUMResourcesHandler(
@@ -24,6 +25,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
             rumAttributesProvider: rumAttributesProvider,
             distributedTracing: distributedTracing,
             headerProcessor: headerProcessor,
+            disallowList: disallowList,
             telemetry: telemetry
         )
         handler.publish(to: commandSubscriber)
@@ -1314,6 +1316,53 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
 
         XCTAssertNil(stopResourceCommand?.attributes[CrossPlatformAttributes.graphqlErrors])
+    }
+
+    // MARK: - Disallow List
+
+    func testGivenDisallowedURL_whenInterceptionStartsAndCompletes_itDoesNotSendAnyRUMCommand() throws {
+        // Given
+        let handler = createHandler(disallowList: DisallowList(["https://excluded.example.com/"]))
+        commandSubscriber.onCommandReceived = { _ in XCTFail("No RUM command should be sent for a disallowed URL") }
+
+        let request: ImmutableRequest = .mockWith(url: URL(string: "https://excluded.example.com/")!)
+        let taskInterception = URLSessionTaskInterception(request: request, isFirstParty: .random(), trackingMode: .mockRandom())
+        taskInterception.register(metrics: .mockAny())
+        taskInterception.register(response: .mockResponseWith(statusCode: 200), error: nil)
+
+        // When & Then (fails via `onCommandReceived` above if any RUM command is sent)
+        handler.interceptionDidStart(interception: taskInterception, capturedStates: [])
+        handler.interceptionDidComplete(interception: taskInterception)
+    }
+
+    func testGivenDisallowedURL_whenInterceptionStarts_itStillRegistersRUMOriginOnInterception() throws {
+        // Given
+        let handler = createHandler(disallowList: DisallowList(["https://excluded.example.com/"]))
+        let request: ImmutableRequest = .mockWith(url: URL(string: "https://excluded.example.com/")!)
+        let taskInterception = URLSessionTaskInterception(request: request, isFirstParty: .random(), trackingMode: .mockRandom())
+
+        // When
+        handler.interceptionDidStart(interception: taskInterception, capturedStates: [])
+
+        // Then - `origin` must still be set to "rum" so Trace's automatic instrumentation is unaffected
+        XCTAssertEqual(taskInterception.origin, "rum")
+    }
+
+    func testGivenNonDisallowedURL_whenDisallowListIsConfigured_itStartsRUMResourceAsUsual() throws {
+        let receiveCommand = expectation(description: "Receive RUM command")
+        commandSubscriber.onCommandReceived = { _ in receiveCommand.fulfill() }
+
+        // Given
+        let handler = createHandler(disallowList: DisallowList(["https://excluded.example.com/"]))
+        let request: ImmutableRequest = .mockWith(url: URL(string: "https://allowed.example.com/")!)
+        let taskInterception = URLSessionTaskInterception(request: request, isFirstParty: .random(), trackingMode: .mockRandom())
+
+        // When
+        handler.interceptionDidStart(interception: taskInterception, capturedStates: [])
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+        XCTAssertTrue(commandSubscriber.lastReceivedCommand is RUMStartResourceCommand)
     }
 
     // MARK: - Helper Methods

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -1344,7 +1344,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         handler.interceptionDidStart(interception: taskInterception, capturedStates: [])
 
-        // Then - `origin` must still be set to "rum" so Trace's automatic instrumentation is unaffected
+        // Then - `origin` stays "rum" so Trace skips its own span (the backend reconstructs it from the
+        // RUM Resource); since the disallowed Resource is never sent, no span is created for this request.
         XCTAssertEqual(taskInterception.origin, "rum")
     }
 

--- a/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -1335,7 +1335,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         handler.interceptionDidComplete(interception: taskInterception)
     }
 
-    func testGivenDisallowedURL_whenInterceptionStarts_itStillRegistersRUMOriginOnInterception() throws {
+    func testGivenDisallowedURL_whenInterceptionStarts_itDoesNotRegisterRUMOriginOnInterception() throws {
         // Given
         let handler = createHandler(disallowList: DisallowList(["https://excluded.example.com/"]))
         let request: ImmutableRequest = .mockWith(url: URL(string: "https://excluded.example.com/")!)
@@ -1344,9 +1344,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // When
         handler.interceptionDidStart(interception: taskInterception, capturedStates: [])
 
-        // Then - `origin` stays "rum" so Trace skips its own span (the backend reconstructs it from the
-        // RUM Resource); since the disallowed Resource is never sent, no span is created for this request.
-        XCTAssertEqual(taskInterception.origin, "rum")
+        // Then
+        XCTAssertNil(taskInterception.origin)
     }
 
     func testGivenNonDisallowedURL_whenDisallowListIsConfigured_itStartsRUMResourceAsUsual() throws {

--- a/DatadogRUM/Tests/RUMConfigurationTests.swift
+++ b/DatadogRUM/Tests/RUMConfigurationTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+import TestUtilities
 import DatadogRUM
 
 class RUMConfigurationTests: XCTestCase {
@@ -38,5 +39,28 @@ class RUMConfigurationTests: XCTestCase {
         XCTAssertNil(config.customEndpoint)
         XCTAssertTrue(config.trackAnonymousUser)
         XCTAssertTrue(config.featureFlags[.trackScrollAndSwipeActions])
+    }
+
+    func testDefaultURLSessionTrackingConfiguration() {
+        // When
+        let tracking = RUM.Configuration.URLSessionTracking()
+
+        // Then
+        XCTAssertNil(tracking.firstPartyHostsTracing)
+        XCTAssertNil(tracking.resourceAttributesProvider)
+        DDAssertReflectionEqual(tracking.disallowList, [])
+    }
+
+    func testURLSessionTrackingConfiguration_withDisallowList() {
+        // When
+        let tracking = RUM.Configuration.URLSessionTracking(
+            disallowList: ["https://foo.com/", "https://bar.com/*", "https://*.baz.com/"]
+        )
+
+        // Then
+        DDAssertReflectionEqual(
+            tracking.disallowList,
+            ["https://foo.com/", "https://bar.com/*", "https://*.baz.com/"]
+        )
     }
 }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3935,6 +3935,7 @@ public class objc_URLSessionTracking: NSObject
     public func setFirstPartyHostsTracing(_ firstPartyHostsTracing: objc_FirstPartyHostsTracing)
     public func setResourceAttributesProvider(_ provider: @escaping (URLRequest, URLResponse?, Data?, Error?) -> [String: Any]?)
     public func setTrackResourceHeaders(_ trackResourceHeaders: objc_TrackResourceHeaders)
+    public func setDisallowList(_ disallowList: [String])
 public final class objc_HeaderCaptureRule: NSObject
     public static let defaults = objc_HeaderCaptureRule(.defaults)
     public static func matchHeaders(_ names: [String]) -> objc_HeaderCaptureRule

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -426,6 +426,7 @@ public enum RUM
             public var firstPartyHostsTracing: FirstPartyHostsTracing?
             public var resourceAttributesProvider: RUM.ResourceAttributesProvider?
             public var trackResourceHeaders: TrackResourceHeaders = .disabled
+            public var disallowList: [String] = []
         public enum VitalsFrequency: String
             case frequent
             case average
@@ -441,7 +442,7 @@ public enum RUM
     public enum HeaderCaptureRule
         case defaults
         case matchHeaders([String])
-    public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,trackResourceHeaders: TrackResourceHeaders = .disabled)
+    public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,trackResourceHeaders: TrackResourceHeaders = .disabled,disallowList: [String] = [])
 [?] extension RUM.Configuration
     public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,featureFlags: FeatureFlags = .defaults)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration


### PR DESCRIPTION
## What and why?

Adds `RUM.Configuration.URLSessionTracking.disallowList: [String]` to exclude specific URLs from RUM Resource tracking.

## Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [x] Run `make api-surface` when adding new APIs