### PR TITLE
[RUM-17832] Remove unused intrinsic content size capture

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
@@ -111,7 +111,6 @@ extension DisplayList.ViewUpdater.ViewInfo: Reflection {
             // This is useful for applying the offset in a scroll-view.
             frame = container.convert(container.bounds, to: view)
             alpha = view.alpha
-            intrinsicContentSize = container.intrinsicContentSize
         } else {
             // In this case 'view' and 'layer' are the same
 
@@ -120,7 +119,6 @@ extension DisplayList.ViewUpdater.ViewInfo: Reflection {
 
             frame = container.convert(container.bounds, to: layer)
             alpha = .init(layer.opacity)
-            intrinsicContentSize = container.preferredFrameSize()
         }
 
         backgroundColor = layer.backgroundColor?.safeCast

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList.swift
@@ -55,9 +55,6 @@ internal struct DisplayList {
 
             /// Original view's `.isHidden`.
             let isHidden: Bool
-
-            /// Original view's `.intrinsicContentSize`.
-            let intrinsicContentSize: CGSize
         }
 
         let viewCache: ViewCache

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -102,9 +102,6 @@ public struct SessionReplayViewAttributes: Equatable {
     /// Original view's `.isHidden`.
     var isHidden: Bool
 
-    /// Original view's `.intrinsicContentSize`.
-    var intrinsicContentSize: CGSize
-
     /// Values copied from privacy overrides, if the view has privacy overrides,
     /// which take precedence over global masking privacy levels.
     var textAndInputPrivacy: TextAndInputPrivacyLevel?
@@ -132,7 +129,6 @@ extension ViewAttributes {
         self.layerCornerRadius = view.layer.cornerRadius
         self.alpha = view.alpha
         self.isHidden = view.isHidden
-        self.intrinsicContentSize = view.intrinsicContentSize
         self.textAndInputPrivacy = overrides?.textAndInputPrivacy
         self.imagePrivacy = overrides?.imagePrivacy
         self.touchPrivacy = overrides?.touchPrivacy

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -30,11 +30,21 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertEqual(attributes.layerCornerRadius, view.layer.cornerRadius)
         XCTAssertEqual(attributes.alpha, view.alpha)
         XCTAssertEqual(attributes.isHidden, view.isHidden)
-        XCTAssertEqual(attributes.intrinsicContentSize, view.intrinsicContentSize)
         XCTAssertNil(attributes.textAndInputPrivacy)
         XCTAssertNil(attributes.imagePrivacy)
         XCTAssertNil(attributes.touchPrivacy)
         XCTAssertNil(attributes.hide)
+    }
+
+    func testItDoesNotCaptureIntrinsicContentSize() {
+        // Given
+        let view = IntrinsicContentSizeTrackingView()
+
+        // When
+        _ = createViewAttributes(with: view)
+
+        // Then
+        XCTAssertEqual(view.numberOfIntrinsicContentSizeReads, 0)
     }
 
     func testWhenViewIsVisible() {
@@ -279,6 +289,15 @@ extension ViewAttributesTests {
             clip: clip ?? view.frame,
             overrides: .mockAny()
         )
+    }
+}
+
+private final class IntrinsicContentSizeTrackingView: UIView {
+    private(set) var numberOfIntrinsicContentSizeReads = 0
+
+    override var intrinsicContentSize: CGSize {
+        numberOfIntrinsicContentSizeReads += 1
+        return CGSize(width: 100, height: 100)
     }
 }
 #endif

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/RecorderMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/RecorderMocks.swift
@@ -66,7 +66,6 @@ extension ViewAttributes: AnyMockable, RandomMockable {
             layerCornerRadius: .mockRandom(min: 0, max: 5),
             alpha: .mockRandom(min: 0, max: 1),
             isHidden: .mockRandom(),
-            intrinsicContentSize: .mockRandom(),
             textAndInputPrivacy: .mockRandom(),
             imagePrivacy: .mockRandom(),
             touchPrivacy: .mockRandom(),
@@ -84,7 +83,6 @@ extension ViewAttributes: AnyMockable, RandomMockable {
         layerCornerRadius: CGFloat = .mockAny(),
         alpha: CGFloat = .mockAny(),
         isHidden: Bool = .mockAny(),
-        intrinsicContentSize: CGSize = .mockAny(),
         overrides: PrivacyOverrides = .mockAny()
     ) -> ViewAttributes {
         return .init(
@@ -96,7 +94,6 @@ extension ViewAttributes: AnyMockable, RandomMockable {
             layerCornerRadius: layerCornerRadius,
             alpha: alpha,
             isHidden: isHidden,
-            intrinsicContentSize: intrinsicContentSize,
             textAndInputPrivacy: overrides.textAndInputPrivacy,
             imagePrivacy: overrides.imagePrivacy,
             touchPrivacy: overrides.touchPrivacy,
@@ -186,7 +183,6 @@ extension ViewAttributes: AnyMockable, RandomMockable {
             layerCornerRadius: .mockRandom(min: 0, max: 4),
             alpha: alpha,
             isHidden: isHidden,
-            intrinsicContentSize: frame.size,
             textAndInputPrivacy: nil,
             imagePrivacy: nil,
             touchPrivacy: nil,


### PR DESCRIPTION
### What and why?

Session Replay was reading `intrinsicContentSize` while building view attributes for every recorded view. That value was not used, and reading it can force expensive layout work in SwiftUI hosting views during recording.

Fixes #3099

### How?

Removed `intrinsicContentSize` from `SessionReplayViewAttributes` and SwiftUI `DisplayList.ViewInfo`.
Added a regression test that fails if creating `ViewAttributes` reads `intrinsicContentSize`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
