### PR TITLE
RUM-17867: Fixes wrong order setting up session sampler and calling `onSessionStart`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add support for UK1 Datadog Site. See [#3087][]
+- [FIX] onSessionStart is now called only after sampling information used by WebView Tracking is in place, avoiding missing traces in early requests. See [#3104][]
 
 # 3.14.0 / 15-07-2026
 
@@ -1200,6 +1201,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3019]: https://github.com/DataDog/dd-sdk-ios/pull/3019
 [#3051]: https://github.com/DataDog/dd-sdk-ios/pull/3051
 [#3087]: https://github.com/DataDog/dd-sdk-ios/pull/3087
+[#3104]: https://github.com/DataDog/dd-sdk-ios/pull/3104
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -111,12 +111,12 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         }()
 
         let onSessionUpdate: RUM.SessionUpdater = { [onSessionStart = configuration.onSessionStart, _rumSessionSampler] sessionScope in
+            _rumSessionSampler.mutate { $0 = sessionScope?.sampler }
             if let sessionScope {
                 let sessionID = sessionScope.sessionUUID.toRUMDataFormat
                 let isDiscarded = !sessionScope.sampler.isSampled
                 onSessionStart?(sessionID, isDiscarded)
             }
-            _rumSessionSampler.mutate { $0 = sessionScope?.sampler }
         }
 
         let dependencies = RUMScopeDependencies(


### PR DESCRIPTION
### What and why?

When a new RUM session is created, we are doing two things:
1. Copy the session sampler to the `_rumSessionSampler` variable, used by the WebViewTracking feature to obtain sampling information and properly feed it to the JS bridge, which the Browser SDK will use to decide if traces are sampled or not;
2. Call the user provided `onSessionStart` callback if not nil.

Right now, we are calling `onSessionStart` before we copy the sampler to `_rumSessionSampler.` This created a problem: when a WebView is created and a request issued, all at application launch, it’s possible the first requests issued by the page displayed in the WebView are not traced properly since the sampling information is not yet available. Even if the customer used `onSessionStart` to delay the WebView initialization, the sampling information wouldn’t be in place yet when the callback runs, so the problem remained.

### How?

This patch inverts the order, so `onSessionStart` will run only after `_rumSessionSampler` contains the session sampler.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
