### PR TITLE
Crash when using RUM `onSessionStart` in a Swift 6 project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FEATURE] Add support for UK1 Datadog Site. See [#3087][]
 - [FIX] onSessionStart is now called only after sampling information used by WebView Tracking is in place, avoiding missing traces in early requests. See [#3104][]
+- [FIX] Fix crash when defining `onSessionStart` in RUM configuration in Swift 6 projects. See [#3106][]
 
 # 3.14.0 / 15-07-2026
 
@@ -1202,6 +1203,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3051]: https://github.com/DataDog/dd-sdk-ios/pull/3051
 [#3087]: https://github.com/DataDog/dd-sdk-ios/pull/3087
 [#3104]: https://github.com/DataDog/dd-sdk-ios/pull/3104
+[#3106]: https://github.com/DataDog/dd-sdk-ios/pull/3106
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-06-29
-sdk_version: 3.13.0
-verified_against_commit: 48f0891ec
+last_updated: 2026-08-04
+sdk_version: 3.14.0
+verified_against_commit: cc8c93bb3
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift
@@ -148,6 +148,8 @@ RUM.enable(
         // Also available: errorEventMapper, actionEventMapper, longTaskEventMapper
         
         // Session start callback
+        // Note: this is a `@Sendable` closure (SessionListener) — it may be
+        // invoked from a background queue, so only capture Sendable state.
         onSessionStart: { sessionId, isDiscarded in
             // `sessionId` matches the emitted RUM event `session.id`
             print("Session \(sessionId) started, sampled out: \(isDiscarded)")

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -709,7 +709,7 @@ public class objc_RUMConfiguration: NSObject {
         }
     }
 
-    public var onSessionStart: ((String, Bool) -> Void)? {
+    public var onSessionStart: (@Sendable (String, Bool) -> Void)? {
         set { swiftConfig.onSessionStart = newValue }
         get { swiftConfig.onSessionStart }
     }

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -47,7 +47,7 @@ extension RUM {
 
     /// RUM session listener.
     /// - See: `RUM.Configuration.onSessionStart`.
-    public typealias SessionListener = (String, Bool) -> Void
+    public typealias SessionListener = @Sendable (String, Bool) -> Void
 
     /// RUM resource attributes provider.
     /// - See: `RUM.Configuration.URLSessionTracking.resourceAttributesProvider`.

--- a/SmokeTests/spm/App/ViewController.swift
+++ b/SmokeTests/spm/App/ViewController.swift
@@ -18,7 +18,14 @@ internal class ViewController: UIViewController {
         DatadogSetup.initialize()
 
         // RUM APIs must be visible:
-        RUM.enable(with: .init(applicationID: "app-id"))
+        RUM.enable(
+            with: .init(
+                applicationID: "app-id",
+                onSessionStart: { sessionID, _ in
+                    print("Session ID is \(sessionID)")
+                }
+            )
+        )
         RUMMonitor.shared().startView(viewController: self)
 
         // Trace APIs must be visible:

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3534,7 +3534,7 @@ public class objc_RUMConfiguration: NSObject
     public func setActionEventMapper(_ mapper: @escaping (objc_RUMActionEvent) -> objc_RUMActionEvent?)
     public func setErrorEventMapper(_ mapper: @escaping (objc_RUMErrorEvent) -> objc_RUMErrorEvent?)
     public func setLongTaskEventMapper(_ mapper: @escaping (objc_RUMLongTaskEvent) -> objc_RUMLongTaskEvent?)
-    public var onSessionStart: ((String, Bool) -> Void)?
+    public var onSessionStart: (@Sendable (String, Bool) -> Void)?
     public var customEndpoint: URL?
     public var trackAnonymousUser: Bool
 public class objc_RUM: NSObject

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -391,7 +391,7 @@ public enum RUM
     public typealias ErrorEventMapper = (RUMErrorEvent) -> RUMErrorEvent?
     public typealias ActionEventMapper = (RUMActionEvent) -> RUMActionEvent?
     public typealias LongTaskEventMapper = (RUMLongTaskEvent) -> RUMLongTaskEvent?
-    public typealias SessionListener = (String, Bool) -> Void
+    public typealias SessionListener = @Sendable (String, Bool) -> Void
     public typealias ResourceAttributesProvider = (URLRequest, URLResponse?, Data?, Error?) -> [AttributeKey: AttributeValue]?
     public struct Configuration
         public let applicationID: String


### PR DESCRIPTION
### What and why?

When RUM is initialized with an `onSessionStart` callback like the following code in a Swift 6 application, there will be no issues at compile time, but at runtime the application crashes due to a failed runtime check related to Swift concurrency. 

```
RUM.enable(
    with: RUM.Configuration(
        onSessionStart: { _, _ in
            …
        }
    )
)
```

### How?

This patch avoids the crash by declaring the closure as Sendable.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
