### PR TITLE
Bump KSCrash to 2.5.1

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -12222,7 +12222,7 @@
 			repositoryURL = "https://github.com/kstenerud/KSCrash.git";
 			requirement = {
 				kind = exactVersion;
-				version = 2.5.0;
+				version = 2.5.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -24,8 +24,8 @@ Pod::Spec.new do |s|
 
   s.source_files = "DatadogCrashReporting/Sources/**/*.swift"
   s.dependency 'DatadogInternal', s.version.to_s
-  s.dependency 'KSCrash/Recording', '2.5.0'
-  s.dependency 'KSCrash/Filters', '2.5.0'
+  s.dependency 'KSCrash/Recording', '2.5.1'
+  s.dependency 'KSCrash/Filters', '2.5.1'
 
   s.resource_bundle = {
     "DatadogCrashReporting" => "DatadogCrashReporting/Resources/PrivacyInfo.xcprivacy"

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/kstenerud/KSCrash.git", from: "2.5.0"),
+        .package(url: "https://github.com/kstenerud/KSCrash.git", from: "2.5.1"),
         .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core", .upToNextMinor(from: "2.5.0")),
     ],
     targets: [


### PR DESCRIPTION
### What and why?

Bumps the KSCrash dependency from 2.5.0 to 2.5.1 across SPM (`Package.swift`), CocoaPods (`DatadogCrashReporting.podspec`), and the Xcode project's SPM package reference.

Closes #3082

### How?

Updated the version pins in `Package.swift`, `DatadogCrashReporting.podspec`, and `Datadog.xcodeproj/project.pbxproj`, and verified the workspace resolves and builds against KSCrash 2.5.1.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration) — N/A, dependency version bump only
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — N/A, internal dependency bump
- [ ] Add Objective-C interface for public APIs — N/A, no public API changes
- [ ] Run `make api-surface` when adding new APIs — N/A, no new APIs