### PR TITLE
chore: Auto-cancel redundant CI pipelines on push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,9 @@ workflow:
     - if: '$CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH !~ /^(develop|master|dogfooding|release\/.*|hotfix\/.*)$/'
       auto_cancel:
         on_new_commit: interruptible
-    - when: always
+    - when: always # develop, master, dogfooding, release/*, hotfix/*: never auto-canceled
+      auto_cancel:
+        on_new_commit: none
 
 # ┌───────────────┐
 # │ Utility jobs: │

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,16 @@ default:
   tags:
     - macos:sequoia-arm64
     - specific:true
+  interruptible: true # a pending/running job may be canceled by a newer push to the same branch
+
+# On any branch other than a known stable branch, cancel interruptible jobs from
+# the previous pipeline when a new commit is pushed to that branch.
+workflow:
+  rules:
+    - if: '$CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH !~ /^(develop|master|dogfooding|release\/.*|hotfix\/.*)$/'
+      auto_cancel:
+        on_new_commit: interruptible
+    - when: always
 
 # ┌───────────────┐
 # │ Utility jobs: │
@@ -457,6 +467,7 @@ Benchmark Test (upload to s8s):
 
 Dogfood (Shopist):
   stage: dogfood
+  interruptible: false
   rules:
     - if: '$CI_COMMIT_BRANCH == $DOGFOODING_BRANCH'
       when: manual
@@ -469,6 +480,7 @@ Dogfood (Shopist):
 
 Dogfood (Datadog app):
   stage: dogfood
+  interruptible: false
   rules:
     - if: '$CI_COMMIT_BRANCH == $DOGFOODING_BRANCH'
       when: manual
@@ -492,6 +504,7 @@ Dogfood (Datadog app):
 
 Build Artifacts:
   stage: release-build
+  interruptible: false
   rules:
     - !reference [.release-pipeline-job, rules]
   id_tokens:
@@ -510,7 +523,8 @@ Build Artifacts:
 
 Publish GH Asset:
   stage: release-publish
-  rules: 
+  interruptible: false
+  rules:
     - !reference [.release-pipeline-job, rules]
   id_tokens:
     <<: *dd-octo-sts-id-token
@@ -524,6 +538,7 @@ Publish GH Asset:
 
 Publish CP podspecs (internal):
   stage: release-publish
+  interruptible: false
   retry: 2
   rules:
     - !reference [.release-pipeline-job, rules]
@@ -537,6 +552,7 @@ Publish CP podspecs (internal):
 
 .publish-dependent-podspec:
   stage: release-publish
+  interruptible: false
   retry: 2
   rules:
     - !reference [.release-pipeline-20m-delayed-job, rules]


### PR DESCRIPTION
### What and why?

📦 This PR auto-cancels stale CI pipelines from earlier pushes to the same branch, to avoid wasting runner resources.

Ref: [GitLab docs: How to auto-cancel redundant pipelines](https://support.gitlab.com/hc/en-us/articles/22118112967068-How-to-auto-cancel-redundant-pipelines)
Mirrors the change already shipped in dd-sdk-android: 
- https://github.com/DataDog/dd-sdk-android/pull/3584
- https://github.com/DataDog/dd-sdk-android/pull/3602

### How?

Jobs default to `interruptible: true`, and a new `workflow.rules` block cancels a branch's previous pipeline on new commits — except on `develop`, `master`, `dogfooding`, `release/*`, and `hotfix/*`. Release and dogfood jobs are explicitly marked `interruptible: false` since they only run on those protected refs.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [ ] Run `make api-surface` when adding new APIs