### PR TITLE
[PANA-8415] Support embedded content in layer tree recording

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRLayerSnapshotTests/Utils/LayerSnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRLayerSnapshotTests/Utils/LayerSnapshotTestCase.swift
@@ -231,6 +231,7 @@ internal class LayerSnapshotTestCase: XCTestCase {
         let output = CompositionTreeBuilder(
             root: layerTreeSnapshot.root,
             webViewSlotIDs: layerTreeSnapshot.webViewSlotIDs,
+            embeddedContentSlots: layerTreeSnapshot.embeddedContentSlots,
             imageSnapshots: imageSnapshots
         ).build()
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Context.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Context.swift
@@ -6,6 +6,7 @@
 
 #if os(iOS)
 import Foundation
+import UIKit
 import WebKit
 
 @preconcurrency import DatadogInternal
@@ -20,14 +21,19 @@ extension CALayerSnapshot {
         /// Weak references to web views found while capturing the layer tree.
         let webViewCache: NSHashTable<WKWebView>
 
+        /// Weak references to embedded content views found while capturing the layer tree.
+        let embeddedContentViewCache: NSHashTable<UIView>
+
         init(
             textAndInputPrivacyLevel: TextAndInputPrivacyLevel,
             imagePrivacyLevel: ImagePrivacyLevel,
-            webViewCache: NSHashTable<WKWebView> = .weakObjects()
+            webViewCache: NSHashTable<WKWebView> = .weakObjects(),
+            embeddedContentViewCache: NSHashTable<UIView> = .weakObjects()
         ) {
             self.textAndInputPrivacyLevel = textAndInputPrivacyLevel
             self.imagePrivacyLevel = imagePrivacyLevel
             self.webViewCache = webViewCache
+            self.embeddedContentViewCache = embeddedContentViewCache
         }
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -58,6 +58,7 @@ internal class CompositionTreeBuilder {
     init(
         root: CALayerSnapshot,
         webViewSlotIDs: Set<Int>,
+        embeddedContentSlots: [Int64: String],
         imageSnapshots: ImageSnapshotBatch
     ) {
         self.root = root
@@ -66,7 +67,8 @@ internal class CompositionTreeBuilder {
         )
         self.layerWireframeBuilder = LayerWireframeBuilder(
             contentSnapshots: imageSnapshots.contentSnapshots,
-            webViewSlotIDs: webViewSlotIDs
+            webViewSlotIDs: webViewSlotIDs,
+            embeddedContentSlots: embeddedContentSlots
         )
     }
 
@@ -78,12 +80,13 @@ internal class CompositionTreeBuilder {
 
         let rootLayer = makeCompositionLayer(from: root, context: Context())
         let hiddenWebViewWireframes = layerWireframeBuilder.makeHiddenWebViewWireframes()
+        let hiddenEmbeddedContentWireframes = layerWireframeBuilder.makeHiddenEmbeddedContentWireframes()
         let output = Output(
             compositionTree: SRCompositionTree(
                 layers: layers,
                 root: rootLayer
             ),
-            wireframes: hiddenWebViewWireframes + wireframes,
+            wireframes: hiddenWebViewWireframes + hiddenEmbeddedContentWireframes + wireframes,
             resources: resources
         )
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerSnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerSnapshotProcessor.swift
@@ -68,6 +68,7 @@ internal final class LayerSnapshotProcessor: LayerSnapshotProcessing {
         let output = CompositionTreeBuilder(
             root: layerTreeSnapshot.root,
             webViewSlotIDs: layerTreeSnapshot.webViewSlotIDs,
+            embeddedContentSlots: layerTreeSnapshot.embeddedContentSlots,
             imageSnapshots: imageSnapshots
         ).build()
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeSnapshotBuilder.swift
@@ -65,9 +65,10 @@ internal final class LayerTreeSnapshotBuilder: LayerTreeSnapshotBuilding {
             root: root,
             webViewSlotIDs: Set(webViewCache.allObjects.map(\.hash)),
             embeddedContentSlots: Dictionary(
-                uniqueKeysWithValues: embeddedContentViewCache
+                embeddedContentViewCache
                     .allObjects
-                    .compactMap(\.embeddedContentSlot)
+                    .compactMap(\.embeddedContentSlot),
+                uniquingKeysWith: { existing, _ in existing }
             )
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeSnapshotBuilder.swift
@@ -6,7 +6,11 @@
 
 #if os(iOS)
 import Foundation
+import UIKit
 import WebKit
+
+@_spi(Internal)
+import DatadogInternal
 
 /// Snapshot of a layer tree and the recording context used to capture it.
 @available(iOS 13.0, tvOS 13.0, *)
@@ -16,6 +20,7 @@ internal struct LayerTreeSnapshot: Sendable {
     let viewportSize: CGSize
     var root: CALayerSnapshot
     let webViewSlotIDs: Set<Int>
+    let embeddedContentSlots: [Int64: String]
 }
 
 /// Creates layer tree snapshots on the main actor.
@@ -31,6 +36,7 @@ internal protocol LayerTreeSnapshotBuilding: AnyObject {
 internal final class LayerTreeSnapshotBuilder: LayerTreeSnapshotBuilding {
     private let layerProvider: any LayerProvider
     private let webViewCache: NSHashTable<WKWebView> = .weakObjects()
+    private let embeddedContentViewCache: NSHashTable<UIView> = .weakObjects()
 
     init(layerProvider: any LayerProvider) {
         self.layerProvider = layerProvider
@@ -44,7 +50,8 @@ internal final class LayerTreeSnapshotBuilder: LayerTreeSnapshotBuilding {
         let snapshotContext = CALayerSnapshot.Context(
             textAndInputPrivacyLevel: context.textAndInputPrivacy,
             imagePrivacyLevel: context.imagePrivacy,
-            webViewCache: webViewCache
+            webViewCache: webViewCache,
+            embeddedContentViewCache: embeddedContentViewCache
         )
 
         guard let root = CALayerSnapshot(from: rootLayer, in: snapshotContext) else {
@@ -56,8 +63,22 @@ internal final class LayerTreeSnapshotBuilder: LayerTreeSnapshotBuilding {
             context: context,
             viewportSize: rootLayer.bounds.size,
             root: root,
-            webViewSlotIDs: Set(webViewCache.allObjects.map(\.hash))
+            webViewSlotIDs: Set(webViewCache.allObjects.map(\.hash)),
+            embeddedContentSlots: Dictionary(
+                uniqueKeysWithValues: embeddedContentViewCache
+                    .allObjects
+                    .compactMap(\.embeddedContentSlot)
+            )
         )
+    }
+}
+
+extension UIView {
+    @available(iOS 13.0, tvOS 13.0, *)
+    fileprivate var embeddedContentSlot: (Int64, String)? {
+        self.dd.sessionReplaySlotID.map {
+            (self.layer.replayID, $0)
+        }
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerWireframeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerWireframeBuilder.swift
@@ -103,7 +103,6 @@ internal struct LayerWireframeBuilder {
         case (.embeddedContent(let embeddedContent), _):
             pendingEmbeddedContentSlots.removeValue(forKey: snapshot.replayID)
             return Output(
-                id: snapshot.replayID,
                 wireframe: SRWireframe(layerSnapshot: snapshot, embeddedContent: embeddedContent),
                 resource: nil
             )
@@ -153,7 +152,7 @@ internal struct LayerWireframeBuilder {
 
     mutating func makeHiddenEmbeddedContentWireframes() -> [SRWireframe] {
         let wireframes = pendingEmbeddedContentSlots.map {
-            SRWireframe(hiddenEmbeddedContentWireframeID: $0.key, slotID: $0.value)
+            SRWireframe(hiddenEmbeddedContentReplayID: $0.key, slotID: $0.value)
         }
         pendingEmbeddedContentSlots.removeAll()
         return wireframes

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerWireframeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerWireframeBuilder.swift
@@ -21,18 +21,24 @@ internal struct LayerWireframeBuilder {
     private let contentSnapshots: [Int64: ContentSnapshotResult]
     private let webViewSlotIDs: Set<Int>
     private var pendingWebViewSlotIDs: Set<Int>
+    private let embeddedContentSlots: [Int64: String]
+    private var pendingEmbeddedContentSlots: [Int64: String]
 
     init(
         contentSnapshots: [Int64: ContentSnapshotResult],
-        webViewSlotIDs: Set<Int>
+        webViewSlotIDs: Set<Int>,
+        embeddedContentSlots: [Int64: String] = [:]
     ) {
         self.contentSnapshots = contentSnapshots
         self.webViewSlotIDs = webViewSlotIDs
         self.pendingWebViewSlotIDs = webViewSlotIDs
+        self.embeddedContentSlots = embeddedContentSlots
+        self.pendingEmbeddedContentSlots = embeddedContentSlots
     }
 
     mutating func reset() {
         pendingWebViewSlotIDs = webViewSlotIDs
+        pendingEmbeddedContentSlots = embeddedContentSlots
     }
 
     mutating func build(
@@ -94,6 +100,13 @@ internal struct LayerWireframeBuilder {
                 wireframe: SRWireframe(layerSnapshot: snapshot, webView: webView),
                 resource: nil
             )
+        case (.embeddedContent(let embeddedContent), _):
+            pendingEmbeddedContentSlots.removeValue(forKey: snapshot.replayID)
+            return Output(
+                id: snapshot.replayID,
+                wireframe: SRWireframe(layerSnapshot: snapshot, embeddedContent: embeddedContent),
+                resource: nil
+            )
         case (.visualEffect(.automaticCapsule), _):
             return Output(
                 wireframe: SRWireframe(
@@ -135,6 +148,14 @@ internal struct LayerWireframeBuilder {
     mutating func makeHiddenWebViewWireframes() -> [SRWireframe] {
         let wireframes = pendingWebViewSlotIDs.map(SRWireframe.init(hiddenWebViewSlotID:))
         pendingWebViewSlotIDs.removeAll()
+        return wireframes
+    }
+
+    mutating func makeHiddenEmbeddedContentWireframes() -> [SRWireframe] {
+        let wireframes = pendingEmbeddedContentSlots.map {
+            SRWireframe(hiddenEmbeddedContentWireframeID: $0.key, slotID: $0.value)
+        }
+        pendingEmbeddedContentSlots.removeAll()
         return wireframes
     }
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
@@ -11,16 +11,16 @@ import UIKit
 
 extension SRWireframe {
     @available(iOS 13.0, tvOS 13.0, *)
-    init(hiddenEmbeddedContentWireframeID id: Int64, slotID: String) {
+    init(hiddenEmbeddedContentReplayID replayID: Int64, slotID: String) {
         self = .embeddedContentWireframe(
             value: .init(
-                height: 0,
-                id: id,
-                isVisible: false,
+                replayID: replayID,
                 slotId: slotID,
-                width: 0,
                 x: 0,
-                y: 0
+                y: 0,
+                width: 0,
+                height: 0,
+                isVisible: false
             )
         )
     }
@@ -163,15 +163,15 @@ extension SRWireframe {
     ) {
         self = .embeddedContentWireframe(
             value: .init(
-                border: .init(layerSnapshot: layerSnapshot),
-                height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
-                id: layerSnapshot.replayID,
-                isVisible: true,
-                shapeStyle: .init(layerSnapshot: layerSnapshot),
+                replayID: layerSnapshot.replayID,
                 slotId: embeddedContent.slotID,
-                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
                 x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
-                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY),
+                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
+                height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
+                border: .init(layerSnapshot: layerSnapshot),
+                isVisible: true,
+                shapeStyle: .init(layerSnapshot: layerSnapshot)
             )
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
@@ -11,6 +11,21 @@ import UIKit
 
 extension SRWireframe {
     @available(iOS 13.0, tvOS 13.0, *)
+    init(hiddenEmbeddedContentWireframeID id: Int64, slotID: String) {
+        self = .embeddedContentWireframe(
+            value: .init(
+                height: 0,
+                id: id,
+                isVisible: false,
+                slotId: slotID,
+                width: 0,
+                x: 0,
+                y: 0
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     init(hiddenWebViewSlotID slotID: Int) {
         self = .webviewWireframe(
             value: .init(
@@ -137,6 +152,26 @@ extension SRWireframe {
                 width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
                 height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
                 label: label
+            )
+        )
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    init(
+        layerSnapshot: CALayerSnapshot,
+        embeddedContent: CALayerSnapshot.SemanticObservation.EmbeddedContentSemantics
+    ) {
+        self = .embeddedContentWireframe(
+            value: .init(
+                border: .init(layerSnapshot: layerSnapshot),
+                height: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.height),
+                id: layerSnapshot.replayID,
+                isVisible: true,
+                shapeStyle: .init(layerSnapshot: layerSnapshot),
+                slotId: embeddedContent.slotID,
+                width: Int64.ddWithNoOverflow(dimension: layerSnapshot.absoluteFrame.width),
+                x: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minX),
+                y: Int64.ddWithNoOverflow(layerSnapshot.absoluteFrame.minY)
             )
         )
     }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservation.swift
@@ -56,6 +56,7 @@ extension CALayerSnapshot.SemanticObservation {
         case label(LabelSemantics)
         case image(ImageSemantics)
         case textInput(TextInputSemantics)
+        case embeddedContent(EmbeddedContentSemantics)
         case webView(WebViewSemantics)
     }
 }
@@ -168,6 +169,19 @@ extension CALayerSnapshot.SemanticObservation {
             self.isSensitiveText = isSensitiveText
             self.isEditable = isEditable
             self.isEmpty = isEmpty
+        }
+    }
+}
+
+// MARK: - EmbeddedContentSemantics
+
+@available(iOS 13.0, tvOS 13.0, *)
+extension CALayerSnapshot.SemanticObservation {
+    struct EmbeddedContentSemantics: Sendable, Equatable {
+        let slotID: String
+
+        init(slotID: String) {
+            self.slotID = slotID
         }
     }
 }

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping+Common.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping+Common.swift
@@ -10,8 +10,27 @@ import QuartzCore
 import UIKit
 import WebKit
 
+@_spi(Internal)
+import DatadogInternal
+
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservationMapping {
+    static let embeddedContent = Self { layer, _, context in
+        guard
+            let view = layer.delegate as? UIView,
+            let slotID = view.dd.sessionReplaySlotID
+        else {
+            return nil
+        }
+
+        context.embeddedContentViewCache.add(view)
+
+        return .init(
+            semantics: .embeddedContent(.init(slotID: slotID)),
+            ignoresSublayers: true
+        )
+    }
+
     static let gradient = Self { layer, _, _ in
         guard let gradientLayer = layer as? CAGradientLayer else {
             return nil

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping.swift
@@ -22,6 +22,7 @@ extension CALayerSnapshot {
 @available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservationMapping: CaseIterable {
     static let allCases: [Self] = [
+        .embeddedContent,
         .gradient,
         .activityIndicator,
         .label,

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotContextMock.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotContextMock.swift
@@ -6,6 +6,7 @@
 
 #if os(iOS)
 import DatadogInternal
+import UIKit
 import WebKit
 
 @testable import DatadogSessionReplay
@@ -15,12 +16,14 @@ extension CALayerSnapshot.Context {
     static func mockAny(
         textAndInputPrivacyLevel: TextAndInputPrivacyLevel = .maskAll,
         imagePrivacyLevel: ImagePrivacyLevel = .maskAll,
-        webViewCache: NSHashTable<WKWebView> = .weakObjects()
+        webViewCache: NSHashTable<WKWebView> = .weakObjects(),
+        embeddedContentViewCache: NSHashTable<UIView> = .weakObjects()
     ) -> Self {
         .init(
             textAndInputPrivacyLevel: textAndInputPrivacyLevel,
             imagePrivacyLevel: imagePrivacyLevel,
-            webViewCache: webViewCache
+            webViewCache: webViewCache,
+            embeddedContentViewCache: embeddedContentViewCache
         )
     }
 }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -45,6 +45,7 @@ struct CompositionTreeBuilderTests {
         let builder = CompositionTreeBuilder(
             root: root,
             webViewSlotIDs: [],
+            embeddedContentSlots: [:],
             imageSnapshots: .init()
         )
 
@@ -86,6 +87,7 @@ struct CompositionTreeBuilderTests {
         let builder = CompositionTreeBuilder(
             root: root,
             webViewSlotIDs: [],
+            embeddedContentSlots: [:],
             imageSnapshots: .init()
         )
 
@@ -120,6 +122,7 @@ struct CompositionTreeBuilderTests {
         let builder = CompositionTreeBuilder(
             root: root,
             webViewSlotIDs: [],
+            embeddedContentSlots: [:],
             imageSnapshots: .init()
         )
 
@@ -158,6 +161,7 @@ struct CompositionTreeBuilderTests {
         let builder = CompositionTreeBuilder(
             root: root,
             webViewSlotIDs: [],
+            embeddedContentSlots: [:],
             imageSnapshots: .init()
         )
 
@@ -180,6 +184,50 @@ struct CompositionTreeBuilderTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build includes embedded content visibility state")
+    func buildIncludesEmbeddedContentVisibilityState() throws {
+        // Given
+        let visibleReplayID: Int64 = 2
+        let hiddenReplayID: Int64 = 3
+        let visibleSnapshot = CALayerSnapshot.mockWith(
+            replayID: visibleReplayID,
+            absoluteFrame: CGRect(x: 10, y: 20, width: 30, height: 40),
+            observation: .init(semantics: .embeddedContent(.init(slotID: "visible-slot")))
+        )
+        let builder = CompositionTreeBuilder(
+            root: .mockRoot(sublayers: [visibleSnapshot]),
+            webViewSlotIDs: [],
+            embeddedContentSlots: [
+                visibleReplayID: "visible-slot",
+                hiddenReplayID: "hidden-slot"
+            ],
+            imageSnapshots: .init()
+        )
+
+        // When
+        let output = builder.build()
+
+        // Then
+        #expect(output.compositionTree.root.children == [.init(id: visibleReplayID, type: .wireframe)])
+        try #require(output.wireframes.count == 2)
+
+        guard
+            case .embeddedContentWireframe(let hiddenWireframe) = output.wireframes[0],
+            case .embeddedContentWireframe(let visibleWireframe) = output.wireframes[1]
+        else {
+            Issue.record("Expected embedded content wireframes")
+            return
+        }
+
+        #expect(hiddenWireframe.id == hiddenReplayID)
+        #expect(hiddenWireframe.slotId == "hidden-slot")
+        #expect(hiddenWireframe.isVisible == false)
+        #expect(visibleWireframe.id == visibleReplayID)
+        #expect(visibleWireframe.slotId == "visible-slot")
+        #expect(visibleWireframe.isVisible == true)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build can be reused without accumulating output state")
     func buildCanBeReusedWithoutAccumulatingOutputState() throws {
         // Given
@@ -195,6 +243,7 @@ struct CompositionTreeBuilderTests {
         let builder = CompositionTreeBuilder(
             root: root,
             webViewSlotIDs: [slotID, hiddenSlotID],
+            embeddedContentSlots: [:],
             imageSnapshots: .init()
         )
 

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -208,7 +208,11 @@ struct CompositionTreeBuilderTests {
         let output = builder.build()
 
         // Then
-        #expect(output.compositionTree.root.children == [.init(id: visibleReplayID, type: .wireframe)])
+        let visibleWireframeID = Int64(namespace: .embeddedContent, replayID: visibleReplayID)
+        let hiddenWireframeID = Int64(namespace: .embeddedContent, replayID: hiddenReplayID)
+        #expect(output.compositionTree.root.children == [
+            .init(id: visibleWireframeID, type: .wireframe)
+        ])
         try #require(output.wireframes.count == 2)
 
         guard
@@ -219,10 +223,10 @@ struct CompositionTreeBuilderTests {
             return
         }
 
-        #expect(hiddenWireframe.id == hiddenReplayID)
+        #expect(hiddenWireframe.id == hiddenWireframeID)
         #expect(hiddenWireframe.slotId == "hidden-slot")
         #expect(hiddenWireframe.isVisible == false)
-        #expect(visibleWireframe.id == visibleReplayID)
+        #expect(visibleWireframe.id == visibleWireframeID)
         #expect(visibleWireframe.slotId == "visible-slot")
         #expect(visibleWireframe.isVisible == true)
     }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
@@ -5,6 +5,7 @@
  */
 
 #if os(iOS)
+@_spi(Internal)
 import DatadogInternal
 import QuartzCore
 import TestUtilities
@@ -150,6 +151,41 @@ struct LayerTreeSnapshotBuilderTests {
         // Then
         #expect(snapshot.root.sublayers.isEmpty)
         #expect(snapshot.webViewSlotIDs == expectedSlots)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Captures embedded content as a leaf and keeps its slot while detached")
+    func capturesEmbeddedContentAsLeafAndKeepsItsSlotWhileDetached() throws {
+        // Given
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+        let embeddedContentView = UILabel(frame: CGRect(x: 10, y: 20, width: 100, height: 80))
+        embeddedContentView.text = "Native label"
+        embeddedContentView.dd.sessionReplaySlotID = "embedded-slot"
+        embeddedContentView.addSubview(UIView(frame: embeddedContentView.bounds))
+        rootView.addSubview(embeddedContentView)
+
+        let builder = LayerTreeSnapshotBuilder(
+            layerProvider: TestLayerProvider(rootLayer: rootView.layer)
+        )
+
+        // When
+        let initialSnapshot = try #require(builder.takeSnapshot(context: Fixtures.context()))
+        embeddedContentView.removeFromSuperview()
+        let detachedSnapshot = try #require(builder.takeSnapshot(context: Fixtures.context()))
+
+        // Then
+        let embeddedContentSnapshot = try #require(initialSnapshot.root.sublayers.first)
+        #expect(
+            embeddedContentSnapshot.observation == .init(
+                semantics: .embeddedContent(.init(slotID: "embedded-slot")),
+                ignoresSublayers: true
+            )
+        )
+        #expect(embeddedContentSnapshot.sublayers.isEmpty)
+        #expect(initialSnapshot.embeddedContentSlots == [embeddedContentView.layer.replayID: "embedded-slot"])
+        #expect(detachedSnapshot.root.sublayers.isEmpty)
+        #expect(detachedSnapshot.embeddedContentSlots == initialSnapshot.embeddedContentSlots)
+        withExtendedLifetime(embeddedContentView) {}
     }
 }
 #endif

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotMocks.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotMocks.swift
@@ -22,7 +22,8 @@ extension LayerTreeSnapshot {
         viewID: String = "view-id",
         viewportSize: CGSize = CGSize(width: 320, height: 640),
         root: CALayerSnapshot = .mockRoot(),
-        webViewSlotIDs: Set<Int> = []
+        webViewSlotIDs: Set<Int> = [],
+        embeddedContentSlots: [Int64: String] = [:]
     ) -> LayerTreeSnapshot {
         return LayerTreeSnapshot(
             date: date,
@@ -40,7 +41,8 @@ extension LayerTreeSnapshot {
             ),
             viewportSize: viewportSize,
             root: root,
-            webViewSlotIDs: webViewSlotIDs
+            webViewSlotIDs: webViewSlotIDs,
+            embeddedContentSlots: embeddedContentSlots
         )
     }
 }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerWireframeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerWireframeBuilderTests.swift
@@ -350,7 +350,7 @@ struct LayerWireframeBuilderTests {
             return
         }
         #expect(hiddenEmbeddedContentWireframes.count == 1)
-        #expect(hiddenWireframe.id == snapshot.replayID)
+        #expect(hiddenWireframe.id == Int64(namespace: .embeddedContent, replayID: snapshot.replayID))
         #expect(hiddenWireframe.slotId == "embedded-slot")
         #expect(hiddenWireframe.isVisible == false)
     }
@@ -434,12 +434,11 @@ struct LayerWireframeBuilderTests {
             return
         }
 
-        #expect(output.id == replayID)
-        #expect(wireframe.id == replayID)
+        #expect(wireframe.id == Int64(namespace: .embeddedContent, replayID: replayID))
         #expect(wireframe.slotId == slotID)
         #expect(wireframe.isVisible == true)
         #expect(hiddenWireframes.count == 1)
-        #expect(hiddenWireframe.id == hiddenReplayID)
+        #expect(hiddenWireframe.id == Int64(namespace: .embeddedContent, replayID: hiddenReplayID))
         #expect(hiddenWireframe.slotId == hiddenSlotID)
         #expect(hiddenWireframe.isVisible == false)
     }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerWireframeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerWireframeBuilderTests.swift
@@ -323,6 +323,39 @@ struct LayerWireframeBuilderTests {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build hides embedded content for a private layer")
+    func buildHidesEmbeddedContentForPrivateLayer() throws {
+        // Given
+        let snapshot = CALayerSnapshot.mockWith(
+            replayID: 2,
+            isPrivate: true
+        )
+        var builder = LayerWireframeBuilder(
+            contentSnapshots: [:],
+            webViewSlotIDs: [],
+            embeddedContentSlots: [snapshot.replayID: "embedded-slot"]
+        )
+
+        // When
+        _ = builder.build(
+            from: snapshot,
+            textInput: nil,
+            cornerRadius: nil
+        )
+        let hiddenEmbeddedContentWireframes = builder.makeHiddenEmbeddedContentWireframes()
+
+        // Then
+        guard case .embeddedContentWireframe(let hiddenWireframe) = try #require(hiddenEmbeddedContentWireframes.first) else {
+            Issue.record("Expected a hidden embedded content wireframe")
+            return
+        }
+        #expect(hiddenEmbeddedContentWireframes.count == 1)
+        #expect(hiddenWireframe.id == snapshot.replayID)
+        #expect(hiddenWireframe.slotId == "embedded-slot")
+        #expect(hiddenWireframe.isVisible == false)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build tracks visible and hidden webviews")
     func buildTracksVisibleAndHiddenWebViews() throws {
         // Given
@@ -360,6 +393,54 @@ struct LayerWireframeBuilderTests {
         #expect(wireframe.isVisible == true)
         #expect(hiddenWireframes.count == 1)
         #expect(hiddenWireframe.slotId == String(hiddenSlotID))
+        #expect(hiddenWireframe.isVisible == false)
+    }
+
+    @available(iOS 13.0, tvOS 13.0, *)
+    @Test("Build emits embedded content visibility state")
+    func buildEmitsEmbeddedContentVisibilityState() throws {
+        // Given
+        let replayID: Int64 = 42
+        let hiddenReplayID: Int64 = 43
+        let slotID = "visible-slot"
+        let hiddenSlotID = "hidden-slot"
+        let snapshot = CALayerSnapshot.mockWith(
+            replayID: replayID,
+            absoluteFrame: CGRect(x: 10, y: 20, width: 60, height: 40),
+            observation: .init(semantics: .embeddedContent(.init(slotID: slotID)))
+        )
+        var builder = LayerWireframeBuilder(
+            contentSnapshots: [:],
+            webViewSlotIDs: [],
+            embeddedContentSlots: [
+                replayID: slotID,
+                hiddenReplayID: hiddenSlotID
+            ]
+        )
+
+        // When
+        let result = builder.build(
+            from: snapshot,
+            textInput: nil,
+            cornerRadius: nil
+        )
+        let output = try #require(result)
+        let hiddenWireframes = builder.makeHiddenEmbeddedContentWireframes()
+
+        // Then
+        guard case .embeddedContentWireframe(let wireframe) = output.wireframe,
+              case .embeddedContentWireframe(let hiddenWireframe) = try #require(hiddenWireframes.first) else {
+            Issue.record("Expected embedded content wireframes")
+            return
+        }
+
+        #expect(output.id == replayID)
+        #expect(wireframe.id == replayID)
+        #expect(wireframe.slotId == slotID)
+        #expect(wireframe.isVisible == true)
+        #expect(hiddenWireframes.count == 1)
+        #expect(hiddenWireframe.id == hiddenReplayID)
+        #expect(hiddenWireframe.slotId == hiddenSlotID)
         #expect(hiddenWireframe.isVisible == false)
     }
 


### PR DESCRIPTION
### What and why?

This PR adds generic embedded-content support to the layer-tree recording pipeline. When a cross-platform SDK renders inside a marked native view, the iOS SDK now emits the container wireframe needed to position that content in the replay.

Depends on:
- #3109

### How?

- Detect views with a Session Replay slot ID and record their layers as embedded-content leaves.
- Keep weak references to embedded views so detached views can emit hidden wireframes.
- Carry replay ID and slot ID information through the layer snapshot pipeline.
- Emit visible and hidden embedded-content wireframes with namespaced IDs.
- Reference the generated wireframe IDs from the composition tree.
- Preserve privacy behavior by emitting the native placeholder while hiding the embedded slot.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
