### PR TITLE
[PANA-8468] Namespace layer wireframe identifiers

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		5B4F552D2E853B3B00A241C3 /* ExposureLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */; };
 		5B4F552F2E853D7700A241C3 /* FlagsClientMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */; };
 		5B4F55312E85400000A241C3 /* ExposureTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F55302E85400000A241C3 /* ExposureTrackerTests.swift */; };
+		5B5522483020ECAF008AC88A /* SRWireframe+ReplayID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5522473020ECA6008AC88A /* SRWireframe+ReplayID.swift */; };
 		5B5B8CB62E8BCA6A00A6740E /* FlagsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CB52E8BCA5F00A6740E /* FlagsRepositoryTests.swift */; };
 		5B5B8CB92E8BD44700A6740E /* FlagsDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CB82E8BD44000A6740E /* FlagsDataStore.swift */; };
 		5B5B8CBF2E8BDB1000A6740E /* FlagsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */; };
@@ -641,6 +642,8 @@
 		615D52C12C88AB1E00F8B8FC /* SynchronizedAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615D52C02C88AB1E00F8B8FC /* SynchronizedAttributesTests.swift */; };
 		615E2B8E2D39444300D85243 /* ViewEndedController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615E2B8D2D39444300D85243 /* ViewEndedController.swift */; };
 		615E2B952D425F5600D85243 /* ViewEndedMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615E2B942D425F5600D85243 /* ViewEndedMetric.swift */; };
+		6165D7353013888F0069D0E4 /* TelemetrySanitizableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */; };
+		6165D7373017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165D7363017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift */; };
 		6167E6D32B7F8B3300C3CA2D /* AppHangsMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D22B7F8B3300C3CA2D /* AppHangsMonitor.swift */; };
 		6167E6D62B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D52B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift */; };
 		6167E6DA2B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167E6D92B8004A500C3CA2D /* AppHangsWatchdogThreadTests.swift */; };
@@ -1014,8 +1017,6 @@
 		D23039F8298D5236001A1FA3 /* InternalLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039CE298D5235001A1FA3 /* InternalLogger.swift */; };
 		D23039F9298D5236001A1FA3 /* CoreLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039CF298D5235001A1FA3 /* CoreLogger.swift */; };
 		D23039FA298D5236001A1FA3 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D0298D5235001A1FA3 /* Telemetry.swift */; };
-		6165D7353013888F0069D0E4 /* TelemetrySanitizableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */; };
-		6165D7373017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6165D7363017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift */; };
 		D23039FB298D5236001A1FA3 /* URLRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D2298D5235001A1FA3 /* URLRequestBuilder.swift */; };
 		D23039FC298D5236001A1FA3 /* DataFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D3298D5235001A1FA3 /* DataFormat.swift */; };
 		D23039FD298D5236001A1FA3 /* DataCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23039D4298D5235001A1FA3 /* DataCompression.swift */; };
@@ -2182,6 +2183,7 @@
 		5B4F552B2E853B2E00A241C3 /* ExposureLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureLoggerTests.swift; sourceTree = "<group>"; };
 		5B4F552E2E853D7200A241C3 /* FlagsClientMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientMocks.swift; sourceTree = "<group>"; };
 		5B4F55302E85400000A241C3 /* ExposureTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureTrackerTests.swift; sourceTree = "<group>"; };
+		5B5522473020ECA6008AC88A /* SRWireframe+ReplayID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRWireframe+ReplayID.swift"; sourceTree = "<group>"; };
 		5B5B8CB52E8BCA5F00A6740E /* FlagsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsRepositoryTests.swift; sourceTree = "<group>"; };
 		5B5B8CB82E8BD44000A6740E /* FlagsDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsDataStore.swift; sourceTree = "<group>"; };
 		5B5B8CBE2E8BDB0D00A6740E /* FlagsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsData.swift; sourceTree = "<group>"; };
@@ -2513,6 +2515,8 @@
 		615E2B942D425F5600D85243 /* ViewEndedMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewEndedMetric.swift; sourceTree = "<group>"; };
 		615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensions.swift; sourceTree = "<group>"; };
 		6161247825CA9CA6009901BE /* CrashReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporting.swift; sourceTree = "<group>"; };
+		6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySanitizableError.swift; sourceTree = "<group>"; };
+		6165D7363017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySanitizableErrorTests.swift; sourceTree = "<group>"; };
 		6167ACBD251A0B410012B4D0 /* Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Example-Bridging-Header.h"; sourceTree = "<group>"; };
 		6167E6D22B7F8B3300C3CA2D /* AppHangsMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangsMonitor.swift; sourceTree = "<group>"; };
 		6167E6D52B7F8C3400C3CA2D /* AppHangsWatchdogThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangsWatchdogThread.swift; sourceTree = "<group>"; };
@@ -2977,8 +2981,6 @@
 		D23039CE298D5235001A1FA3 /* InternalLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalLogger.swift; sourceTree = "<group>"; };
 		D23039CF298D5235001A1FA3 /* CoreLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreLogger.swift; sourceTree = "<group>"; };
 		D23039D0298D5235001A1FA3 /* Telemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
-		6165D7343013888F0069D0E4 /* TelemetrySanitizableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySanitizableError.swift; sourceTree = "<group>"; };
-		6165D7363017AA010069D0E4 /* TelemetrySanitizableErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySanitizableErrorTests.swift; sourceTree = "<group>"; };
 		D23039D2298D5235001A1FA3 /* URLRequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRequestBuilder.swift; sourceTree = "<group>"; };
 		D23039D3298D5235001A1FA3 /* DataFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataFormat.swift; sourceTree = "<group>"; };
 		D23039D4298D5235001A1FA3 /* DataCompression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCompression.swift; sourceTree = "<group>"; };
@@ -6227,6 +6229,7 @@
 				7C61BC8C730F46F1A8EF112E /* OcclusionMap.swift */,
 				5BB771B52FEA7A0E00C95960 /* ImageSnapshotResource.swift */,
 				5BB771B72FEA7A2800C95960 /* SRWireframe+CALayerSnapshot.swift */,
+				5B5522473020ECA6008AC88A /* SRWireframe+ReplayID.swift */,
 			);
 			path = LayerTreeRecorder;
 			sourceTree = "<group>";
@@ -8643,6 +8646,7 @@
 				5BD25CFB301A3BF40064A649 /* EmbeddedContentReceiver.swift in Sources */,
 				5B74482F2EFAB819003E622C /* CALayerSwizzler.swift in Sources */,
 				5B7448302EFAB819003E622C /* CALayerChange.swift in Sources */,
+				5B5522483020ECAF008AC88A /* SRWireframe+ReplayID.swift in Sources */,
 				B73450522F9F240000000001 /* CALayerReference.swift in Sources */,
 				5B23A8AB2FF7A8A800024C6F /* MaskSnapshot.swift in Sources */,
 				5B7448312EFAB819003E622C /* CALayerChangeAggregator.swift in Sources */,

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -171,7 +171,7 @@ internal class CompositionTreeBuilder {
         }
 
         wireframes.append(output.wireframe)
-        return SRCompositionLayerChild(id: output.id, type: .wireframe)
+        return SRCompositionLayerChild(id: output.wireframe.id, type: .wireframe)
     }
 }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerWireframeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerWireframeBuilder.swift
@@ -14,7 +14,6 @@ internal struct LayerWireframeBuilder {
     typealias TextInputSemantics = CALayerSnapshot.SemanticObservation.TextInputSemantics
 
     struct Output {
-        let id: Int64
         let wireframe: SRWireframe
         let resource: Resource?
     }
@@ -43,7 +42,6 @@ internal struct LayerWireframeBuilder {
     ) -> Output? {
         guard !snapshot.isPrivate else {
             return Output(
-                id: snapshot.replayID,
                 wireframe: SRWireframe(placeholderFor: snapshot, label: .hiddenPlaceholder),
                 resource: nil
             )
@@ -63,22 +61,22 @@ internal struct LayerWireframeBuilder {
             )
         case (.layer, .none):
             return SRWireframe(layerSnapshot: snapshot, cornerRadius: cornerRadius)
-                .map { Output(id: snapshot.replayID, wireframe: $0, resource: nil) }
+                .map { Output(wireframe: $0, resource: nil) }
         case (.gradient(let gradient), _):
             return SRWireframe(
                 layerSnapshot: snapshot,
                 backgroundGradient: SRShapeGradient(gradient: gradient),
                 cornerRadius: cornerRadius
-            ).map { Output(id: snapshot.replayID, wireframe: $0, resource: nil) }
+            ).map { Output(wireframe: $0, resource: nil) }
         case (.label(let label), _):
             return SRWireframe(
                 layerSnapshot: snapshot,
                 label: label,
                 cornerRadius: cornerRadius
-            ).map { Output(id: snapshot.replayID, wireframe: $0, resource: nil) }
+            ).map { Output(wireframe: $0, resource: nil) }
         case (.textInput, .none):
             return SRWireframe(layerSnapshot: snapshot, cornerRadius: cornerRadius)
-                .map { Output(id: snapshot.replayID, wireframe: $0, resource: nil) }
+                .map { Output(wireframe: $0, resource: nil) }
         case (.image(let image), .none) where image.hasContent:
             let wireframe = SRWireframe(
                 placeholderFor: snapshot,
@@ -86,20 +84,18 @@ internal struct LayerWireframeBuilder {
                     ? .contentImagePlaceholder
                     : .imagePlaceholder
             )
-            return Output(id: snapshot.replayID, wireframe: wireframe, resource: nil)
+            return Output(wireframe: wireframe, resource: nil)
         case (.image, .none):
             return SRWireframe(layerSnapshot: snapshot, cornerRadius: cornerRadius)
-                .map { Output(id: snapshot.replayID, wireframe: $0, resource: nil) }
+                .map { Output(wireframe: $0, resource: nil) }
         case (.webView(let webView), _):
             pendingWebViewSlotIDs.remove(webView.slotID)
             return Output(
-                id: Int64(webView.slotID),
                 wireframe: SRWireframe(layerSnapshot: snapshot, webView: webView),
                 resource: nil
             )
         case (.visualEffect(.automaticCapsule), _):
             return Output(
-                id: snapshot.replayID,
                 wireframe: SRWireframe(
                     layerSnapshot: snapshot,
                     backgroundColor: .systemBackground,
@@ -109,19 +105,16 @@ internal struct LayerWireframeBuilder {
             )
         case (.visualEffect(.glassGroup), _) where snapshot.cornerRadii != .zero:
             return Output(
-                id: snapshot.replayID,
                 wireframe: SRWireframe(layerSnapshot: snapshot, backgroundColor: .systemBackground),
                 resource: nil
             )
         case (.visualEffect(.backdrop), _):
             return Output(
-                id: snapshot.replayID,
                 wireframe: SRWireframe(layerSnapshot: snapshot, backgroundColor: .systemBackground),
                 resource: nil
             )
         case (.visualEffect(.background(let color)), _):
             return Output(
-                id: snapshot.replayID,
                 wireframe: SRWireframe(
                     layerSnapshot: snapshot,
                     backgroundColor: color ?? .secondarySystemFill
@@ -133,7 +126,7 @@ internal struct LayerWireframeBuilder {
                 return nil
             }
             return SRWireframe(layerSnapshot: snapshot, backgroundGradient: gradient)
-                .map { Output(id: snapshot.replayID, wireframe: $0, resource: nil) }
+                .map { Output(wireframe: $0, resource: nil) }
         default:
             return nil
         }
@@ -158,9 +151,8 @@ internal struct LayerWireframeBuilder {
                 case .image(let image):
                     let resource = ImageSnapshotResource(image: image)
                     return Output(
-                        id: layerSnapshot.replayID,
                         wireframe: SRWireframe(
-                            id: layerSnapshot.replayID,
+                            replayID: layerSnapshot.replayID,
                             imageSnapshot: imageSnapshot,
                             resource: resource
                         ),
@@ -168,7 +160,6 @@ internal struct LayerWireframeBuilder {
                     )
                 case .placeholder(let color):
                     return Output(
-                        id: layerSnapshot.replayID,
                         wireframe: SRWireframe(
                             layerSnapshot: layerSnapshot,
                             backgroundColor: color,
@@ -179,7 +170,6 @@ internal struct LayerWireframeBuilder {
                 }
             } catch {
                 return Output(
-                    id: layerSnapshot.replayID,
                     wireframe: SRWireframe(
                         placeholderFor: layerSnapshot,
                         label: .redactedPlaceholder
@@ -189,7 +179,6 @@ internal struct LayerWireframeBuilder {
             }
         case .failure(.timedOut):
             return Output(
-                id: layerSnapshot.replayID,
                 wireframe: SRWireframe(
                     placeholderFor: layerSnapshot,
                     label: .timedOutPlaceholder

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
@@ -37,17 +37,17 @@ extension SRWireframe {
 
         self = .shapeWireframe(
             value: .init(
-                border: .init(layerSnapshot: layerSnapshot),
+                replayID: layerSnapshot.replayID,
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY),
+                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
                 height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
-                id: layerSnapshot.replayID,
+                border: .init(layerSnapshot: layerSnapshot),
                 shapeStyle: .init(
                     layerSnapshot: layerSnapshot,
                     backgroundGradient: backgroundGradient,
                     cornerRadius: cornerRadius
-                ),
-                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
-                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
-                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+                )
             )
         )
     }
@@ -60,16 +60,16 @@ extension SRWireframe {
     ) {
         self = .shapeWireframe(
             value: .init(
+                replayID: layerSnapshot.replayID,
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY),
+                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
                 height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
-                id: layerSnapshot.replayID,
                 shapeStyle: .init(
                     backgroundColor: hexString(from: backgroundColor.cgColor) ?? .fallbackColor,
                     cornerRadius: (cornerRadius ?? layerSnapshot.cornerRadii.uniformCornerRadius)
                         .map(Double.init)
-                ),
-                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
-                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
-                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+                )
             )
         )
     }
@@ -90,36 +90,36 @@ extension SRWireframe {
 
         self = .textWireframe(
             value: .init(
-                border: .init(layerSnapshot: layerSnapshot),
-                height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
-                id: layerSnapshot.replayID,
-                shapeStyle: .init(layerSnapshot: layerSnapshot, cornerRadius: cornerRadius),
-                text: text,
-                textPosition: .init(label: label),
-                textStyle: .init(label: label, frame: layerSnapshot.absoluteFrame),
-                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
+                replayID: layerSnapshot.replayID,
                 x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
-                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY),
+                height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
+                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
+                text: text,
+                textStyle: .init(label: label, frame: layerSnapshot.absoluteFrame),
+                border: .init(layerSnapshot: layerSnapshot),
+                shapeStyle: .init(layerSnapshot: layerSnapshot, cornerRadius: cornerRadius),
+                textPosition: .init(label: label)
             )
         )
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
     init(
-        id: Int64,
+        replayID: Int64,
         imageSnapshot: ContentSnapshot,
         resource: Resource
     ) {
         self = .imageWireframe(
             value: .init(
+                replayID: replayID,
+                x: Int64.ddWithNoOverflow(imageSnapshot.frame.minX),
+                y: Int64.ddWithNoOverflow(imageSnapshot.frame.minY),
+                width: Int64.ddWithNoOverflow(dimension: imageSnapshot.frame.width),
                 height: Int64.ddWithNoOverflow(dimension: imageSnapshot.frame.height),
-                id: id,
                 isEmpty: false,
                 mimeType: resource.mimeType,
                 resourceId: resource.calculateIdentifier(),
-                width: Int64.ddWithNoOverflow(dimension: imageSnapshot.frame.width),
-                x: Int64.ddWithNoOverflow(imageSnapshot.frame.minX),
-                y: Int64.ddWithNoOverflow(imageSnapshot.frame.minY)
             )
         )
     }
@@ -131,12 +131,12 @@ extension SRWireframe {
     ) {
         self = .placeholderWireframe(
             value: .init(
-                height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
-                id: layerSnapshot.replayID,
-                label: label,
-                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
+                replayID: layerSnapshot.replayID,
                 x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
-                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY),
+                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
+                height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
+                label: label
             )
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+ReplayID.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+ReplayID.swift
@@ -1,0 +1,171 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+
+extension SRWireframe {
+    internal enum IdentifierNamespace: Int64 {
+        case shape = 1
+        case text = 2
+        case image = 3
+        case placeholder = 4
+        case embeddedContent = 5
+    }
+}
+
+extension Int64 {
+    internal init(namespace: SRWireframe.IdentifierNamespace, replayID: Int64) {
+        self = (namespace.rawValue << 32) | replayID
+    }
+}
+
+extension SRShapeWireframe {
+    init(
+        replayID: Int64,
+        x: Int64,
+        y: Int64,
+        width: Int64,
+        height: Int64,
+        border: SRShapeBorder? = nil,
+        clip: SRContentClip? = nil,
+        shapeStyle: SRShapeStyle? = nil,
+        permanentId: String? = nil
+    ) {
+        self.init(
+            border: border,
+            clip: clip,
+            height: height,
+            id: .init(namespace: .shape, replayID: replayID),
+            permanentId: permanentId,
+            shapeStyle: shapeStyle,
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
+extension SRTextWireframe {
+    init(
+        replayID: Int64,
+        x: Int64,
+        y: Int64,
+        height: Int64,
+        width: Int64,
+        text: String,
+        textStyle: SRTextStyle,
+        border: SRShapeBorder? = nil,
+        clip: SRContentClip? = nil,
+        shapeStyle: SRShapeStyle? = nil,
+        textPosition: SRTextPosition? = nil,
+        permanentId: String? = nil
+    ) {
+        self.init(
+            border: border,
+            clip: clip,
+            height: height,
+            id: .init(namespace: .text, replayID: replayID),
+            permanentId: permanentId,
+            shapeStyle: shapeStyle,
+            text: text,
+            textPosition: textPosition,
+            textStyle: textStyle,
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
+extension SRImageWireframe {
+    init(
+        replayID: Int64,
+        x: Int64,
+        y: Int64,
+        width: Int64,
+        height: Int64,
+        base64: String? = nil,
+        border: SRShapeBorder? = nil,
+        clip: SRContentClip? = nil,
+        isEmpty: Bool? = nil,
+        mimeType: String? = nil,
+        resourceId: String? = nil,
+        shapeStyle: SRShapeStyle? = nil,
+        permanentId: String? = nil
+    ) {
+        self.init(
+            base64: base64,
+            border: border,
+            clip: clip,
+            height: height,
+            id: .init(namespace: .image, replayID: replayID),
+            isEmpty: isEmpty,
+            mimeType: mimeType,
+            permanentId: permanentId,
+            resourceId: resourceId,
+            shapeStyle: shapeStyle,
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
+extension SRPlaceholderWireframe {
+    init(
+        replayID: Int64,
+        x: Int64,
+        y: Int64,
+        width: Int64,
+        height: Int64,
+        clip: SRContentClip? = nil,
+        label: String? = nil,
+        permanentId: String? = nil
+    ) {
+        self.init(
+            clip: clip,
+            height: height,
+            id: .init(namespace: .placeholder, replayID: replayID),
+            label: label,
+            permanentId: permanentId,
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+
+extension SREmbeddedContentWireframe {
+    init(
+        replayID: Int64,
+        slotId: String,
+        x: Int64,
+        y: Int64,
+        width: Int64,
+        height: Int64,
+        border: SRShapeBorder? = nil,
+        clip: SRContentClip? = nil,
+        isVisible: Bool? = nil,
+        shapeStyle: SRShapeStyle? = nil,
+        permanentId: String? = nil,
+    ) {
+        self.init(
+            border: border,
+            clip: clip,
+            height: height,
+            id: .init(namespace: .embeddedContent, replayID: replayID),
+            isVisible: isVisible,
+            permanentId: permanentId,
+            shapeStyle: shapeStyle,
+            slotId: slotId,
+            width: width,
+            x: x,
+            y: y
+        )
+    }
+}
+#endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -60,8 +60,8 @@ struct CompositionTreeBuilderTests {
             output.compositionTree.layers?.first { $0.id == containerSnapshot.replayID }
         )
         #expect(layer.children == [
-            .init(id: containerSnapshot.replayID, type: .wireframe),
-            .init(id: contentSnapshot.replayID, type: .wireframe)
+            .init(id: .init(namespace: .shape, replayID: containerSnapshot.replayID), type: .wireframe),
+            .init(id: .init(namespace: .shape, replayID: contentSnapshot.replayID), type: .wireframe)
         ])
         #expect(output.wireframes.count == 2)
         #expect(output.resources.isEmpty)
@@ -97,8 +97,8 @@ struct CompositionTreeBuilderTests {
             output.compositionTree.layers?.first { $0.id == capsuleSnapshot.replayID }
         )
         #expect(layer.children == [
-            .init(id: capsuleSnapshot.replayID, type: .wireframe),
-            .init(id: contentSnapshot.replayID, type: .wireframe)
+            .init(id: .init(namespace: .shape, replayID: capsuleSnapshot.replayID), type: .wireframe),
+            .init(id: .init(namespace: .shape, replayID: contentSnapshot.replayID), type: .wireframe)
         ])
     }
 
@@ -133,7 +133,9 @@ struct CompositionTreeBuilderTests {
 
         let layer = try #require(output.compositionTree.layers?.first)
         #expect(layer.id == leaf.replayID)
-        #expect(layer.children == [.init(id: leaf.replayID, type: .wireframe)])
+        #expect(layer.children == [
+            .init(id: .init(namespace: .shape, replayID: leaf.replayID), type: .wireframe)
+        ])
         #expect(output.wireframes.count == 1)
     }
 
@@ -167,7 +169,7 @@ struct CompositionTreeBuilderTests {
             guard case .shapeWireframe(let shapeWireframe) = wireframe else {
                 return false
             }
-            return shapeWireframe.id == contentSnapshot.replayID
+            return shapeWireframe.id == Int64(namespace: .shape, replayID: contentSnapshot.replayID)
         })
         guard case .shapeWireframe(let shapeWireframe) = wireframe else {
             Issue.record("Expected a shape wireframe")

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerSnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerSnapshotProcessorTests.swift
@@ -152,8 +152,8 @@ struct LayerSnapshotProcessorTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    @Test("Diffing errors fall back to a full snapshot and update state")
-    func diffingErrorsFallBackToFullSnapshotAndUpdateState() throws {
+    @Test("Wireframe type changes use incremental mutations and update state")
+    func wireframeTypeChangesUseIncrementalMutationsAndUpdateState() throws {
         // Given
         let fixture = Fixture()
         let shapeSnapshot = LayerTreeSnapshot.mockWith(root: .mockRoot(sublayers: [
@@ -189,14 +189,29 @@ struct LayerSnapshotProcessorTests {
         )
 
         // Then
-        #expect(fixture.recordWriter.records.count == 2)
-        #expect(fixture.recordWriter.records[1].records.map(\.type) == [.fullSnapshot])
-        #expect(
-            fixture.telemetry.messages.firstError()?.message.hasPrefix(
-                "[SR] Failed to build layer recording mutation records"
-            ) == true
+        let shapeWireframeID = Int64(namespace: .shape, replayID: 2)
+        let placeholderWireframeID = Int64(namespace: .placeholder, replayID: 2)
+        let mutationRecord = try #require(
+            fixture.recordWriter.records[1].records[0].incrementalSnapshot?.mutationData
         )
-        #expect(fixture.core.recordsCountByViewID == ["view-id": 4])
+        let compositionTreeMutationRecord = try #require(
+            fixture.recordWriter.records[1].records[1]
+                .incrementalSnapshot?.compositionTreeMutationData
+        )
+
+        #expect(fixture.recordWriter.records.count == 2)
+        #expect(fixture.recordWriter.records[1].records.map(\.type) == [
+            .incrementalSnapshot,
+            .incrementalSnapshot
+        ])
+        #expect(mutationRecord.adds.map(\.wireframe.id) == [placeholderWireframeID])
+        #expect(mutationRecord.removes.map(\.id) == [shapeWireframeID])
+        #expect(mutationRecord.updates.isEmpty)
+        #expect(compositionTreeMutationRecord.root?.children == [
+            .init(id: placeholderWireframeID, type: .wireframe)
+        ])
+        #expect(fixture.telemetry.messages.firstError() == nil)
+        #expect(fixture.core.recordsCountByViewID == ["view-id": 5])
     }
 }
 

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerWireframeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerWireframeBuilderTests.swift
@@ -49,8 +49,7 @@ struct LayerWireframeBuilderTests {
             return
         }
 
-        #expect(output.id == snapshot.replayID)
-        #expect(wireframe.id == snapshot.replayID)
+        #expect(wireframe.id == Int64(namespace: .shape, replayID: snapshot.replayID))
         #expect(wireframe.shapeStyle?.backgroundColor == "#FF0000FF")
         #expect(wireframe.shapeStyle?.cornerRadius == 4)
         #expect(output.resource == nil)
@@ -319,7 +318,7 @@ struct LayerWireframeBuilderTests {
             return
         }
 
-        #expect(wireframe.id == snapshot.replayID)
+        #expect(wireframe.id == Int64(namespace: .placeholder, replayID: snapshot.replayID))
         #expect(wireframe.label == "Hidden")
     }
 
@@ -356,7 +355,7 @@ struct LayerWireframeBuilderTests {
             return
         }
 
-        #expect(output.id == Int64(slotID))
+        #expect(wireframe.id == Int64(slotID))
         #expect(wireframe.slotId == String(slotID))
         #expect(wireframe.isVisible == true)
         #expect(hiddenWireframes.count == 1)
@@ -400,7 +399,7 @@ struct LayerWireframeBuilderTests {
         }
 
         let resource = try #require(output.resource)
-        #expect(wireframe.id == snapshot.replayID)
+        #expect(wireframe.id == Int64(namespace: .image, replayID: snapshot.replayID))
         #expect(wireframe.resourceId == resource.calculateIdentifier())
         #expect(resource.calculateData().isEmpty == false)
     }


### PR DESCRIPTION
### What and why?

The layer-tree recorder currently uses a layer's replay ID as its wireframe ID. If the same layer starts producing a different wireframe type, such as changing from a shape to a private placeholder, the recorder cannot express that as an incremental update and falls back to a full snapshot.

This PR gives each wireframe type its own identifier namespace. A type change can then be sent as removing the old wireframe and adding the new one.

### How?

- Derive wireframe IDs from the wireframe type and the layer's replay ID.
- Keep composition layer IDs unchanged and update their children to reference the derived wireframe IDs.
- Keep WebView wireframes using their slot IDs.
- Centralize ID generation in type-specific wireframe initializers.
- Update tests to verify namespaced IDs and incremental type changes.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
