### PR TITLE
[RUM-17847] Add remote configuration telemetry

### DIFF
--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -133,16 +133,12 @@ internal final class DatadogCore {
             self?.send(message: .context(context))
         }
 
-        self.remoteConfigurationProvider?.start { [weak self] result in
-            switch result {
-            case let .success(remoteConfiguration):
+        self.remoteConfigurationProvider?.start(
+            { [weak self] remoteConfiguration in
                 self?.remoteConfiguration = remoteConfiguration
-            case let .failure(.etagError(error)):
-                self?.telemetry.error("[RemoteConfig] ETag caching failed", error: error)
-            case let .failure(error):
-                self?.telemetry.error("[RemoteConfig] Sync failed", error: error)
-            }
-        }
+            },
+            telemetry: telemetry
+        )
     }
 
     /// Sets current user information.

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -7,27 +7,39 @@
 import Foundation
 import DatadogInternal
 
-/// CDN response metadata for a remote configuration fetch, used to correlate
-/// configuration propagation telemetry with the CDN version that produced it.
-internal struct RemoteConfigurationMetadata: Codable, Equatable {
+/// On-disk representation of a cached remote configuration.
+///
+/// The HTTP ETag, the propagation metadata, and the configuration payload itself are kept
+/// together and written in a single atomic file, so metadata can never point at a
+/// configuration version that was not durably cached (and vice versa).
+internal struct RemoteConfigurationCache: Codable {
+    /// Propagation metadata for a cached remote configuration, used to correlate configuration
+    /// propagation telemetry with the CDN version that produced it.
+    struct Metadata: Codable, Equatable {
+        /// Value of the `x-amz-version-id` response header.
+        let versionId: String?
+        /// Parsed value of the `last-modified` response header.
+        let lastModified: Date?
+        /// Date this configuration was fetched and persisted.
+        let lastSynced: Date?
+        /// Identifier of the sync that produced this configuration version, generated the same
+        /// way as the request IDs used for event uploads. Reused by every session running on
+        /// this version, until the next genuine (non-304) sync.
+        let syncId: String?
+        /// Date this configuration version was first observed as applied. Stamped once and
+        /// reused on every subsequent session that runs on the same version.
+        let firstApplied: Date?
+    }
+
     /// Value of the `etag` response header, sent back as `If-None-Match`.
     let etag: String?
-    /// Value of the `x-amz-version-id` response header.
-    let versionId: String?
-    /// Parsed value of the `last-modified` response header.
-    let lastModified: Date?
-    /// Date this configuration was fetched and persisted.
-    let lastSynced: Date?
-    /// Identifier of the sync that produced this configuration version, generated the same way
-    /// as the request IDs used for event uploads. Reused by every session running on this
-    /// version, until the next genuine (non-304) sync.
-    let syncId: String?
-    /// Date this configuration version was first observed as applied. Stamped once and reused
-    /// on every subsequent session that runs on the same version.
-    let firstApplied: Date?
+    /// Propagation metadata for `configuration`, if it was successfully cached.
+    let metadata: Metadata?
+    /// The last successfully decoded and cached configuration payload.
+    let configuration: RemoteConfiguration?
 }
 
-extension RemoteConfigurationMetadata {
+extension RemoteConfigurationCache.Metadata {
     /// Formats and parses the `last-modified` response header (RFC 7231 IMF-fixdate,
     /// e.g. `Wed, 21 Oct 2015 07:28:00 GMT`).
     static let httpDateFormatter: DateFormatter = {
@@ -47,11 +59,11 @@ extension RemoteConfigurationMetadata {
 /// converge on the latest configuration without requiring a restart.
 ///
 /// ## Caching
-/// A successful fetch is persisted as `<id>.json` inside the supplied `directory`.
-/// The accompanying HTTP ETag, and the `x-amz-version-id` / `last-modified` headers
-/// used for propagation telemetry, are stored in `<id>.metadata.json`. The ETag is sent
-/// back as `If-None-Match` on subsequent requests, turning unchanged responses into
-/// lightweight 304s that skip body transfer and re-parse entirely.
+/// A successful fetch is persisted as `<id>.json` inside the supplied `directory`, as a single
+/// `RemoteConfigurationCache` document combining the HTTP ETag, the propagation metadata used
+/// for configuration telemetry, and the configuration payload. The ETag is sent back as
+/// `If-None-Match` on subsequent requests, turning unchanged responses into lightweight 304s
+/// that skip body transfer and re-parse entirely.
 ///
 /// ## Threading
 /// - The synchronous cache read in `start` runs on the caller's thread.
@@ -109,11 +121,13 @@ internal final class RemoteConfigurationProvider {
     ///     `telemetry` instead.
     ///   - telemetry: Reports the propagation of the configuration version delivered from
     ///     cache (if any) on the once-per-session configuration telemetry, synchronously
-    ///     from the cache read below. Configuration telemetry buffers sends made before a
-    ///     receiver is registered for the session, so reporting this early is safe. A
-    ///     genuinely new fetch (non-304) only updates the persisted metadata; it does not
-    ///     report telemetry on its own, since the fetched version does not take effect
-    ///     until the next application launch. Read and fetch errors are also reported here.
+    ///     from the cache read below. `MessageBus` accumulates configuration telemetry and
+    ///     flushes it once, 5 seconds after core initialization, to whichever receivers are
+    ///     connected by then — reporting this early is safe as long as the consuming feature
+    ///     (e.g. RUM) is enabled within that window, but telemetry sent before a receiver
+    ///     connects is dropped if that window has already passed. A genuinely new fetch
+    ///     (non-304) is only reported on a later launch's cache read, once it has been
+    ///     applied. Read and fetch errors are also reported here.
     func start(
         _ handler: @escaping (RemoteConfiguration) -> Void,
         telemetry: Telemetry = NOPTelemetry()
@@ -176,9 +190,15 @@ internal final class RemoteConfigurationProvider {
 
         do {
             let data = try directory.file(named: cacheFilename).read()
-            let remoteConfiguration = try JSONDecoder().decode(RemoteConfiguration.self, from: data)
-            reportMetadata(to: telemetry)
-            return remoteConfiguration
+            let cache = try JSONDecoder().decode(RemoteConfigurationCache.self, from: data)
+
+            guard let configuration = cache.configuration else {
+                return nil
+            }
+
+            report(cache: cache, to: telemetry)
+
+            return configuration
         } catch {
             telemetry.error("[RemoteConfig] Failed to read cached remote configuration", error: error)
             return nil
@@ -192,7 +212,6 @@ internal final class RemoteConfigurationProvider {
     ) {
         let decoder = JSONDecoder()
         let cacheFilename = "\(id).json"
-        let metadataFilename = "\(id).metadata.json"
 
         // Build request with conditional ETag header if a previous ETag is stored.
         var request = URLRequest(
@@ -202,10 +221,11 @@ internal final class RemoteConfigurationProvider {
                 .appendingPathExtension("json")
         )
 
-        if let file = try? directory.file(named: metadataFilename) {
+        var cache: RemoteConfigurationCache?
+        if let file = try? directory.file(named: cacheFilename) {
             do {
-                let metadata = try decoder.decode(RemoteConfigurationMetadata.self, from: file.read())
-                metadata.etag.map { request.setValue($0, forHTTPHeaderField: "If-None-Match") }
+                cache = try decoder.decode(RemoteConfigurationCache.self, from: file.read())
+                cache?.etag.map { request.setValue($0, forHTTPHeaderField: "If-None-Match") }
             } catch {
                 telemetry.error("[RemoteConfig] Failed to read cached metadata etag", error: error)
             }
@@ -228,21 +248,30 @@ internal final class RemoteConfigurationProvider {
                     throw RemoteConfigurationError.httpError(http.statusCode)
                 }
 
-                // Persist metadata before decoding — it belongs to the HTTP response,
-                // not to whether we could parse the body. This prevents re-fetching a
-                // known-bad payload on every sync; we recover when the server updates.
-                self.saveMetadata(from: http, telemetry: telemetry)
-
                 guard let data, !data.isEmpty else {
+                    // Still update the ETag so a known-bad payload is not re-fetched on every
+                    // sync; we recover once the server publishes an update. Previously cached
+                    // configuration and metadata are left untouched.
+                    self.updateETag(from: http, previous: cache, telemetry: telemetry)
                     throw RemoteConfigurationError.emptyBody
                 }
 
-                let remoteConfiguration = try decoder.decode(RemoteConfiguration.self, from: data)
+                let remoteConfiguration: RemoteConfiguration
+                do {
+                    remoteConfiguration = try decoder.decode(RemoteConfiguration.self, from: data)
+                } catch {
+                    self.updateETag(from: http, previous: cache, telemetry: telemetry)
+                    throw error
+                }
 
-                // All checks passed — persist to disk.
-                // File.write uses .atomic (write to temp, then rename), so the update is
-                // all-or-nothing: the existing file is never left in a truncated state.
-                try self.write(data, to: cacheFilename)
+                // All checks passed — persist configuration, metadata, and etag together in a
+                // single atomic write (File.write uses .atomic: write to temp, then rename), so
+                // a later `readCache()` never reports a version that was never actually written
+                // to disk. If the write fails, the configuration is not durably cached, so it is
+                // not delivered to `handler` either — the outer catch reports the failure and a
+                // later sync will retry.
+                try self.saveCache(remoteConfiguration, from: http)
+
                 self.lastSyncDate = self.dateProvider.now
 
                 handler(remoteConfiguration)
@@ -256,70 +285,94 @@ internal final class RemoteConfigurationProvider {
     /// configuration telemetry. Stamps `firstApplied` the first time this version is
     /// observed as applied, and persists it back to disk so every later session running
     /// on the same version reports the same value.
-    private func reportMetadata(to telemetry: Telemetry) {
-        guard let file = try? directory.file(named: "\(id).metadata.json") else {
+    private func report(cache: RemoteConfigurationCache, to telemetry: Telemetry) {
+        guard var metadata = cache.metadata else {
             return
         }
 
-        do {
-            var metadata = try JSONDecoder().decode(RemoteConfigurationMetadata.self, from: file.read())
-
-            if metadata.firstApplied == nil {
-                metadata = RemoteConfigurationMetadata(
-                    etag: metadata.etag,
-                    versionId: metadata.versionId,
-                    lastModified: metadata.lastModified,
-                    lastSynced: metadata.lastSynced,
-                    syncId: metadata.syncId,
-                    firstApplied: dateProvider.now
-                )
-                try write(metadata: metadata)
-            }
-
-            telemetry.configuration(
-                remoteConfiguration: .init(
-                    configId: id,
-                    versionId: metadata.versionId,
-                    lastModified: metadata.lastModified,
-                    lastSynced: metadata.lastSynced,
-                    firstApplied: metadata.firstApplied,
-                    syncId: metadata.syncId
-                )
+        if metadata.firstApplied == nil {
+            metadata = RemoteConfigurationCache.Metadata(
+                versionId: metadata.versionId,
+                lastModified: metadata.lastModified,
+                lastSynced: metadata.lastSynced,
+                syncId: metadata.syncId,
+                firstApplied: dateProvider.now
             )
-        } catch {
-            telemetry.error("[RemoteConfig] Failed to report applied remote configuration", error: error)
+            do {
+                try write(
+                    cache: RemoteConfigurationCache(etag: cache.etag, metadata: metadata, configuration: cache.configuration)
+                )
+            } catch {
+                telemetry.error("[RemoteConfig] Failed to save remote configuration metadata", error: error)
+            }
         }
+
+        telemetry.configuration(
+            remoteConfiguration: .init(
+                configId: id,
+                versionId: metadata.versionId,
+                lastModified: metadata.lastModified,
+                lastSynced: metadata.lastSynced,
+                firstApplied: metadata.firstApplied,
+                syncId: metadata.syncId
+            )
+        )
     }
 
-    /// Builds and persists metadata from a genuine (non-304) fetch's HTTP response.
-    /// `syncId` and `lastSynced` mark this as a genuine sync, distinct from a 304.
-    /// `firstApplied` is left unset: this version has not been applied yet, since a
-    /// fetch that completes mid-session does not retroactively re-apply already
-    /// initialized features.
-    private func saveMetadata(from response: HTTPURLResponse, telemetry: Telemetry) {
+    /// Builds and persists the cache from a genuine (non-304) fetch's HTTP response, once the
+    /// fetched configuration has been successfully decoded. `syncId` and `lastSynced` mark this
+    /// as a genuine sync, distinct from a 304. `firstApplied` is left unset: this version has
+    /// not been applied yet, since a fetch that completes mid-session does not retroactively
+    /// re-apply already initialized features.
+    ///
+    /// Throws if the write fails, so the caller can treat an undelivered, uncached configuration
+    /// as a failed sync rather than deliver a configuration that was never durably persisted.
+    private func saveCache(_ configuration: RemoteConfiguration, from response: HTTPURLResponse) throws {
         let etag = response.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "etag" })?.value as? String
         let versionId = response.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "x-amz-version-id" })?.value as? String
         let lastModifiedHeader = response.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "last-modified" })?.value as? String
 
-        let metadata = RemoteConfigurationMetadata(
+        let cache = RemoteConfigurationCache(
             etag: etag,
-            versionId: versionId,
-            lastModified: lastModifiedHeader.flatMap { RemoteConfigurationMetadata.httpDateFormatter.date(from: $0) },
-            lastSynced: dateProvider.now,
-            syncId: UUID().uuidString,
-            firstApplied: nil
+            metadata: RemoteConfigurationCache.Metadata(
+                versionId: versionId,
+                lastModified: lastModifiedHeader.flatMap { RemoteConfigurationCache.Metadata.httpDateFormatter.date(from: $0) },
+                lastSynced: dateProvider.now,
+                syncId: UUID().uuidString,
+                firstApplied: nil
+            ),
+            configuration: configuration
+        )
+
+        try write(cache: cache)
+    }
+
+    /// Persists only the response's `ETag`, leaving any previously cached configuration and
+    /// metadata untouched.
+    ///
+    /// Called when the response body could not be cached or decoded, so the next sync sends
+    /// `If-None-Match` for this same (still-broken) payload and short-circuits to a lightweight
+    /// 304 instead of re-fetching and re-failing on every sync, without `report(cache:to:)`
+    /// ever reporting this undelivered version as applied.
+    private func updateETag(from response: HTTPURLResponse, previous: RemoteConfigurationCache?, telemetry: Telemetry) {
+        let etag = response.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "etag" })?.value as? String
+
+        let cache = RemoteConfigurationCache(
+            etag: etag,
+            metadata: previous?.metadata,
+            configuration: previous?.configuration
         )
 
         do {
-            try write(metadata: metadata)
+            try write(cache: cache)
         } catch {
             telemetry.error("[RemoteConfig] Failed to save remote configuration metadata", error: error)
         }
     }
 
-    /// Persists metadata to `<id>.metadata.json`.
-    private func write(metadata: RemoteConfigurationMetadata) throws {
-        try write(JSONEncoder().encode(metadata), to: "\(id).metadata.json")
+    /// Persists the cache to `<id>.json`.
+    private func write(cache: RemoteConfigurationCache) throws {
+        try write(JSONEncoder().encode(cache), to: "\(id).json")
     }
 
     private func write(_ data: Data, to filename: String) throws {

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -7,6 +7,38 @@
 import Foundation
 import DatadogInternal
 
+/// CDN response metadata for a remote configuration fetch, used to correlate
+/// configuration propagation telemetry with the CDN version that produced it.
+internal struct RemoteConfigurationMetadata: Codable, Equatable {
+    /// Value of the `etag` response header, sent back as `If-None-Match`.
+    let etag: String?
+    /// Value of the `x-amz-version-id` response header.
+    let versionId: String?
+    /// Parsed value of the `last-modified` response header.
+    let lastModified: Date?
+    /// Date this configuration was fetched and persisted.
+    let lastSynced: Date?
+    /// Identifier of the sync that produced this configuration version, generated the same way
+    /// as the request IDs used for event uploads. Reused by every session running on this
+    /// version, until the next genuine (non-304) sync.
+    let syncId: String?
+    /// Date this configuration version was first observed as applied. Stamped once and reused
+    /// on every subsequent session that runs on the same version.
+    let firstApplied: Date?
+}
+
+extension RemoteConfigurationMetadata {
+    /// Formats and parses the `last-modified` response header (RFC 7231 IMF-fixdate,
+    /// e.g. `Wed, 21 Oct 2015 07:28:00 GMT`).
+    static let httpDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        return formatter
+    }()
+}
+
 /// Fetches and caches remote configuration from the Datadog CDN.
 ///
 /// On `start(_:)`, the provider immediately delivers any previously cached configuration
@@ -16,9 +48,10 @@ import DatadogInternal
 ///
 /// ## Caching
 /// A successful fetch is persisted as `<id>.json` inside the supplied `directory`.
-/// The accompanying HTTP ETag is stored in `<id>.etag` and sent back as `If-None-Match`
-/// on subsequent requests, turning unchanged responses into lightweight 304s that skip
-/// body transfer and re-parse entirely.
+/// The accompanying HTTP ETag, and the `x-amz-version-id` / `last-modified` headers
+/// used for propagation telemetry, are stored in `<id>.metadata.json`. The ETag is sent
+/// back as `If-None-Match` on subsequent requests, turning unchanged responses into
+/// lightweight 304s that skip body transfer and re-parse entirely.
 ///
 /// ## Threading
 /// - The synchronous cache read in `start` runs on the caller's thread.
@@ -70,13 +103,25 @@ internal final class RemoteConfigurationProvider {
     /// Each invocation carries the latest result, so callers should replace the previously
     /// delivered value rather than accumulate.
     ///
-    /// - Parameter handler: Called with `.success` when configuration is available
-    ///   (from cache or network), or `.failure` if a read or fetch error occurs.
-    func start(_ handler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
+    /// - Parameters:
+    ///   - handler: Called with the configuration whenever one is available (from cache or
+    ///     network). Read or fetch errors are not surfaced here; they are reported to
+    ///     `telemetry` instead.
+    ///   - telemetry: Reports the propagation of the configuration version delivered from
+    ///     cache (if any) on the once-per-session configuration telemetry, synchronously
+    ///     from the cache read below. Configuration telemetry buffers sends made before a
+    ///     receiver is registered for the session, so reporting this early is safe. A
+    ///     genuinely new fetch (non-304) only updates the persisted metadata; it does not
+    ///     report telemetry on its own, since the fetched version does not take effect
+    ///     until the next application launch. Read and fetch errors are also reported here.
+    func start(
+        _ handler: @escaping (RemoteConfiguration) -> Void,
+        telemetry: Telemetry = NOPTelemetry()
+    ) {
         // Synchronous read on the caller's thread (main thread during SDK init).
         // Acceptable because the file is small (a single JSON document) and only
         // present after a previous successful fetch — absent on first launch.
-        readCache().map(handler)
+        readCache(telemetry: telemetry).map(handler)
 
 #if canImport(UIKit)
         foregroundObserver = notificationCenter.addObserver(
@@ -93,11 +138,11 @@ internal final class RemoteConfigurationProvider {
                     return
                 }
             }
-            self.sync(handler)
+            self.sync(handler, telemetry: telemetry)
         }
 #endif
 
-        sync(handler)
+        sync(handler, telemetry: telemetry)
     }
 
     deinit {
@@ -123,7 +168,7 @@ internal final class RemoteConfigurationProvider {
 
     // MARK: - Private
 
-    private func readCache() -> Result<RemoteConfiguration, RemoteConfigurationError>? {
+    private func readCache(telemetry: Telemetry) -> RemoteConfiguration? {
         let cacheFilename = "\(id).json"
         guard directory.hasFile(named: cacheFilename) else {
             return nil
@@ -132,18 +177,22 @@ internal final class RemoteConfigurationProvider {
         do {
             let data = try directory.file(named: cacheFilename).read()
             let remoteConfiguration = try JSONDecoder().decode(RemoteConfiguration.self, from: data)
-            return .success(remoteConfiguration)
-        } catch let error as DecodingError {
-            return .failure(.decodingError(error))
+            reportMetadata(to: telemetry)
+            return remoteConfiguration
         } catch {
-            return .failure(.internalError(error))
+            telemetry.error("[RemoteConfig] Failed to read cached remote configuration", error: error)
+            return nil
         }
     }
 
     /// Fires an async CDN fetch and persists the configuration on success.
-    private func sync(_ handler: @escaping (Result<RemoteConfiguration, RemoteConfigurationError>) -> Void) {
+    private func sync(
+        _ handler: @escaping (RemoteConfiguration) -> Void,
+        telemetry: Telemetry
+    ) {
+        let decoder = JSONDecoder()
         let cacheFilename = "\(id).json"
-        let etagFilename = "\(id).etag"
+        let metadataFilename = "\(id).metadata.json"
 
         // Build request with conditional ETag header if a previous ETag is stored.
         var request = URLRequest(
@@ -153,12 +202,12 @@ internal final class RemoteConfigurationProvider {
                 .appendingPathExtension("json")
         )
 
-        if let file = try? directory.file(named: etagFilename) {
+        if let file = try? directory.file(named: metadataFilename) {
             do {
-                try String(data: file.read(), encoding: .utf8)
-                    .map { request.setValue($0, forHTTPHeaderField: "If-None-Match") }
+                let metadata = try decoder.decode(RemoteConfigurationMetadata.self, from: file.read())
+                metadata.etag.map { request.setValue($0, forHTTPHeaderField: "If-None-Match") }
             } catch {
-                handler(.failure(.etagError(error)))
+                telemetry.error("[RemoteConfig] Failed to read cached metadata etag", error: error)
             }
         }
 
@@ -168,9 +217,7 @@ internal final class RemoteConfigurationProvider {
             }
 
             do {
-                let (http, data) = try result
-                    .mapError { RemoteConfigurationError.networkError($0) }
-                    .get()
+                let (http, data) = try result.get()
 
                 if http.statusCode == 304 {
                     self.lastSyncDate = self.dateProvider.now
@@ -181,25 +228,16 @@ internal final class RemoteConfigurationProvider {
                     throw RemoteConfigurationError.httpError(http.statusCode)
                 }
 
-                do {
-                    // Persist ETag before decoding — the ETag belongs to the HTTP response,
-                    // not to whether we could parse the body. This prevents re-fetching a
-                    // known-bad payload on every sync; we recover when the server updates.
-                    if let etag = http.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "etag" })?.value as? String {
-                        try self.write(Data(etag.utf8), to: etagFilename)
-                    } else if let file = try? directory.file(named: etagFilename) {
-                        // Only delete a validator that actually exists; "nothing to delete" is not an error.
-                        try file.delete()
-                    }
-                } catch {
-                    handler(.failure(.etagError(error)))
-                }
+                // Persist metadata before decoding — it belongs to the HTTP response,
+                // not to whether we could parse the body. This prevents re-fetching a
+                // known-bad payload on every sync; we recover when the server updates.
+                self.saveMetadata(from: http, telemetry: telemetry)
 
                 guard let data, !data.isEmpty else {
                     throw RemoteConfigurationError.emptyBody
                 }
 
-                let remoteConfiguration = try JSONDecoder().decode(RemoteConfiguration.self, from: data)
+                let remoteConfiguration = try decoder.decode(RemoteConfiguration.self, from: data)
 
                 // All checks passed — persist to disk.
                 // File.write uses .atomic (write to temp, then rename), so the update is
@@ -207,15 +245,81 @@ internal final class RemoteConfigurationProvider {
                 try self.write(data, to: cacheFilename)
                 self.lastSyncDate = self.dateProvider.now
 
-                handler(.success(remoteConfiguration))
-            } catch let error as RemoteConfigurationError {
-                handler(.failure(error))
-            } catch let error as DecodingError {
-                handler(.failure(.decodingError(error)))
+                handler(remoteConfiguration)
             } catch {
-                handler(.failure(.internalError(error)))
+                telemetry.error("[RemoteConfig] Failed to sync remote configuration", error: error)
             }
         }
+    }
+
+    /// Reports the configuration version applied from cache on the once-per-session
+    /// configuration telemetry. Stamps `firstApplied` the first time this version is
+    /// observed as applied, and persists it back to disk so every later session running
+    /// on the same version reports the same value.
+    private func reportMetadata(to telemetry: Telemetry) {
+        guard let file = try? directory.file(named: "\(id).metadata.json") else {
+            return
+        }
+
+        do {
+            var metadata = try JSONDecoder().decode(RemoteConfigurationMetadata.self, from: file.read())
+
+            if metadata.firstApplied == nil {
+                metadata = RemoteConfigurationMetadata(
+                    etag: metadata.etag,
+                    versionId: metadata.versionId,
+                    lastModified: metadata.lastModified,
+                    lastSynced: metadata.lastSynced,
+                    syncId: metadata.syncId,
+                    firstApplied: dateProvider.now
+                )
+                try write(metadata: metadata)
+            }
+
+            telemetry.configuration(
+                remoteConfiguration: .init(
+                    configId: id,
+                    versionId: metadata.versionId,
+                    lastModified: metadata.lastModified,
+                    lastSynced: metadata.lastSynced,
+                    firstApplied: metadata.firstApplied,
+                    syncId: metadata.syncId
+                )
+            )
+        } catch {
+            telemetry.error("[RemoteConfig] Failed to report applied remote configuration", error: error)
+        }
+    }
+
+    /// Builds and persists metadata from a genuine (non-304) fetch's HTTP response.
+    /// `syncId` and `lastSynced` mark this as a genuine sync, distinct from a 304.
+    /// `firstApplied` is left unset: this version has not been applied yet, since a
+    /// fetch that completes mid-session does not retroactively re-apply already
+    /// initialized features.
+    private func saveMetadata(from response: HTTPURLResponse, telemetry: Telemetry) {
+        let etag = response.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "etag" })?.value as? String
+        let versionId = response.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "x-amz-version-id" })?.value as? String
+        let lastModifiedHeader = response.allHeaderFields.first(where: { ($0.key as? String)?.lowercased() == "last-modified" })?.value as? String
+
+        let metadata = RemoteConfigurationMetadata(
+            etag: etag,
+            versionId: versionId,
+            lastModified: lastModifiedHeader.flatMap { RemoteConfigurationMetadata.httpDateFormatter.date(from: $0) },
+            lastSynced: dateProvider.now,
+            syncId: UUID().uuidString,
+            firstApplied: nil
+        )
+
+        do {
+            try write(metadata: metadata)
+        } catch {
+            telemetry.error("[RemoteConfig] Failed to save remote configuration metadata", error: error)
+        }
+    }
+
+    /// Persists metadata to `<id>.metadata.json`.
+    private func write(metadata: RemoteConfigurationMetadata) throws {
+        try write(JSONEncoder().encode(metadata), to: "\(id).metadata.json")
     }
 
     private func write(_ data: Data, to filename: String) throws {
@@ -227,21 +331,13 @@ internal final class RemoteConfigurationProvider {
 }
 
 internal enum RemoteConfigurationError: Error, LocalizedError {
-    case networkError(Error)
     case httpError(Int)
     case emptyBody
-    case decodingError(DecodingError)
-    case etagError(Error)
-    case internalError(Error)
 
     var errorDescription: String? {
         switch self {
-        case .networkError(let error): return "Network error: \(error.localizedDescription)"
         case .httpError(let code): return "Non-2xx response: HTTP \(code)"
         case .emptyBody: return "Empty response body"
-        case .decodingError(let error): return "Decoding failed: \(error.localizedDescription)"
-        case .etagError(let error): return "Etag storage failed: \(error.localizedDescription)"
-        case .internalError(let error): return "Internal error: \(error.localizedDescription)"
         }
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -54,55 +54,43 @@ class RemoteConfigurationTests: XCTestCase {
         return provider
     }
 
+    /// Raw CDN response payload for a remote configuration fetch.
     private func remoteConfigurationData(applicationID: String = "application-id") -> Data {
         Data("{\"rum\":{\"applicationId\":\"\(applicationID)\"}}".utf8)
     }
 
-    private func metadataData(
+    /// Encodes a `RemoteConfigurationCache` as it would be persisted on disk, for pre-seeding
+    /// the cache file in tests.
+    private func cacheData(
         etag: String? = nil,
         versionId: String? = nil,
         lastModified: Date? = nil,
         lastSynced: Date? = nil,
         syncId: String? = nil,
-        firstApplied: Date? = nil
+        firstApplied: Date? = nil,
+        applicationID: String? = nil
     ) -> Data {
-        try! JSONEncoder().encode(
-            RemoteConfigurationMetadata(
-                etag: etag,
-                versionId: versionId,
-                lastModified: lastModified,
-                lastSynced: lastSynced,
-                syncId: syncId,
-                firstApplied: firstApplied
-            )
-        )
+        let metadata: RemoteConfigurationCache.Metadata? = versionId != nil || lastModified != nil || lastSynced != nil || syncId != nil || firstApplied != nil
+            ? RemoteConfigurationCache.Metadata(versionId: versionId, lastModified: lastModified, lastSynced: lastSynced, syncId: syncId, firstApplied: firstApplied)
+            : nil
+        let configuration = applicationID.map { RemoteConfiguration(rum: .init(applicationId: $0)) }
+        return try! JSONEncoder().encode(RemoteConfigurationCache(etag: etag, metadata: metadata, configuration: configuration))
     }
 
-    private func readMetadata(fileName: String = "test-id.metadata.json") -> RemoteConfigurationMetadata? {
+    private func readCache(fileName: String = "test-id.json") -> RemoteConfigurationCache? {
         guard let data = try? Data(contentsOf: coreDir.coreDirectory.url.appendingPathComponent(fileName)) else {
             return nil
         }
-        return try? JSONDecoder().decode(RemoteConfigurationMetadata.self, from: data)
+        return try? JSONDecoder().decode(RemoteConfigurationCache.self, from: data)
     }
 
     private func waitForPersistedConfiguration(
         applicationID: String,
-        fileData: Data? = nil,
         fileName: String = "test-id.json"
     ) {
         let expectation = expectation(description: "remote configuration is persisted")
         wait(until: {
-            let fileURL = self.coreDir.coreDirectory.url.appendingPathComponent(fileName)
-            guard let persistedData = try? Data(contentsOf: fileURL),
-                  (try? JSONDecoder().decode(RemoteConfiguration.self, from: persistedData).rum?.applicationId) == applicationID else {
-                return false
-            }
-
-            guard let fileData else {
-                return true
-            }
-
-            return persistedData == fileData
+            self.readCache(fileName: fileName)?.configuration?.rum?.applicationId == applicationID
         }, andThenFulfill: expectation)
         wait(for: [expectation], timeout: 2)
     }
@@ -167,9 +155,8 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testStartReadsCacheFromPreviousLaunch() throws {
-        let payload = remoteConfigurationData(applicationID: "cached-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
-        try payload.write(to: fileURL, options: .atomic)
+        try cacheData(applicationID: "cached-application-id").write(to: fileURL, options: .atomic)
 
         let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
         let expectation = expectation(description: "cached remote configuration is returned")
@@ -218,14 +205,14 @@ class RemoteConfigurationTests: XCTestCase {
         let payload = remoteConfigurationData(applicationID: "fetched-application-id")
         let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload))
 
-        waitForPersistedConfiguration(applicationID: "fetched-application-id", fileData: payload)
+        waitForPersistedConfiguration(applicationID: "fetched-application-id")
         withExtendedLifetime(rc) {}
     }
 
     func testInitSyncPersistsConfigurationAcrossInstances() throws {
         let payload = remoteConfigurationData(applicationID: "persisted-application-id")
         let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload))
-        waitForPersistedConfiguration(applicationID: "persisted-application-id", fileData: payload)
+        waitForPersistedConfiguration(applicationID: "persisted-application-id")
 
         let cachedProvider = makeProvider(httpClient: NeverHTTPClient(), start: false)
         let expectation = expectation(description: "persisted remote configuration is returned")
@@ -254,9 +241,8 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testInitSyncNon2xxReportsTelemetryAndPreservesPersistedConfiguration() throws {
-        let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
-        try existing.write(to: fileURL, options: .atomic)
+        try cacheData(applicationID: "existing-application-id").write(to: fileURL, options: .atomic)
 
         let telemetry = TelemetryMock()
         let rc = makeProvider(httpClient: HTTPClientMock(responseCode: 500), start: false)
@@ -264,7 +250,7 @@ class RemoteConfigurationTests: XCTestCase {
 
         waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
 
-        XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after non-2xx")
+        XCTAssertEqual(readCache()?.configuration?.rum?.applicationId, "existing-application-id", "Existing configuration must be preserved after non-2xx")
         withExtendedLifetime(rc) {}
     }
 
@@ -276,15 +262,13 @@ class RemoteConfigurationTests: XCTestCase {
 
         waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
 
-        let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        XCTAssertNil(readCache()?.configuration, "An empty response body must never be cached as a configuration")
         withExtendedLifetime(rc) {}
     }
 
     func testInitSyncInvalidJSONBodyReportsTelemetryAndPreservesPersistedConfiguration() throws {
-        let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
-        try existing.write(to: fileURL, options: .atomic)
+        try cacheData(applicationID: "existing-application-id").write(to: fileURL, options: .atomic)
 
         let telemetry = TelemetryMock()
         let nonJSON = Data("this is not json".utf8)
@@ -293,7 +277,7 @@ class RemoteConfigurationTests: XCTestCase {
 
         waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
 
-        XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after decoding error")
+        XCTAssertEqual(readCache()?.configuration?.rum?.applicationId, "existing-application-id", "Existing configuration must be preserved after decoding error")
         withExtendedLifetime(rc) {}
     }
 
@@ -313,9 +297,9 @@ class RemoteConfigurationTests: XCTestCase {
         waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
     }
 
-    // MARK: ETag / metadata persistence
+    // MARK: ETag persistence
 
-    func testInitSyncPersistsETagInMetadataAfterSuccessfulFetch() {
+    func testInitSyncPersistsETagAfterSuccessfulFetch() {
         let response = HTTPURLResponse(
             url: URL(string: "https://sdk-configuration.browser-intake-datadoghq.com")!,
             statusCode: 200,
@@ -324,9 +308,9 @@ class RemoteConfigurationTests: XCTestCase {
         )!
         let provider = makeProvider(httpClient: HTTPClientMock(response: response, data: Data("{}".utf8)))
 
-        let expectation = expectation(description: "etag is stored in metadata")
+        let expectation = expectation(description: "etag is stored in cache")
         wait(until: {
-            self.readMetadata()?.etag == "abc123"
+            self.readCache()?.etag == "abc123"
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
@@ -346,14 +330,14 @@ class RemoteConfigurationTests: XCTestCase {
 
         waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
 
-        XCTAssertEqual(readMetadata()?.etag, "abc123", "ETag must be persisted from the response even when the body cannot be decoded")
+        XCTAssertEqual(readCache()?.etag, "abc123", "ETag must be persisted from the response even when the body cannot be decoded")
         withExtendedLifetime(rc) {}
     }
 
     func testInitSyncOverwritesStaleETagWhenResponseHasNoETag() throws {
         // Given — a stale etag from a previous fetch
-        try metadataData(etag: "old-etag")
-            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
+        try cacheData(etag: "old-etag")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
 
         // When — server returns 200 with new data but no ETag header
         let provider = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8)))
@@ -361,7 +345,7 @@ class RemoteConfigurationTests: XCTestCase {
         // Then — the stale etag must be overwritten so it is never sent as If-None-Match again
         let expectation = expectation(description: "stale etag is cleared")
         wait(until: {
-            self.readMetadata()?.etag == nil
+            self.readCache()?.etag == nil
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
@@ -369,11 +353,11 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testInitSyncSendsIfNoneMatchWhenETagStoredEvenWithoutConfiguration() throws {
-        // Given — metadata with an ETag exists but the JSON configuration does not. This happens
-        // when a previous fetch returned a payload we could not decode: we keep its ETag on
-        // purpose so we can skip re-downloading the known-bad payload.
-        try metadataData(etag: "abc123")
-            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
+        // Given — a cache with an ETag but no configuration. This happens when a previous fetch
+        // returned a payload we could not decode: we keep its ETag on purpose so we can skip
+        // re-downloading the known-bad payload.
+        try cacheData(etag: "abc123")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
 
         let httpClient = HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8))
         let provider = makeProvider(httpClient: httpClient)
@@ -392,12 +376,8 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testInitSyncSendsIfNoneMatchHeaderWhenETagStored() throws {
-        try metadataData(etag: "abc123")
-            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
-        try Data("{}".utf8).write(
-            to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
-            options: .atomic
-        )
+        try cacheData(etag: "abc123")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
 
         let httpClient = HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8))
         let provider = makeProvider(httpClient: httpClient)
@@ -411,9 +391,9 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(provider) {}
     }
 
-    func testSyncReportsTelemetryErrorWhenCachedMetadataCannotBeRead() throws {
+    func testSyncReportsTelemetryErrorWhenCachedFileCannotBeRead() throws {
         try FileManager.default.createDirectory(
-            at: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"),
+            at: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             withIntermediateDirectories: false
         )
         let telemetry = TelemetryMock()
@@ -427,7 +407,7 @@ class RemoteConfigurationTests: XCTestCase {
 
     func test304ResponsePreservesCache() throws {
         // Given — pre-populate persisted configuration
-        let existing = remoteConfigurationData(applicationID: "existing-application-id")
+        let existing = cacheData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
 
@@ -485,13 +465,13 @@ class RemoteConfigurationTests: XCTestCase {
             return .success((.mockResponseWith(statusCode: 200), payload))
         }
         let rc = makeProvider(httpClient: httpClient, notificationCenter: notificationCenter, dateProvider: dateProvider)
-        waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
+        waitForPersistedConfiguration(applicationID: "initial-application-id")
 
         // Advance past TTL so the foreground sync is not suppressed
         dateProvider.advance(bySeconds: 360)
         notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
 
-        waitForPersistedConfiguration(applicationID: "foreground-application-id", fileData: foregroundPayload)
+        waitForPersistedConfiguration(applicationID: "foreground-application-id")
         withExtendedLifetime(rc) {}
     }
 
@@ -516,12 +496,12 @@ class RemoteConfigurationTests: XCTestCase {
         rc.start { _ in
             completionExpectation.fulfill()
         }
-        waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
+        waitForPersistedConfiguration(applicationID: "initial-application-id")
 
         // Advance past TTL so the foreground sync is not suppressed
         dateProvider.advance(bySeconds: 360)
         notificationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
-        waitForPersistedConfiguration(applicationID: "foreground-application-id", fileData: foregroundPayload)
+        waitForPersistedConfiguration(applicationID: "foreground-application-id")
 
         wait(for: [completionExpectation], timeout: 2)
         withExtendedLifetime(rc) {}
@@ -609,11 +589,8 @@ class RemoteConfigurationTests: XCTestCase {
         // Given — init sync returns 304, TTL not elapsed
         let notificationCenter = NotificationCenter()
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0)
-        let cachedPayload = remoteConfigurationData(applicationID: "cached-application-id")
-        try cachedPayload.write(
-            to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
-            options: .atomic
-        )
+        try cacheData(applicationID: "cached-application-id")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
         let httpClient = HTTPClientMock { _ in
             .success((.mockResponseWith(statusCode: 304), nil))
         }
@@ -645,10 +622,10 @@ class RemoteConfigurationTests: XCTestCase {
         let payload2 = remoteConfigurationData(applicationID: "application-id-two")
 
         let rc1 = makeProvider(id: "id-one", httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload1))
-        waitForPersistedConfiguration(applicationID: "application-id-one", fileData: payload1, fileName: "id-one.json")
+        waitForPersistedConfiguration(applicationID: "application-id-one", fileName: "id-one.json")
 
         let rc2 = makeProvider(id: "id-two", httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload2))
-        waitForPersistedConfiguration(applicationID: "application-id-two", fileData: payload2, fileName: "id-two.json")
+        waitForPersistedConfiguration(applicationID: "application-id-two", fileName: "id-two.json")
 
         let cachedProvider1 = makeProvider(id: "id-one", httpClient: NeverHTTPClient(), start: false)
         let cachedProvider2 = makeProvider(id: "id-two", httpClient: NeverHTTPClient(), start: false)
@@ -686,12 +663,12 @@ class RemoteConfigurationTests: XCTestCase {
 
         let expectation = expectation(description: "metadata is persisted with syncId and lastSynced")
         wait(until: {
-            let metadata = self.readMetadata()
+            let metadata = self.readCache()?.metadata
             return metadata?.syncId != nil && metadata?.lastSynced != nil
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
-        XCTAssertNil(readMetadata()?.firstApplied, "A freshly fetched version has not been applied yet")
+        XCTAssertNil(readCache()?.metadata?.firstApplied, "A freshly fetched version has not been applied yet")
         withExtendedLifetime(provider) {}
     }
 
@@ -701,7 +678,7 @@ class RemoteConfigurationTests: XCTestCase {
         let provider = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload), start: false)
 
         provider.start({ _ in }, telemetry: telemetry)
-        waitForPersistedConfiguration(applicationID: "fetched-application-id", fileData: payload)
+        waitForPersistedConfiguration(applicationID: "fetched-application-id")
 
         XCTAssertNil(telemetry.messages.firstConfiguration(), "Nothing was applied from cache on first launch, so nothing should be reported")
         withExtendedLifetime(provider) {}
@@ -710,10 +687,14 @@ class RemoteConfigurationTests: XCTestCase {
     func testCachedVersionIsReportedOnConfigurationTelemetryWithFirstAppliedStamped() throws {
         let lastModified = Date(timeIntervalSince1970: 1_767_225_600) // 2026-01-01T00:00:00Z
         let lastSynced = Date(timeIntervalSince1970: 1_767_312_000) // 2026-01-02T00:00:00Z
-        try metadataData(versionId: "v1", lastModified: lastModified, lastSynced: lastSynced, syncId: "sync-1")
-            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
-        try remoteConfigurationData(applicationID: "cached-application-id")
-            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
+        try cacheData(
+            versionId: "v1",
+            lastModified: lastModified,
+            lastSynced: lastSynced,
+            syncId: "sync-1",
+            applicationID: "cached-application-id"
+        )
+        .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
 
         let telemetry = TelemetryMock()
         let provider = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 304)), start: false)
@@ -735,9 +716,7 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testFirstAppliedIsStampedOnceAndReusedAcrossSessions() throws {
-        try metadataData(versionId: "v1", syncId: "sync-1")
-            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
-        try remoteConfigurationData(applicationID: "cached-application-id")
+        try cacheData(versionId: "v1", syncId: "sync-1", applicationID: "cached-application-id")
             .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
 
         let firstSessionTelemetry = TelemetryMock()

--- a/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/RemoteConfigurationTests.swift
@@ -58,6 +58,33 @@ class RemoteConfigurationTests: XCTestCase {
         Data("{\"rum\":{\"applicationId\":\"\(applicationID)\"}}".utf8)
     }
 
+    private func metadataData(
+        etag: String? = nil,
+        versionId: String? = nil,
+        lastModified: Date? = nil,
+        lastSynced: Date? = nil,
+        syncId: String? = nil,
+        firstApplied: Date? = nil
+    ) -> Data {
+        try! JSONEncoder().encode(
+            RemoteConfigurationMetadata(
+                etag: etag,
+                versionId: versionId,
+                lastModified: lastModified,
+                lastSynced: lastSynced,
+                syncId: syncId,
+                firstApplied: firstApplied
+            )
+        )
+    }
+
+    private func readMetadata(fileName: String = "test-id.metadata.json") -> RemoteConfigurationMetadata? {
+        guard let data = try? Data(contentsOf: coreDir.coreDirectory.url.appendingPathComponent(fileName)) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(RemoteConfigurationMetadata.self, from: data)
+    }
+
     private func waitForPersistedConfiguration(
         applicationID: String,
         fileData: Data? = nil,
@@ -78,6 +105,16 @@ class RemoteConfigurationTests: XCTestCase {
             return persistedData == fileData
         }, andThenFulfill: expectation)
         wait(for: [expectation], timeout: 2)
+    }
+
+    private func waitForTelemetryError(_ telemetry: TelemetryMock, messagePrefix: String) {
+        let expectation = expectation(description: "telemetry error '\(messagePrefix)' is reported")
+        wait(until: {
+            telemetry.messages.contains {
+                $0.asError?.message.hasPrefix(messagePrefix) == true
+            }
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 2)
     }
 
     // MARK: endpoint URL construction
@@ -137,9 +174,8 @@ class RemoteConfigurationTests: XCTestCase {
         let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
         let expectation = expectation(description: "cached remote configuration is returned")
 
-        rc.start { result in
-            if case .success(let remoteConfiguration) = result,
-               remoteConfiguration.rum?.applicationId == "cached-application-id" {
+        rc.start { remoteConfiguration in
+            if remoteConfiguration.rum?.applicationId == "cached-application-id" {
                 expectation.fulfill()
             }
         }
@@ -148,26 +184,7 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(rc) {}
     }
 
-    func testStartReturnsFailureWhenFileCannotBeRead() throws {
-        try FileManager.default.createDirectory(
-            at: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
-            withIntermediateDirectories: false
-        )
-
-        let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
-        let expectation = expectation(description: "cache read failure is returned")
-
-        rc.start { result in
-            if case .failure = result {
-                expectation.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 2)
-
-        withExtendedLifetime(rc) {}
-    }
-
-    func testStartCacheReadFailureCanBeReportedToTelemetryByCaller() throws {
+    func testStartReportsTelemetryErrorWhenCachedFileCannotBeRead() throws {
         try FileManager.default.createDirectory(
             at: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             withIntermediateDirectories: false
@@ -175,34 +192,23 @@ class RemoteConfigurationTests: XCTestCase {
         let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
         let telemetry = TelemetryMock()
 
-        let expectation = expectation(description: "cache read failure is returned")
-        rc.start { result in
-            if case .failure(let error) = result {
-                telemetry.error("[RemoteConfig] Load failed", error: error)
-                expectation.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 2)
+        rc.start({ _ in }, telemetry: telemetry)
 
-        XCTAssertTrue(telemetry.messages.firstError()?.message.hasPrefix("[RemoteConfig] Load failed") == true)
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to read cached remote configuration")
+        withExtendedLifetime(rc) {}
     }
 
-    func testStartReturnsFailureWhenFileCannotBeDecoded() throws {
+    func testStartReportsTelemetryErrorWhenCachedFileCannotBeDecoded() throws {
         try Data("this is not json".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             options: .atomic
         )
-
         let rc = makeProvider(httpClient: NeverHTTPClient(), start: false)
-        let expectation = expectation(description: "cache decoding failure is returned")
+        let telemetry = TelemetryMock()
 
-        rc.start { result in
-            if case .failure(.decodingError) = result {
-                expectation.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 2)
+        rc.start({ _ in }, telemetry: telemetry)
 
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to read cached remote configuration")
         withExtendedLifetime(rc) {}
     }
 
@@ -223,9 +229,8 @@ class RemoteConfigurationTests: XCTestCase {
 
         let cachedProvider = makeProvider(httpClient: NeverHTTPClient(), start: false)
         let expectation = expectation(description: "persisted remote configuration is returned")
-        cachedProvider.start { result in
-            if case .success(let remoteConfiguration) = result,
-               remoteConfiguration.rum?.applicationId == "persisted-application-id" {
+        cachedProvider.start { remoteConfiguration in
+            if remoteConfiguration.rum?.applicationId == "persisted-application-id" {
                 expectation.fulfill()
             }
         }
@@ -235,74 +240,64 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(cachedProvider) {}
     }
 
-    func testInitSyncNetworkErrorReturnsFailureAndLeavesNoPersistedConfiguration() {
+    func testInitSyncNetworkErrorReportsTelemetryAndLeavesNoPersistedConfiguration() {
+        let telemetry = TelemetryMock()
         let rc = makeProvider(httpClient: HTTPClientMock(error: URLError(.networkConnectionLost)), start: false)
 
-        let expectation = expectation(description: "sync fails")
-        rc.start { result in
-            if case .failure(.networkError) = result {
-                expectation.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 2)
+        rc.start({ _ in }, telemetry: telemetry)
+
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
 
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        withExtendedLifetime(rc) {}
     }
 
-    func testInitSyncNon2xxReturnsFailureAndPreservesPersistedConfiguration() throws {
+    func testInitSyncNon2xxReportsTelemetryAndPreservesPersistedConfiguration() throws {
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
 
+        let telemetry = TelemetryMock()
         let rc = makeProvider(httpClient: HTTPClientMock(responseCode: 500), start: false)
-        let requestExpectation = expectation(description: "request completes")
-        rc.start { result in
-            if case .failure(.httpError) = result {
-                requestExpectation.fulfill()
-            }
-        }
-        wait(for: [requestExpectation], timeout: 2)
+        rc.start({ _ in }, telemetry: telemetry)
+
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
 
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after non-2xx")
         withExtendedLifetime(rc) {}
     }
 
-    func testInitSyncEmptyBodyReturnsFailureAndLeavesNoPersistedConfiguration() {
+    func testInitSyncEmptyBodyReportsTelemetryAndLeavesNoPersistedConfiguration() {
+        let telemetry = TelemetryMock()
         let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data()), start: false)
 
-        let expectation = expectation(description: "sync fails")
-        rc.start { result in
-            if case .failure(.emptyBody) = result {
-                expectation.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 2)
+        rc.start({ _ in }, telemetry: telemetry)
+
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
 
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        withExtendedLifetime(rc) {}
     }
 
-    func testInitSyncInvalidJSONBodyReturnsFailureAndPreservesPersistedConfiguration() throws {
+    func testInitSyncInvalidJSONBodyReportsTelemetryAndPreservesPersistedConfiguration() throws {
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
         let fileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
         try existing.write(to: fileURL, options: .atomic)
 
+        let telemetry = TelemetryMock()
         let nonJSON = Data("this is not json".utf8)
         let rc = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: nonJSON), start: false)
-        let requestExpectation = expectation(description: "request completes")
-        rc.start { result in
-            if case .failure(.decodingError) = result {
-                requestExpectation.fulfill()
-            }
-        }
-        wait(for: [requestExpectation], timeout: 2)
+        rc.start({ _ in }, telemetry: telemetry)
+
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
 
         XCTAssertEqual(try? Data(contentsOf: fileURL), existing, "Existing file must be preserved after decoding error")
         withExtendedLifetime(rc) {}
     }
 
-    func testInitSyncDiskWriteFailureReturnsFailure() {
+    func testInitSyncDiskWriteFailureReportsTelemetry() {
         let missingDir = Directory(url: URL(fileURLWithPath: "/no/such/path/"))
         let rc = RemoteConfigurationProvider(
             id: "test-id",
@@ -311,19 +306,16 @@ class RemoteConfigurationTests: XCTestCase {
             httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8)),
             notificationCenter: NotificationCenter()
         )
+        let telemetry = TelemetryMock()
 
-        let expectation = expectation(description: "sync fails")
-        rc.start { result in
-            if case .failure = result {
-                expectation.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 2)
+        rc.start({ _ in }, telemetry: telemetry)
+
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
     }
 
-    // MARK: ETag
+    // MARK: ETag / metadata persistence
 
-    func testInitSyncStoresETagAfterSuccessfulFetch() {
+    func testInitSyncPersistsETagInMetadataAfterSuccessfulFetch() {
         let response = HTTPURLResponse(
             url: URL(string: "https://sdk-configuration.browser-intake-datadoghq.com")!,
             statusCode: 200,
@@ -332,108 +324,56 @@ class RemoteConfigurationTests: XCTestCase {
         )!
         let provider = makeProvider(httpClient: HTTPClientMock(response: response, data: Data("{}".utf8)))
 
-        let expectation = expectation(description: "etag is stored")
-        let etagFileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.etag")
+        let expectation = expectation(description: "etag is stored in metadata")
         wait(until: {
-            (try? String(data: Data(contentsOf: etagFileURL), encoding: .utf8)) == "abc123"
+            self.readMetadata()?.etag == "abc123"
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
-        let storedETag = try? String(data: Data(contentsOf: etagFileURL), encoding: .utf8)
-        XCTAssertEqual(storedETag, "abc123")
         withExtendedLifetime(provider) {}
     }
 
-    func testInitSyncStoresETagEvenWhenBodyCannotBeDecoded() {
+    func testInitSyncPersistsETagEvenWhenBodyCannotBeDecoded() {
         let response = HTTPURLResponse(
             url: URL(string: "https://sdk-configuration.browser-intake-datadoghq.com")!,
             statusCode: 200,
             httpVersion: nil,
             headerFields: ["ETag": "abc123"]
         )!
+        let telemetry = TelemetryMock()
         let rc = makeProvider(httpClient: HTTPClientMock(response: response, data: Data("this is not json".utf8)), start: false)
-        let expectation = expectation(description: "decode fails")
-        rc.start { result in
-            if case .failure(.decodingError) = result { expectation.fulfill() }
-        }
-        waitForExpectations(timeout: 2)
+        rc.start({ _ in }, telemetry: telemetry)
 
-        let etagFileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.etag")
-        XCTAssertEqual(try String(data: Data(contentsOf: etagFileURL), encoding: .utf8), "abc123")
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to sync remote configuration")
+
+        XCTAssertEqual(readMetadata()?.etag, "abc123", "ETag must be persisted from the response even when the body cannot be decoded")
         withExtendedLifetime(rc) {}
     }
 
-    func testInitSyncStillDeliversConfigurationWhenETagWriteFails() throws {
-        // Given — the ETag path is occupied by a directory, so writing the ETag fails,
-        // while the configuration (.json) write still succeeds.
-        try FileManager.default.createDirectory(
-            at: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
-            withIntermediateDirectories: false
-        )
-        let response = HTTPURLResponse(
-            url: URL(string: "https://sdk-configuration.browser-intake-datadoghq.com")!,
-            statusCode: 200,
-            httpVersion: nil,
-            headerFields: ["ETag": "abc123"]
-        )!
-        let payload = remoteConfigurationData(applicationID: "fetched-application-id")
-        let rc = makeProvider(httpClient: HTTPClientMock(response: response, data: payload), start: false)
-
-        // Then — ETag caching is best-effort: the failure is reported, but the freshly
-        // fetched configuration is still delivered. The handler may fire more than once,
-        // and an ETag error may be reported more than once (the conditional-request read
-        // and the persist write both fail when the path is a directory).
-        let etagFailure = expectation(description: "ETag failure is reported")
-        etagFailure.assertForOverFulfill = false
-        let configDelivered = expectation(description: "configuration is still delivered")
-        rc.start { result in
-            switch result {
-            case .failure(.etagError): etagFailure.fulfill()
-            case .success: configDelivered.fulfill()
-            case .failure: break
-            }
-        }
-        waitForExpectations(timeout: 2)
-
-        // And — the configuration is persisted to disk despite the ETag failure.
-        let configURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.json")
-        XCTAssertEqual(try? Data(contentsOf: configURL), payload, "Configuration must be persisted even when the ETag write fails")
-        withExtendedLifetime(rc) {}
-    }
-
-    func testInitSyncDeletesStaleETagWhenResponseHasNoETag() throws {
-        // Given — a stale ETag file from a previous fetch
-        try Data("old-etag".utf8).write(
-            to: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
-            options: .atomic
-        )
+    func testInitSyncOverwritesStaleETagWhenResponseHasNoETag() throws {
+        // Given — a stale etag from a previous fetch
+        try metadataData(etag: "old-etag")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
 
         // When — server returns 200 with new data but no ETag header
         let provider = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8)))
 
-        // Then — stale ETag file must be deleted so it is never sent as If-None-Match
-        let expectation = expectation(description: "stale etag is deleted")
-        let etagFileURL = coreDir.coreDirectory.url.appendingPathComponent("test-id.etag")
+        // Then — the stale etag must be overwritten so it is never sent as If-None-Match again
+        let expectation = expectation(description: "stale etag is cleared")
         wait(until: {
-            !FileManager.default.fileExists(atPath: etagFileURL.path)
+            self.readMetadata()?.etag == nil
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
-        XCTAssertFalse(
-            FileManager.default.fileExists(atPath: etagFileURL.path),
-            "Stale ETag must be deleted when 200 response carries no ETag"
-        )
         withExtendedLifetime(provider) {}
     }
 
     func testInitSyncSendsIfNoneMatchWhenETagStoredEvenWithoutConfiguration() throws {
-        // Given — an ETag exists but the JSON configuration does not. This happens when a
-        // previous fetch returned a payload we could not decode: we keep its ETag on purpose
-        // so we can skip re-downloading the known-bad payload.
-        try Data("abc123".utf8).write(
-            to: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
-            options: .atomic
-        )
+        // Given — metadata with an ETag exists but the JSON configuration does not. This happens
+        // when a previous fetch returned a payload we could not decode: we keep its ETag on
+        // purpose so we can skip re-downloading the known-bad payload.
+        try metadataData(etag: "abc123")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
 
         let httpClient = HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8))
         let provider = makeProvider(httpClient: httpClient)
@@ -443,8 +383,6 @@ class RemoteConfigurationTests: XCTestCase {
         }, andThenFulfill: expectation)
         waitForExpectations(timeout: 2)
 
-        // Then — If-None-Match is still sent: a 304 means the known-bad payload is unchanged
-        // (nothing to gain by re-downloading), and a 200 with a new ETag lets us recover.
         XCTAssertEqual(
             httpClient.requestsSent().first?.value(forHTTPHeaderField: "If-None-Match"),
             "abc123",
@@ -454,13 +392,8 @@ class RemoteConfigurationTests: XCTestCase {
     }
 
     func testInitSyncSendsIfNoneMatchHeaderWhenETagStored() throws {
-        // Given — store an ETag from a previous fetch
-        try Data("abc123".utf8).write(
-            to: coreDir.coreDirectory.url.appendingPathComponent("test-id.etag"),
-            options: .atomic
-        )
-
-        // Pre-populate .json so persisted configuration is available (required to send If-None-Match)
+        try metadataData(etag: "abc123")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
         try Data("{}".utf8).write(
             to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"),
             options: .atomic
@@ -478,6 +411,20 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(provider) {}
     }
 
+    func testSyncReportsTelemetryErrorWhenCachedMetadataCannotBeRead() throws {
+        try FileManager.default.createDirectory(
+            at: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"),
+            withIntermediateDirectories: false
+        )
+        let telemetry = TelemetryMock()
+        let httpClient = HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: Data("{}".utf8))
+        let rc = makeProvider(httpClient: httpClient, start: false)
+        rc.start({ _ in }, telemetry: telemetry)
+
+        waitForTelemetryError(telemetry, messagePrefix: "[RemoteConfig] Failed to read cached metadata etag")
+        withExtendedLifetime(rc) {}
+    }
+
     func test304ResponsePreservesCache() throws {
         // Given — pre-populate persisted configuration
         let existing = remoteConfigurationData(applicationID: "existing-application-id")
@@ -489,8 +436,8 @@ class RemoteConfigurationTests: XCTestCase {
         // completion is called once synchronously from cache; NOT again after CDN 304
         let cacheExpectation = expectation(description: "cached config returned once from start")
         let rc = makeProvider(httpClient: httpClient, start: false)
-        rc.start { result in
-            if case .success(let config) = result, config.rum?.applicationId == "existing-application-id" {
+        rc.start { config in
+            if config.rum?.applicationId == "existing-application-id" {
                 cacheExpectation.fulfill()
             }
         }
@@ -566,10 +513,7 @@ class RemoteConfigurationTests: XCTestCase {
         let completionExpectation = expectation(description: "completion is called for each sync")
         completionExpectation.expectedFulfillmentCount = 2
         let rc = makeProvider(httpClient: httpClient, notificationCenter: notificationCenter, dateProvider: dateProvider, start: false)
-        rc.start { result in
-            guard case .success = result else {
-                return
-            }
+        rc.start { _ in
             completionExpectation.fulfill()
         }
         waitForPersistedConfiguration(applicationID: "initial-application-id", fileData: initialPayload)
@@ -711,15 +655,13 @@ class RemoteConfigurationTests: XCTestCase {
         let expectation1 = expectation(description: "first cached configuration is returned")
         let expectation2 = expectation(description: "second cached configuration is returned")
 
-        cachedProvider1.start { result in
-            if case .success(let remoteConfiguration) = result,
-               remoteConfiguration.rum?.applicationId == "application-id-one" {
+        cachedProvider1.start { remoteConfiguration in
+            if remoteConfiguration.rum?.applicationId == "application-id-one" {
                 expectation1.fulfill()
             }
         }
-        cachedProvider2.start { result in
-            if case .success(let remoteConfiguration) = result,
-               remoteConfiguration.rum?.applicationId == "application-id-two" {
+        cachedProvider2.start { remoteConfiguration in
+            if remoteConfiguration.rum?.applicationId == "application-id-two" {
                 expectation2.fulfill()
             }
         }
@@ -729,5 +671,95 @@ class RemoteConfigurationTests: XCTestCase {
         withExtendedLifetime(rc2) {}
         withExtendedLifetime(cachedProvider1) {}
         withExtendedLifetime(cachedProvider2) {}
+    }
+
+    // MARK: Configuration telemetry
+
+    func testGenuineFetchPersistsSyncIdAndLastSyncedWithoutFirstApplied() {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://sdk-configuration.browser-intake-datadoghq.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["x-amz-version-id": "v1", "last-modified": "Mon, 01 Jan 2026 00:00:00 GMT"]
+        )!
+        let provider = makeProvider(httpClient: HTTPClientMock(response: response, data: Data("{}".utf8)))
+
+        let expectation = expectation(description: "metadata is persisted with syncId and lastSynced")
+        wait(until: {
+            let metadata = self.readMetadata()
+            return metadata?.syncId != nil && metadata?.lastSynced != nil
+        }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 2)
+
+        XCTAssertNil(readMetadata()?.firstApplied, "A freshly fetched version has not been applied yet")
+        withExtendedLifetime(provider) {}
+    }
+
+    func testNoTelemetryIsReportedWhenNothingWasCached() {
+        let telemetry = TelemetryMock()
+        let payload = remoteConfigurationData(applicationID: "fetched-application-id")
+        let provider = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 200), data: payload), start: false)
+
+        provider.start({ _ in }, telemetry: telemetry)
+        waitForPersistedConfiguration(applicationID: "fetched-application-id", fileData: payload)
+
+        XCTAssertNil(telemetry.messages.firstConfiguration(), "Nothing was applied from cache on first launch, so nothing should be reported")
+        withExtendedLifetime(provider) {}
+    }
+
+    func testCachedVersionIsReportedOnConfigurationTelemetryWithFirstAppliedStamped() throws {
+        let lastModified = Date(timeIntervalSince1970: 1_767_225_600) // 2026-01-01T00:00:00Z
+        let lastSynced = Date(timeIntervalSince1970: 1_767_312_000) // 2026-01-02T00:00:00Z
+        try metadataData(versionId: "v1", lastModified: lastModified, lastSynced: lastSynced, syncId: "sync-1")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
+        try remoteConfigurationData(applicationID: "cached-application-id")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
+
+        let telemetry = TelemetryMock()
+        let provider = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 304)), start: false)
+
+        provider.start({ _ in }, telemetry: telemetry)
+
+        let expectation = expectation(description: "configuration telemetry is reported")
+        wait(until: { telemetry.messages.firstConfiguration()?.remoteConfiguration != nil }, andThenFulfill: expectation)
+        waitForExpectations(timeout: 2)
+
+        let reported = try XCTUnwrap(telemetry.messages.firstConfiguration()?.remoteConfiguration)
+        XCTAssertEqual(reported.configId, "test-id")
+        XCTAssertEqual(reported.versionId, "v1")
+        XCTAssertEqual(reported.lastModified, lastModified)
+        XCTAssertEqual(reported.lastSynced, lastSynced)
+        XCTAssertEqual(reported.syncId, "sync-1")
+        XCTAssertNotNil(reported.firstApplied, "firstApplied must be stamped the first time this version is observed as applied")
+        withExtendedLifetime(provider) {}
+    }
+
+    func testFirstAppliedIsStampedOnceAndReusedAcrossSessions() throws {
+        try metadataData(versionId: "v1", syncId: "sync-1")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.metadata.json"), options: .atomic)
+        try remoteConfigurationData(applicationID: "cached-application-id")
+            .write(to: coreDir.coreDirectory.url.appendingPathComponent("test-id.json"), options: .atomic)
+
+        let firstSessionTelemetry = TelemetryMock()
+        let firstSession = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 304)), start: false)
+        firstSession.start({ _ in }, telemetry: firstSessionTelemetry)
+
+        let firstExpectation = expectation(description: "first session reports configuration telemetry")
+        wait(until: { firstSessionTelemetry.messages.firstConfiguration()?.remoteConfiguration != nil }, andThenFulfill: firstExpectation)
+        waitForExpectations(timeout: 2)
+        let firstApplied = try XCTUnwrap(firstSessionTelemetry.messages.firstConfiguration()?.remoteConfiguration?.firstApplied)
+
+        let secondSessionTelemetry = TelemetryMock()
+        let secondSession = makeProvider(httpClient: HTTPClientMock(response: .mockResponseWith(statusCode: 304)), start: false)
+        secondSession.start({ _ in }, telemetry: secondSessionTelemetry)
+
+        let secondExpectation = expectation(description: "second session reports configuration telemetry")
+        wait(until: { secondSessionTelemetry.messages.firstConfiguration()?.remoteConfiguration != nil }, andThenFulfill: secondExpectation)
+        waitForExpectations(timeout: 2)
+        let secondFirstApplied = try XCTUnwrap(secondSessionTelemetry.messages.firstConfiguration()?.remoteConfiguration?.firstApplied)
+
+        XCTAssertEqual(firstApplied, secondFirstApplied, "firstApplied must be stable across sessions running on the same version")
+        withExtendedLifetime(firstSession) {}
+        withExtendedLifetime(secondSession) {}
     }
 }

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -60,7 +60,7 @@ class DatadogCoreTests: XCTestCase {
 
     func testGivenRemoteConfigurationProvider_whenReadingRemoteConfiguration_itReturnsCachedValue() throws {
         // Given
-        try Data(#"{"rum":{"applicationId":"cache-application-id"}}"#.utf8).write(
+        try Data(#"{"configuration":{"rum":{"applicationId":"cache-application-id"}}}"#.utf8).write(
             to: temporaryCoreDirectory.coreDirectory.url.appendingPathComponent("test-id.json"),
             options: .atomic
         )

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -722,6 +722,9 @@ public struct RUMActionEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -733,6 +736,7 @@ public struct RUMActionEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -742,16 +746,19 @@ public struct RUMActionEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -1071,7 +1078,7 @@ public struct RUMActionEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -1188,7 +1195,7 @@ public struct RUMActionEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -1734,6 +1741,9 @@ public struct RUMErrorEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -1745,6 +1755,7 @@ public struct RUMErrorEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -1754,16 +1765,19 @@ public struct RUMErrorEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -1915,7 +1929,7 @@ public struct RUMErrorEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -2595,7 +2609,7 @@ public struct RUMErrorEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -3175,6 +3189,9 @@ public struct RUMLongTaskEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -3186,6 +3203,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -3195,16 +3213,19 @@ public struct RUMLongTaskEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -3356,7 +3377,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -3660,7 +3681,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -4034,6 +4055,9 @@ public struct RUMResourceEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -4045,6 +4069,7 @@ public struct RUMResourceEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -4054,16 +4079,19 @@ public struct RUMResourceEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -4188,7 +4216,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -4292,6 +4320,9 @@ public struct RUMResourceEvent: RUMDataModel {
         /// UUID of the resource
         public let id: String?
 
+        /// Whether the resource was served from the device's local cache
+        public let localCacheHit: Bool?
+
         /// HTTP method of the resource
         public let method: RUMMethod?
 
@@ -4345,6 +4376,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case firstByte = "first_byte"
             case graphql = "graphql"
             case id = "id"
+            case localCacheHit = "local_cache_hit"
             case method = "method"
             case `protocol` = "protocol"
             case provider = "provider"
@@ -4374,6 +4406,7 @@ public struct RUMResourceEvent: RUMDataModel {
         ///   - firstByte: First Byte phase properties
         ///   - graphql: GraphQL request parameters
         ///   - id: UUID of the resource
+        ///   - localCacheHit: Whether the resource was served from the device's local cache
         ///   - method: HTTP method of the resource
         ///   - `protocol`: Network protocol used to fetch the resource (e.g., 'http/1.1', 'h2')
         ///   - provider: The provider for this resource
@@ -4399,6 +4432,7 @@ public struct RUMResourceEvent: RUMDataModel {
             firstByte: FirstByte? = nil,
             graphql: RUMGraphql? = nil,
             id: String? = nil,
+            localCacheHit: Bool? = nil,
             method: RUMMethod? = nil,
             `protocol`: String? = nil,
             provider: Provider? = nil,
@@ -4424,6 +4458,7 @@ public struct RUMResourceEvent: RUMDataModel {
             self.firstByte = firstByte
             self.graphql = graphql
             self.id = id
+            self.localCacheHit = localCacheHit
             self.method = method
             self.`protocol` = `protocol`
             self.provider = provider
@@ -4839,7 +4874,7 @@ public struct RUMResourceEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -5141,6 +5176,1221 @@ public struct RUMTelemetryOperatingSystem: Codable {
         self.build = build
         self.name = name
         self.version = version
+    }
+}
+
+/// Schema for a CPU timeseries event.
+public struct RUMTimeseriesCpuEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Account properties
+    public var account: RUMAccount?
+
+    /// Application properties
+    public let application: Application
+
+    /// Generated unique ID of the application build. Unlike version or build_version this field is not meant to be coming from the user, but rather generated by the tooling for each build.
+    public let buildId: String?
+
+    /// The build version for this application
+    public let buildVersion: String?
+
+    /// CI Visibility properties
+    public let ciTest: RUMCITest?
+
+    /// Device connectivity properties
+    public let connectivity: RUMConnectivity?
+
+    /// User provided context
+    public var context: RUMEventAttributes?
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// Tags of the event in key:value format, separated by commas (e.g. 'env:prod,version:1.2.3')
+    public let ddtags: String?
+
+    /// Device properties
+    public let device: Device?
+
+    /// Display properties
+    public let display: Display?
+
+    /// Operating system properties
+    public let os: OperatingSystem?
+
+    /// The service name for this application
+    public let service: String?
+
+    /// Session properties
+    public let session: Session
+
+    /// The source of this event
+    public let source: Source?
+
+    /// Stream properties
+    public let stream: Stream?
+
+    /// Synthetics properties
+    public var synthetics: RUMSyntheticsTest?
+
+    /// Tab properties
+    public let tab: TAB?
+
+    /// CPU timeseries properties
+    public let timeseries: Timeseries
+
+    /// RUM event type
+    public let type: String = "timeseries"
+
+    /// User properties
+    public var usr: RUMUser?
+
+    /// The version for this application
+    public let version: String?
+
+    /// View properties
+    public var view: View?
+
+    public enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case account = "account"
+        case application = "application"
+        case buildId = "build_id"
+        case buildVersion = "build_version"
+        case ciTest = "ci_test"
+        case connectivity = "connectivity"
+        case context = "context"
+        case date = "date"
+        case ddtags = "ddtags"
+        case device = "device"
+        case display = "display"
+        case os = "os"
+        case service = "service"
+        case session = "session"
+        case source = "source"
+        case stream = "stream"
+        case synthetics = "synthetics"
+        case tab = "tab"
+        case timeseries = "timeseries"
+        case type = "type"
+        case usr = "usr"
+        case version = "version"
+        case view = "view"
+    }
+
+    /// Schema for a CPU timeseries event.
+    ///
+    /// - Parameters:
+    ///   - dd: Internal properties
+    ///   - account: Account properties
+    ///   - application: Application properties
+    ///   - buildId: Generated unique ID of the application build. Unlike version or build_version this field is not meant to be coming from the user, but rather generated by the tooling for each build.
+    ///   - buildVersion: The build version for this application
+    ///   - ciTest: CI Visibility properties
+    ///   - connectivity: Device connectivity properties
+    ///   - context: User provided context
+    ///   - date: Start of the event in ms from epoch
+    ///   - ddtags: Tags of the event in key:value format, separated by commas (e.g. 'env:prod,version:1.2.3')
+    ///   - device: Device properties
+    ///   - display: Display properties
+    ///   - os: Operating system properties
+    ///   - service: The service name for this application
+    ///   - session: Session properties
+    ///   - source: The source of this event
+    ///   - stream: Stream properties
+    ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
+    ///   - timeseries: CPU timeseries properties
+    ///   - usr: User properties
+    ///   - version: The version for this application
+    ///   - view: View properties
+    public init(
+        dd: DD,
+        account: RUMAccount? = nil,
+        application: Application,
+        buildId: String? = nil,
+        buildVersion: String? = nil,
+        ciTest: RUMCITest? = nil,
+        connectivity: RUMConnectivity? = nil,
+        context: RUMEventAttributes? = nil,
+        date: Int64,
+        ddtags: String? = nil,
+        device: Device? = nil,
+        display: Display? = nil,
+        os: OperatingSystem? = nil,
+        service: String? = nil,
+        session: Session,
+        source: Source? = nil,
+        stream: Stream? = nil,
+        synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
+        timeseries: Timeseries,
+        usr: RUMUser? = nil,
+        version: String? = nil,
+        view: View? = nil
+    ) {
+        self.dd = dd
+        self.account = account
+        self.application = application
+        self.buildId = buildId
+        self.buildVersion = buildVersion
+        self.ciTest = ciTest
+        self.connectivity = connectivity
+        self.context = context
+        self.date = date
+        self.ddtags = ddtags
+        self.device = device
+        self.display = display
+        self.os = os
+        self.service = service
+        self.session = session
+        self.source = source
+        self.stream = stream
+        self.synthetics = synthetics
+        self.tab = tab
+        self.timeseries = timeseries
+        self.usr = usr
+        self.version = version
+        self.view = view
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
+        /// Subset of the SDK configuration options in use during its execution
+        public let configuration: Configuration?
+
+        /// Version of the RUM event format
+        public let formatVersion: Int64 = 2
+
+        /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
+        public let sdkName: String?
+
+        /// Session-related internal properties
+        public let session: Session?
+
+        public enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
+            case configuration = "configuration"
+            case formatVersion = "format_version"
+            case sdkName = "sdk_name"
+            case session = "session"
+        }
+
+        /// Internal properties
+        ///
+        /// - Parameters:
+        ///   - browserSdkVersion: Browser SDK version
+        ///   - configuration: Subset of the SDK configuration options in use during its execution
+        ///   - sdkName: SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
+        ///   - session: Session-related internal properties
+        public init(
+            browserSdkVersion: String? = nil,
+            configuration: Configuration? = nil,
+            sdkName: String? = nil,
+            session: Session? = nil
+        ) {
+            self.browserSdkVersion = browserSdkVersion
+            self.configuration = configuration
+            self.sdkName = sdkName
+            self.session = session
+        }
+
+        /// Subset of the SDK configuration options in use during its execution
+        public struct Configuration: Codable {
+            /// The percentage of sessions profiled
+            public let profilingSampleRate: Double?
+
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
+            /// The percentage of sessions with RUM & Session Replay pricing tracked
+            public let sessionReplaySampleRate: Double?
+
+            /// The percentage of sessions tracked
+            public let sessionSampleRate: Double
+
+            /// The percentage of sessions with traced resources
+            public let traceSampleRate: Double?
+
+            public enum CodingKeys: String, CodingKey {
+                case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
+                case sessionReplaySampleRate = "session_replay_sample_rate"
+                case sessionSampleRate = "session_sample_rate"
+                case traceSampleRate = "trace_sample_rate"
+            }
+
+            /// Subset of the SDK configuration options in use during its execution
+            ///
+            /// - Parameters:
+            ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
+            ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
+            ///   - sessionSampleRate: The percentage of sessions tracked
+            ///   - traceSampleRate: The percentage of sessions with traced resources
+            public init(
+                profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
+                sessionReplaySampleRate: Double? = nil,
+                sessionSampleRate: Double,
+                traceSampleRate: Double? = nil
+            ) {
+                self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
+                self.sessionReplaySampleRate = sessionReplaySampleRate
+                self.sessionSampleRate = sessionSampleRate
+                self.traceSampleRate = traceSampleRate
+            }
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
+            public let plan: Plan?
+
+            /// The precondition that led to the creation of the session
+            public let sessionPrecondition: RUMSessionPrecondition?
+
+            public enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+                case sessionPrecondition = "session_precondition"
+            }
+
+            /// Session-related internal properties
+            ///
+            /// - Parameters:
+            ///   - plan: Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
+            ///   - sessionPrecondition: The precondition that led to the creation of the session
+            public init(
+                plan: Plan? = nil,
+                sessionPrecondition: RUMSessionPrecondition? = nil
+            ) {
+                self.plan = plan
+                self.sessionPrecondition = sessionPrecondition
+            }
+
+            /// Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
+        }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// The user's current locale as a language tag (language + region), computed from their preferences and the app's supported languages, e.g. 'es-FR'.
+        public let currentLocale: String?
+
+        /// UUID of the application
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case currentLocale = "current_locale"
+            case id = "id"
+        }
+
+        /// Application properties
+        ///
+        /// - Parameters:
+        ///   - currentLocale: The user's current locale as a language tag (language + region), computed from their preferences and the app's supported languages, e.g. 'es-FR'.
+        ///   - id: UUID of the application
+        public init(
+            currentLocale: String? = nil,
+            id: String
+        ) {
+            self.currentLocale = currentLocale
+            self.id = id
+        }
+    }
+
+    /// Display properties
+    public struct Display: Codable {
+        /// The viewport represents the rectangular area that is currently being viewed. Content outside the viewport is not visible onscreen until scrolled into view.
+        public let viewport: Viewport?
+
+        public enum CodingKeys: String, CodingKey {
+            case viewport = "viewport"
+        }
+
+        /// Display properties
+        ///
+        /// - Parameters:
+        ///   - viewport: The viewport represents the rectangular area that is currently being viewed. Content outside the viewport is not visible onscreen until scrolled into view.
+        public init(
+            viewport: Viewport? = nil
+        ) {
+            self.viewport = viewport
+        }
+
+        /// The viewport represents the rectangular area that is currently being viewed. Content outside the viewport is not visible onscreen until scrolled into view.
+        public struct Viewport: Codable {
+            /// Height of the viewport (in pixels)
+            public let height: Double
+
+            /// Width of the viewport (in pixels)
+            public let width: Double
+
+            public enum CodingKeys: String, CodingKey {
+                case height = "height"
+                case width = "width"
+            }
+
+            /// The viewport represents the rectangular area that is currently being viewed. Content outside the viewport is not visible onscreen until scrolled into view.
+            ///
+            /// - Parameters:
+            ///   - height: Height of the viewport (in pixels)
+            ///   - width: Width of the viewport (in pixels)
+            public init(
+                height: Double,
+                width: Double
+            ) {
+                self.height = height
+                self.width = width
+            }
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// Whether this session has a replay
+        public let hasReplay: Bool?
+
+        /// UUID of the session
+        public let id: String
+
+        /// Type of the session
+        public let type: RUMSessionType
+
+        public enum CodingKeys: String, CodingKey {
+            case hasReplay = "has_replay"
+            case id = "id"
+            case type = "type"
+        }
+
+        /// Session properties
+        ///
+        /// - Parameters:
+        ///   - hasReplay: Whether this session has a replay
+        ///   - id: UUID of the session
+        ///   - type: Type of the session
+        public init(
+            hasReplay: Bool? = nil,
+            id: String,
+            type: RUMSessionType
+        ) {
+            self.hasReplay = hasReplay
+            self.id = id
+            self.type = type
+        }
+    }
+
+    /// The source of this event
+    public enum Source: String, Codable {
+        case android = "android"
+        case ios = "ios"
+        case browser = "browser"
+        case flutter = "flutter"
+        case reactNative = "react-native"
+        case roku = "roku"
+        case unity = "unity"
+        case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
+        case cpp = "cpp"
+        case maui = "maui"
+    }
+
+    /// Stream properties
+    public struct Stream: Codable {
+        /// UUID of the stream
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Stream properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the stream
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// CPU timeseries properties
+    public struct Timeseries: Codable {
+        /// Flattened CPU data points
+        public let data: Data
+
+        /// Timestamp of the last sample in nanoseconds from epoch
+        public let end: Int64
+
+        /// UUID of the timeseries batch
+        public let id: String
+
+        /// Name identifying the timeseries metric
+        public let name: String = "cpu"
+
+        /// Wire-shape discriminator for the data field
+        public let schema: String = "object-v2"
+
+        /// Timestamp of the first sample in nanoseconds from epoch
+        public let start: Int64
+
+        public enum CodingKeys: String, CodingKey {
+            case data = "data"
+            case end = "end"
+            case id = "id"
+            case name = "name"
+            case schema = "schema"
+            case start = "start"
+        }
+
+        /// CPU timeseries properties
+        ///
+        /// - Parameters:
+        ///   - data: Flattened CPU data points
+        ///   - end: Timestamp of the last sample in nanoseconds from epoch
+        ///   - id: UUID of the timeseries batch
+        ///   - start: Timestamp of the first sample in nanoseconds from epoch
+        public init(
+            data: Data,
+            end: Int64,
+            id: String,
+            start: Int64
+        ) {
+            self.data = data
+            self.end = end
+            self.id = id
+            self.start = start
+        }
+
+        /// Flattened CPU data points
+        public struct Data: Codable {
+            /// Sample timestamps in nanoseconds from epoch
+            public let timestamps: [Int64]
+
+            /// CPU measurements, aligned index-for-index with timestamps
+            public let values: Values
+
+            public enum CodingKeys: String, CodingKey {
+                case timestamps = "timestamps"
+                case values = "values"
+            }
+
+            /// Flattened CPU data points
+            ///
+            /// - Parameters:
+            ///   - timestamps: Sample timestamps in nanoseconds from epoch
+            ///   - values: CPU measurements, aligned index-for-index with timestamps
+            public init(
+                timestamps: [Int64],
+                values: Values
+            ) {
+                self.timestamps = timestamps
+                self.values = values
+            }
+
+            /// CPU measurements, aligned index-for-index with timestamps
+            public struct Values: Codable {
+                /// CPU usage as a percentage (0.0 to 100.0)
+                public let cpuUsage: [Double]
+
+                public enum CodingKeys: String, CodingKey {
+                    case cpuUsage = "cpu_usage"
+                }
+
+                /// CPU measurements, aligned index-for-index with timestamps
+                ///
+                /// - Parameters:
+                ///   - cpuUsage: CPU usage as a percentage (0.0 to 100.0)
+                public init(
+                    cpuUsage: [Double]
+                ) {
+                    self.cpuUsage = cpuUsage
+                }
+            }
+        }
+    }
+
+    /// View properties
+    public struct View: Codable {
+        /// UUID of the view
+        public let id: String
+
+        /// User defined name of the view
+        public var name: String?
+
+        /// URL that linked to the initial view of the page
+        public var referrer: String?
+
+        /// URL of the view
+        public var url: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+            case name = "name"
+            case referrer = "referrer"
+            case url = "url"
+        }
+
+        /// View properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the view
+        ///   - name: User defined name of the view
+        ///   - referrer: URL that linked to the initial view of the page
+        ///   - url: URL of the view
+        public init(
+            id: String,
+            name: String? = nil,
+            referrer: String? = nil,
+            url: String
+        ) {
+            self.id = id
+            self.name = name
+            self.referrer = referrer
+            self.url = url
+        }
+    }
+}
+
+/// Schema for a memory timeseries event.
+public struct RUMTimeseriesMemoryEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Account properties
+    public var account: RUMAccount?
+
+    /// Application properties
+    public let application: Application
+
+    /// Generated unique ID of the application build. Unlike version or build_version this field is not meant to be coming from the user, but rather generated by the tooling for each build.
+    public let buildId: String?
+
+    /// The build version for this application
+    public let buildVersion: String?
+
+    /// CI Visibility properties
+    public let ciTest: RUMCITest?
+
+    /// Device connectivity properties
+    public let connectivity: RUMConnectivity?
+
+    /// User provided context
+    public var context: RUMEventAttributes?
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// Tags of the event in key:value format, separated by commas (e.g. 'env:prod,version:1.2.3')
+    public let ddtags: String?
+
+    /// Device properties
+    public let device: Device?
+
+    /// Display properties
+    public let display: Display?
+
+    /// Operating system properties
+    public let os: OperatingSystem?
+
+    /// The service name for this application
+    public let service: String?
+
+    /// Session properties
+    public let session: Session
+
+    /// The source of this event
+    public let source: Source?
+
+    /// Stream properties
+    public let stream: Stream?
+
+    /// Synthetics properties
+    public var synthetics: RUMSyntheticsTest?
+
+    /// Tab properties
+    public let tab: TAB?
+
+    /// Memory timeseries properties
+    public let timeseries: Timeseries
+
+    /// RUM event type
+    public let type: String = "timeseries"
+
+    /// User properties
+    public var usr: RUMUser?
+
+    /// The version for this application
+    public let version: String?
+
+    /// View properties
+    public var view: View?
+
+    public enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case account = "account"
+        case application = "application"
+        case buildId = "build_id"
+        case buildVersion = "build_version"
+        case ciTest = "ci_test"
+        case connectivity = "connectivity"
+        case context = "context"
+        case date = "date"
+        case ddtags = "ddtags"
+        case device = "device"
+        case display = "display"
+        case os = "os"
+        case service = "service"
+        case session = "session"
+        case source = "source"
+        case stream = "stream"
+        case synthetics = "synthetics"
+        case tab = "tab"
+        case timeseries = "timeseries"
+        case type = "type"
+        case usr = "usr"
+        case version = "version"
+        case view = "view"
+    }
+
+    /// Schema for a memory timeseries event.
+    ///
+    /// - Parameters:
+    ///   - dd: Internal properties
+    ///   - account: Account properties
+    ///   - application: Application properties
+    ///   - buildId: Generated unique ID of the application build. Unlike version or build_version this field is not meant to be coming from the user, but rather generated by the tooling for each build.
+    ///   - buildVersion: The build version for this application
+    ///   - ciTest: CI Visibility properties
+    ///   - connectivity: Device connectivity properties
+    ///   - context: User provided context
+    ///   - date: Start of the event in ms from epoch
+    ///   - ddtags: Tags of the event in key:value format, separated by commas (e.g. 'env:prod,version:1.2.3')
+    ///   - device: Device properties
+    ///   - display: Display properties
+    ///   - os: Operating system properties
+    ///   - service: The service name for this application
+    ///   - session: Session properties
+    ///   - source: The source of this event
+    ///   - stream: Stream properties
+    ///   - synthetics: Synthetics properties
+    ///   - tab: Tab properties
+    ///   - timeseries: Memory timeseries properties
+    ///   - usr: User properties
+    ///   - version: The version for this application
+    ///   - view: View properties
+    public init(
+        dd: DD,
+        account: RUMAccount? = nil,
+        application: Application,
+        buildId: String? = nil,
+        buildVersion: String? = nil,
+        ciTest: RUMCITest? = nil,
+        connectivity: RUMConnectivity? = nil,
+        context: RUMEventAttributes? = nil,
+        date: Int64,
+        ddtags: String? = nil,
+        device: Device? = nil,
+        display: Display? = nil,
+        os: OperatingSystem? = nil,
+        service: String? = nil,
+        session: Session,
+        source: Source? = nil,
+        stream: Stream? = nil,
+        synthetics: RUMSyntheticsTest? = nil,
+        tab: TAB? = nil,
+        timeseries: Timeseries,
+        usr: RUMUser? = nil,
+        version: String? = nil,
+        view: View? = nil
+    ) {
+        self.dd = dd
+        self.account = account
+        self.application = application
+        self.buildId = buildId
+        self.buildVersion = buildVersion
+        self.ciTest = ciTest
+        self.connectivity = connectivity
+        self.context = context
+        self.date = date
+        self.ddtags = ddtags
+        self.device = device
+        self.display = display
+        self.os = os
+        self.service = service
+        self.session = session
+        self.source = source
+        self.stream = stream
+        self.synthetics = synthetics
+        self.tab = tab
+        self.timeseries = timeseries
+        self.usr = usr
+        self.version = version
+        self.view = view
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
+        /// Subset of the SDK configuration options in use during its execution
+        public let configuration: Configuration?
+
+        /// Version of the RUM event format
+        public let formatVersion: Int64 = 2
+
+        /// SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
+        public let sdkName: String?
+
+        /// Session-related internal properties
+        public let session: Session?
+
+        public enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
+            case configuration = "configuration"
+            case formatVersion = "format_version"
+            case sdkName = "sdk_name"
+            case session = "session"
+        }
+
+        /// Internal properties
+        ///
+        /// - Parameters:
+        ///   - browserSdkVersion: Browser SDK version
+        ///   - configuration: Subset of the SDK configuration options in use during its execution
+        ///   - sdkName: SDK name (e.g. 'logs', 'rum', 'rum-slim', etc.)
+        ///   - session: Session-related internal properties
+        public init(
+            browserSdkVersion: String? = nil,
+            configuration: Configuration? = nil,
+            sdkName: String? = nil,
+            session: Session? = nil
+        ) {
+            self.browserSdkVersion = browserSdkVersion
+            self.configuration = configuration
+            self.sdkName = sdkName
+            self.session = session
+        }
+
+        /// Subset of the SDK configuration options in use during its execution
+        public struct Configuration: Codable {
+            /// The percentage of sessions profiled
+            public let profilingSampleRate: Double?
+
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
+            /// The percentage of sessions with RUM & Session Replay pricing tracked
+            public let sessionReplaySampleRate: Double?
+
+            /// The percentage of sessions tracked
+            public let sessionSampleRate: Double
+
+            /// The percentage of sessions with traced resources
+            public let traceSampleRate: Double?
+
+            public enum CodingKeys: String, CodingKey {
+                case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
+                case sessionReplaySampleRate = "session_replay_sample_rate"
+                case sessionSampleRate = "session_sample_rate"
+                case traceSampleRate = "trace_sample_rate"
+            }
+
+            /// Subset of the SDK configuration options in use during its execution
+            ///
+            /// - Parameters:
+            ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
+            ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
+            ///   - sessionSampleRate: The percentage of sessions tracked
+            ///   - traceSampleRate: The percentage of sessions with traced resources
+            public init(
+                profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
+                sessionReplaySampleRate: Double? = nil,
+                sessionSampleRate: Double,
+                traceSampleRate: Double? = nil
+            ) {
+                self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
+                self.sessionReplaySampleRate = sessionReplaySampleRate
+                self.sessionSampleRate = sessionSampleRate
+                self.traceSampleRate = traceSampleRate
+            }
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
+            public let plan: Plan?
+
+            /// The precondition that led to the creation of the session
+            public let sessionPrecondition: RUMSessionPrecondition?
+
+            public enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+                case sessionPrecondition = "session_precondition"
+            }
+
+            /// Session-related internal properties
+            ///
+            /// - Parameters:
+            ///   - plan: Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
+            ///   - sessionPrecondition: The precondition that led to the creation of the session
+            public init(
+                plan: Plan? = nil,
+                sessionPrecondition: RUMSessionPrecondition? = nil
+            ) {
+                self.plan = plan
+                self.sessionPrecondition = sessionPrecondition
+            }
+
+            /// Session plan: 1 is the plan without replay, 2 is the plan with replay (deprecated)
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
+        }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// The user's current locale as a language tag (language + region), computed from their preferences and the app's supported languages, e.g. 'es-FR'.
+        public let currentLocale: String?
+
+        /// UUID of the application
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case currentLocale = "current_locale"
+            case id = "id"
+        }
+
+        /// Application properties
+        ///
+        /// - Parameters:
+        ///   - currentLocale: The user's current locale as a language tag (language + region), computed from their preferences and the app's supported languages, e.g. 'es-FR'.
+        ///   - id: UUID of the application
+        public init(
+            currentLocale: String? = nil,
+            id: String
+        ) {
+            self.currentLocale = currentLocale
+            self.id = id
+        }
+    }
+
+    /// Display properties
+    public struct Display: Codable {
+        /// The viewport represents the rectangular area that is currently being viewed. Content outside the viewport is not visible onscreen until scrolled into view.
+        public let viewport: Viewport?
+
+        public enum CodingKeys: String, CodingKey {
+            case viewport = "viewport"
+        }
+
+        /// Display properties
+        ///
+        /// - Parameters:
+        ///   - viewport: The viewport represents the rectangular area that is currently being viewed. Content outside the viewport is not visible onscreen until scrolled into view.
+        public init(
+            viewport: Viewport? = nil
+        ) {
+            self.viewport = viewport
+        }
+
+        /// The viewport represents the rectangular area that is currently being viewed. Content outside the viewport is not visible onscreen until scrolled into view.
+        public struct Viewport: Codable {
+            /// Height of the viewport (in pixels)
+            public let height: Double
+
+            /// Width of the viewport (in pixels)
+            public let width: Double
+
+            public enum CodingKeys: String, CodingKey {
+                case height = "height"
+                case width = "width"
+            }
+
+            /// The viewport represents the rectangular area that is currently being viewed. Content outside the viewport is not visible onscreen until scrolled into view.
+            ///
+            /// - Parameters:
+            ///   - height: Height of the viewport (in pixels)
+            ///   - width: Width of the viewport (in pixels)
+            public init(
+                height: Double,
+                width: Double
+            ) {
+                self.height = height
+                self.width = width
+            }
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// Whether this session has a replay
+        public let hasReplay: Bool?
+
+        /// UUID of the session
+        public let id: String
+
+        /// Type of the session
+        public let type: RUMSessionType
+
+        public enum CodingKeys: String, CodingKey {
+            case hasReplay = "has_replay"
+            case id = "id"
+            case type = "type"
+        }
+
+        /// Session properties
+        ///
+        /// - Parameters:
+        ///   - hasReplay: Whether this session has a replay
+        ///   - id: UUID of the session
+        ///   - type: Type of the session
+        public init(
+            hasReplay: Bool? = nil,
+            id: String,
+            type: RUMSessionType
+        ) {
+            self.hasReplay = hasReplay
+            self.id = id
+            self.type = type
+        }
+    }
+
+    /// The source of this event
+    public enum Source: String, Codable {
+        case android = "android"
+        case ios = "ios"
+        case browser = "browser"
+        case flutter = "flutter"
+        case reactNative = "react-native"
+        case roku = "roku"
+        case unity = "unity"
+        case kotlinMultiplatform = "kotlin-multiplatform"
+        case electron = "electron"
+        case cpp = "cpp"
+        case maui = "maui"
+    }
+
+    /// Stream properties
+    public struct Stream: Codable {
+        /// UUID of the stream
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Stream properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the stream
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Tab properties
+    public struct TAB: Codable {
+        /// UUID of the browser tab
+        public let id: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+
+        /// Tab properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the browser tab
+        public init(
+            id: String
+        ) {
+            self.id = id
+        }
+    }
+
+    /// Memory timeseries properties
+    public struct Timeseries: Codable {
+        /// Flattened memory data points
+        public let data: Data
+
+        /// Timestamp of the last sample in nanoseconds from epoch
+        public let end: Int64
+
+        /// UUID of the timeseries batch
+        public let id: String
+
+        /// Name identifying the timeseries metric
+        public let name: String = "memory"
+
+        /// Wire-shape discriminator for the data field
+        public let schema: String = "object-v2"
+
+        /// Timestamp of the first sample in nanoseconds from epoch
+        public let start: Int64
+
+        public enum CodingKeys: String, CodingKey {
+            case data = "data"
+            case end = "end"
+            case id = "id"
+            case name = "name"
+            case schema = "schema"
+            case start = "start"
+        }
+
+        /// Memory timeseries properties
+        ///
+        /// - Parameters:
+        ///   - data: Flattened memory data points
+        ///   - end: Timestamp of the last sample in nanoseconds from epoch
+        ///   - id: UUID of the timeseries batch
+        ///   - start: Timestamp of the first sample in nanoseconds from epoch
+        public init(
+            data: Data,
+            end: Int64,
+            id: String,
+            start: Int64
+        ) {
+            self.data = data
+            self.end = end
+            self.id = id
+            self.start = start
+        }
+
+        /// Flattened memory data points
+        public struct Data: Codable {
+            /// Sample timestamps in nanoseconds from epoch
+            public let timestamps: [Int64]
+
+            /// Memory measurements, aligned index-for-index with timestamps
+            public let values: Values
+
+            public enum CodingKeys: String, CodingKey {
+                case timestamps = "timestamps"
+                case values = "values"
+            }
+
+            /// Flattened memory data points
+            ///
+            /// - Parameters:
+            ///   - timestamps: Sample timestamps in nanoseconds from epoch
+            ///   - values: Memory measurements, aligned index-for-index with timestamps
+            public init(
+                timestamps: [Int64],
+                values: Values
+            ) {
+                self.timestamps = timestamps
+                self.values = values
+            }
+
+            /// Memory measurements, aligned index-for-index with timestamps
+            public struct Values: Codable {
+                /// Physical memory footprint of the process in kilobytes
+                public let memoryFootprint: [Double]
+
+                /// Memory footprint as a percentage of total device RAM
+                public let memoryPercent: [Double]
+
+                public enum CodingKeys: String, CodingKey {
+                    case memoryFootprint = "memory_footprint"
+                    case memoryPercent = "memory_percent"
+                }
+
+                /// Memory measurements, aligned index-for-index with timestamps
+                ///
+                /// - Parameters:
+                ///   - memoryFootprint: Physical memory footprint of the process in kilobytes
+                ///   - memoryPercent: Memory footprint as a percentage of total device RAM
+                public init(
+                    memoryFootprint: [Double],
+                    memoryPercent: [Double]
+                ) {
+                    self.memoryFootprint = memoryFootprint
+                    self.memoryPercent = memoryPercent
+                }
+            }
+        }
+    }
+
+    /// View properties
+    public struct View: Codable {
+        /// UUID of the view
+        public let id: String
+
+        /// User defined name of the view
+        public var name: String?
+
+        /// URL that linked to the initial view of the page
+        public var referrer: String?
+
+        /// URL of the view
+        public var url: String
+
+        public enum CodingKeys: String, CodingKey {
+            case id = "id"
+            case name = "name"
+            case referrer = "referrer"
+            case url = "url"
+        }
+
+        /// View properties
+        ///
+        /// - Parameters:
+        ///   - id: UUID of the view
+        ///   - name: User defined name of the view
+        ///   - referrer: URL that linked to the initial view of the page
+        ///   - url: URL of the view
+        public init(
+            id: String,
+            name: String? = nil,
+            referrer: String? = nil,
+            url: String
+        ) {
+            self.id = id
+            self.name = name
+            self.referrer = referrer
+            self.url = url
+        }
     }
 }
 
@@ -5523,6 +6773,9 @@ public struct RUMViewEvent: RUMDataModel {
             /// The id of the remote configuration applied to the SDK, if any
             public let remoteConfigurationId: String?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -5538,6 +6791,7 @@ public struct RUMViewEvent: RUMDataModel {
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
                 case remoteConfigurationId = "remote_configuration_id"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
@@ -5549,6 +6803,7 @@ public struct RUMViewEvent: RUMDataModel {
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
             ///   - remoteConfigurationId: The id of the remote configuration applied to the SDK, if any
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - startSessionReplayRecordingManually: Whether session replay recording configured to start manually
@@ -5556,6 +6811,7 @@ public struct RUMViewEvent: RUMDataModel {
             public init(
                 profilingSampleRate: Double? = nil,
                 remoteConfigurationId: String? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 startSessionReplayRecordingManually: Bool? = nil,
@@ -5563,6 +6819,7 @@ public struct RUMViewEvent: RUMDataModel {
             ) {
                 self.profilingSampleRate = profilingSampleRate
                 self.remoteConfigurationId = remoteConfigurationId
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.startSessionReplayRecordingManually = startSessionReplayRecordingManually
@@ -5738,7 +6995,7 @@ public struct RUMViewEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -5959,7 +7216,7 @@ public struct RUMViewEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -7690,6 +8947,9 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             /// The id of the remote configuration applied to the SDK, if any
             public let remoteConfigurationId: String?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -7705,6 +8965,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
                 case remoteConfigurationId = "remote_configuration_id"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
@@ -7716,6 +8977,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
             ///   - remoteConfigurationId: The id of the remote configuration applied to the SDK, if any
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - startSessionReplayRecordingManually: Whether session replay recording configured to start manually
@@ -7723,6 +8985,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             public init(
                 profilingSampleRate: Double? = nil,
                 remoteConfigurationId: String? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 startSessionReplayRecordingManually: Bool? = nil,
@@ -7730,6 +8993,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             ) {
                 self.profilingSampleRate = profilingSampleRate
                 self.remoteConfigurationId = remoteConfigurationId
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.startSessionReplayRecordingManually = startSessionReplayRecordingManually
@@ -7905,7 +9169,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -8126,7 +9390,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -9799,6 +11063,9 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -9810,6 +11077,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -9819,16 +11087,19 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -9933,7 +11204,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -10050,7 +11321,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -10461,6 +11732,9 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -10472,6 +11746,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -10481,16 +11756,19 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -10595,7 +11873,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -10712,7 +11990,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -11083,6 +12361,9 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -11094,6 +12375,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -11103,16 +12385,19 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -11217,7 +12502,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             case unity = "unity"
             case kotlinMultiplatform = "kotlin-multiplatform"
             case electron = "electron"
-            case rumCpp = "rum-cpp"
+            case cpp = "cpp"
             case maui = "maui"
         }
 
@@ -11334,7 +12619,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -11677,7 +12962,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -11755,6 +13040,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether the beta encode cookie options is enabled
             public var betaEncodeCookieOptions: Bool?
 
+            /// Whether the beta track WebSockets feature is enabled
+            public var betaTrackWebSockets: Bool?
+
             /// Whether intake requests are compressed
             public let compressIntakeRequests: Bool?
 
@@ -11814,6 +13102,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
 
             /// The version of React used in a ReactNative application
             public var reactVersion: String?
+
+            /// Metadata of the remote configuration currently applied for this session
+            public var remoteConfiguration: RemoteConfiguration?
 
             /// The id of the remote configuration
             public var remoteConfigurationId: String?
@@ -11971,6 +13262,9 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether beforeSend callback function is used
             public let useBeforeSend: Bool?
 
+            /// Whether tracing feature's client-side-stats generation is enabled
+            public let useClientSideStats: Bool?
+
             /// Whether a secure cross-site session cookie is used (deprecated)
             public let useCrossSiteSessionCookie: Bool?
 
@@ -12027,6 +13321,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case batchUploadFrequency = "batch_upload_frequency"
                 case betaEnableViewUpdates = "beta_enable_view_updates"
                 case betaEncodeCookieOptions = "beta_encode_cookie_options"
+                case betaTrackWebSockets = "beta_track_web_sockets"
                 case compressIntakeRequests = "compress_intake_requests"
                 case dartVersion = "dart_version"
                 case defaultPrivacyLevel = "default_privacy_level"
@@ -12047,6 +13342,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case propagateTraceBaggage = "propagate_trace_baggage"
                 case reactNativeVersion = "react_native_version"
                 case reactVersion = "react_version"
+                case remoteConfiguration = "remote_configuration"
                 case remoteConfigurationId = "remote_configuration_id"
                 case replaySampleRate = "replay_sample_rate"
                 case sdkVersion = "sdk_version"
@@ -12099,6 +13395,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case useAllowedTracingUrls = "use_allowed_tracing_urls"
                 case useAllowedTrackingOrigins = "use_allowed_tracking_origins"
                 case useBeforeSend = "use_before_send"
+                case useClientSideStats = "use_client_side_stats"
                 case useCrossSiteSessionCookie = "use_cross_site_session_cookie"
                 case useExcludedActivityUrls = "use_excluded_activity_urls"
                 case useFirstPartyHosts = "use_first_party_hosts"
@@ -12129,6 +13426,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - batchUploadFrequency: The upload frequency of batches (in milliseconds)
             ///   - betaEnableViewUpdates: Whether the beta partial view updates feature is enabled
             ///   - betaEncodeCookieOptions: Whether the beta encode cookie options is enabled
+            ///   - betaTrackWebSockets: Whether the beta track WebSockets feature is enabled
             ///   - compressIntakeRequests: Whether intake requests are compressed
             ///   - dartVersion: The version of Dart used in a Flutter application
             ///   - defaultPrivacyLevel: Session replay default privacy level
@@ -12149,6 +13447,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - propagateTraceBaggage: Whether trace baggage is propagated to child spans
             ///   - reactNativeVersion: The version of ReactNative used in a ReactNative application
             ///   - reactVersion: The version of React used in a ReactNative application
+            ///   - remoteConfiguration: Metadata of the remote configuration currently applied for this session
             ///   - remoteConfigurationId: The id of the remote configuration
             ///   - replaySampleRate: The percentage of sessions with Browser RUM & Session Replay pricing tracked (deprecated in favor of session_replay_sample_rate)
             ///   - sdkVersion: The version of the SDK that is running.
@@ -12201,6 +13500,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             ///   - useAllowedTracingUrls: Whether the allowed tracing urls list is used
             ///   - useAllowedTrackingOrigins: Whether a list of allowed origins is used to control SDK execution in browser extension contexts. When enabled, the SDK will check if the current origin matches the allowed origins list before running.
             ///   - useBeforeSend: Whether beforeSend callback function is used
+            ///   - useClientSideStats: Whether tracing feature's client-side-stats generation is enabled
             ///   - useCrossSiteSessionCookie: Whether a secure cross-site session cookie is used (deprecated)
             ///   - useExcludedActivityUrls: Whether the request origins list to ignore when computing the page activity is used
             ///   - useFirstPartyHosts: Whether the client has provided a list of first party hosts
@@ -12227,6 +13527,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 batchUploadFrequency: Int64? = nil,
                 betaEnableViewUpdates: Bool? = nil,
                 betaEncodeCookieOptions: Bool? = nil,
+                betaTrackWebSockets: Bool? = nil,
                 compressIntakeRequests: Bool? = nil,
                 dartVersion: String? = nil,
                 defaultPrivacyLevel: String? = nil,
@@ -12247,6 +13548,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 propagateTraceBaggage: Bool? = nil,
                 reactNativeVersion: String? = nil,
                 reactVersion: String? = nil,
+                remoteConfiguration: RemoteConfiguration? = nil,
                 remoteConfigurationId: String? = nil,
                 replaySampleRate: Int64? = nil,
                 sdkVersion: String? = nil,
@@ -12299,6 +13601,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 useAllowedTracingUrls: Bool? = nil,
                 useAllowedTrackingOrigins: Bool? = nil,
                 useBeforeSend: Bool? = nil,
+                useClientSideStats: Bool? = nil,
                 useCrossSiteSessionCookie: Bool? = nil,
                 useExcludedActivityUrls: Bool? = nil,
                 useFirstPartyHosts: Bool? = nil,
@@ -12325,6 +13628,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.batchUploadFrequency = batchUploadFrequency
                 self.betaEnableViewUpdates = betaEnableViewUpdates
                 self.betaEncodeCookieOptions = betaEncodeCookieOptions
+                self.betaTrackWebSockets = betaTrackWebSockets
                 self.compressIntakeRequests = compressIntakeRequests
                 self.dartVersion = dartVersion
                 self.defaultPrivacyLevel = defaultPrivacyLevel
@@ -12345,6 +13649,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.propagateTraceBaggage = propagateTraceBaggage
                 self.reactNativeVersion = reactNativeVersion
                 self.reactVersion = reactVersion
+                self.remoteConfiguration = remoteConfiguration
                 self.remoteConfigurationId = remoteConfigurationId
                 self.replaySampleRate = replaySampleRate
                 self.sdkVersion = sdkVersion
@@ -12397,6 +13702,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 self.useAllowedTracingUrls = useAllowedTracingUrls
                 self.useAllowedTrackingOrigins = useAllowedTrackingOrigins
                 self.useBeforeSend = useBeforeSend
+                self.useClientSideStats = useClientSideStats
                 self.useCrossSiteSessionCookie = useCrossSiteSessionCookie
                 self.useExcludedActivityUrls = useExcludedActivityUrls
                 self.useFirstPartyHosts = useFirstPartyHosts
@@ -12518,6 +13824,61 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 ) {
                     self.name = name
                     self.pluginsInfo = pluginsInfo
+                }
+            }
+
+            /// Metadata of the remote configuration currently applied for this session
+            public struct RemoteConfiguration: Codable {
+                /// Identifier of the remote configuration bundle this metadata belongs to
+                public var configId: String?
+
+                /// Timestamp at which this configuration version was first observed as applied by the device, in ms from epoch. Stamped once and reused on every subsequent session that runs on the same version
+                public var firstApplied: Int64?
+
+                /// CDN publish timestamp of the applied configuration, in ms from epoch
+                public var lastModified: Int64?
+
+                /// Timestamp at which the device fetched and cached this configuration version, in ms from epoch
+                public var lastSynced: Int64?
+
+                /// Identifier of the sync that produced this configuration version, used to deduplicate repeat sessions from the same device without a persistent identifier
+                public var syncId: String?
+
+                /// CDN version identifier of the applied configuration
+                public var versionId: String?
+
+                public enum CodingKeys: String, CodingKey {
+                    case configId = "config_id"
+                    case firstApplied = "first_applied"
+                    case lastModified = "last_modified"
+                    case lastSynced = "last_synced"
+                    case syncId = "sync_id"
+                    case versionId = "version_id"
+                }
+
+                /// Metadata of the remote configuration currently applied for this session
+                ///
+                /// - Parameters:
+                ///   - configId: Identifier of the remote configuration bundle this metadata belongs to
+                ///   - firstApplied: Timestamp at which this configuration version was first observed as applied by the device, in ms from epoch. Stamped once and reused on every subsequent session that runs on the same version
+                ///   - lastModified: CDN publish timestamp of the applied configuration, in ms from epoch
+                ///   - lastSynced: Timestamp at which the device fetched and cached this configuration version, in ms from epoch
+                ///   - syncId: Identifier of the sync that produced this configuration version, used to deduplicate repeat sessions from the same device without a persistent identifier
+                ///   - versionId: CDN version identifier of the applied configuration
+                public init(
+                    configId: String? = nil,
+                    firstApplied: Int64? = nil,
+                    lastModified: Int64? = nil,
+                    lastSynced: Int64? = nil,
+                    syncId: String? = nil,
+                    versionId: String? = nil
+                ) {
+                    self.configId = configId
+                    self.firstApplied = firstApplied
+                    self.lastModified = lastModified
+                    self.lastSynced = lastSynced
+                    self.syncId = syncId
+                    self.versionId = versionId
                 }
             }
 
@@ -12838,7 +14199,7 @@ public struct TelemetryDebugEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -13128,7 +14489,7 @@ public struct TelemetryErrorEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -13454,7 +14815,7 @@ public struct TelemetryUsageEvent: RUMDataModel {
         case unity = "unity"
         case kotlinMultiplatform = "kotlin-multiplatform"
         case electron = "electron"
-        case rumCpp = "rum-cpp"
+        case cpp = "cpp"
         case maui = "maui"
     }
 
@@ -14271,4 +15632,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/4ed60cbe47c30afcef051481a035adf88161d4b7
+// Generated from https://github.com/DataDog/rum-events-format/tree/0b3c97fd5f99d5bddb6a4ace637aff6a9d85c833

--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -65,6 +65,43 @@ public struct ConfigurationTelemetry: Equatable {
     public let useSecureSessionCookie: Bool?
     public let useTracing: Bool?
     public let useWorkerUrl: Bool?
+    public let remoteConfiguration: RemoteConfiguration?
+}
+
+extension ConfigurationTelemetry {
+    /// Metadata of the remote configuration currently applied for this session.
+    public struct RemoteConfiguration: Equatable {
+        /// Identifier of the remote configuration bundle this metadata belongs to.
+        public let configId: String?
+        /// CDN version identifier of the applied configuration (`x-amz-version-id` response header).
+        public let versionId: String?
+        /// CDN publish timestamp of the applied configuration (`last-modified` response header).
+        public let lastModified: Date?
+        /// Timestamp at which the device fetched and cached this configuration version.
+        public let lastSynced: Date?
+        /// Timestamp at which this configuration version was first observed as applied by the
+        /// device. Stamped once and reused on every subsequent session that runs on the same version.
+        public let firstApplied: Date?
+        /// Identifier of the sync that produced this configuration version, used to deduplicate
+        /// repeat sessions from the same device without a persistent identifier.
+        public let syncId: String?
+
+        public init(
+            configId: String? = nil,
+            versionId: String? = nil,
+            lastModified: Date? = nil,
+            lastSynced: Date? = nil,
+            firstApplied: Date? = nil,
+            syncId: String? = nil
+        ) {
+            self.configId = configId
+            self.versionId = versionId
+            self.lastModified = lastModified
+            self.lastSynced = lastSynced
+            self.firstApplied = firstApplied
+            self.syncId = syncId
+        }
+    }
 }
 
 /// A telemetry event that can be sampled in addition to the global telemetry sample rate.
@@ -428,7 +465,8 @@ extension Telemetry {
         useProxy: Bool? = nil,
         useSecureSessionCookie: Bool? = nil,
         useTracing: Bool? = nil,
-        useWorkerUrl: Bool? = nil
+        useWorkerUrl: Bool? = nil,
+        remoteConfiguration: ConfigurationTelemetry.RemoteConfiguration? = nil
     ) {
         self.report(configuration: .init(
             actionNameAttribute: actionNameAttribute,
@@ -487,7 +525,8 @@ extension Telemetry {
             useProxy: useProxy,
             useSecureSessionCookie: useSecureSessionCookie,
             useTracing: useTracing,
-            useWorkerUrl: useWorkerUrl
+            useWorkerUrl: useWorkerUrl,
+            remoteConfiguration: remoteConfiguration
         ))
     }
 
@@ -631,7 +670,8 @@ extension ConfigurationTelemetry {
             useProxy: other.useProxy ?? useProxy,
             useSecureSessionCookie: other.useSecureSessionCookie ?? useSecureSessionCookie,
             useTracing: other.useTracing ?? useTracing,
-            useWorkerUrl: other.useWorkerUrl ?? useWorkerUrl
+            useWorkerUrl: other.useWorkerUrl ?? useWorkerUrl,
+            remoteConfiguration: other.remoteConfiguration ?? remoteConfiguration
         )
     }
 }

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -282,6 +282,10 @@ public class objc_RUMActionEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -817,7 +821,7 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -833,7 +837,7 @@ public enum objc_RUMActionEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -847,7 +851,7 @@ public enum objc_RUMActionEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -1111,7 +1115,7 @@ public enum objc_RUMActionEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -1128,7 +1132,7 @@ public enum objc_RUMActionEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -1143,7 +1147,7 @@ public enum objc_RUMActionEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -1462,6 +1466,10 @@ public class objc_RUMErrorEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -1977,7 +1985,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -1993,7 +2001,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -2007,7 +2015,7 @@ public enum objc_RUMErrorEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -3056,7 +3064,7 @@ public enum objc_RUMErrorEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -3073,7 +3081,7 @@ public enum objc_RUMErrorEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -3088,7 +3096,7 @@ public enum objc_RUMErrorEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -3387,6 +3395,10 @@ public class objc_RUMLongTaskEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -3902,7 +3914,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -3918,7 +3930,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -3932,7 +3944,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -4363,7 +4375,7 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -4380,7 +4392,7 @@ public enum objc_RUMLongTaskEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -4395,7 +4407,7 @@ public enum objc_RUMLongTaskEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -4698,6 +4710,10 @@ public class objc_RUMResourceEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -5071,7 +5087,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -5087,7 +5103,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -5101,7 +5117,7 @@ public enum objc_RUMResourceEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -5351,6 +5367,10 @@ public class objc_RUMResourceEventResource: NSObject {
 
     public var id: String? {
         root.swiftModel.resource.id
+    }
+
+    public var localCacheHit: NSNumber? {
+        root.swiftModel.resource.localCacheHit as NSNumber?
     }
 
     public var method: objc_RUMResourceEventResourceRUMMethod {
@@ -6041,7 +6061,7 @@ public enum objc_RUMResourceEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -6058,7 +6078,7 @@ public enum objc_RUMResourceEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -6073,7 +6093,7 @@ public enum objc_RUMResourceEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -6194,6 +6214,1860 @@ public class objc_RUMResourceEventView: NSObject {
     public var url: String {
         set { root.swiftModel.view.url = newValue }
         get { root.swiftModel.view.url }
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEvent)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEvent: NSObject {
+    public internal(set) var swiftModel: RUMTimeseriesCpuEvent
+    internal var root: objc_RUMTimeseriesCpuEvent { self }
+
+    public init(swiftModel: RUMTimeseriesCpuEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    public var dd: objc_RUMTimeseriesCpuEventDD {
+        objc_RUMTimeseriesCpuEventDD(root: root)
+    }
+
+    public var account: objc_RUMTimeseriesCpuEventRUMAccount? {
+        root.swiftModel.account != nil ? objc_RUMTimeseriesCpuEventRUMAccount(root: root) : nil
+    }
+
+    public var application: objc_RUMTimeseriesCpuEventApplication {
+        objc_RUMTimeseriesCpuEventApplication(root: root)
+    }
+
+    public var buildId: String? {
+        root.swiftModel.buildId
+    }
+
+    public var buildVersion: String? {
+        root.swiftModel.buildVersion
+    }
+
+    public var ciTest: objc_RUMTimeseriesCpuEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? objc_RUMTimeseriesCpuEventRUMCITest(root: root) : nil
+    }
+
+    public var connectivity: objc_RUMTimeseriesCpuEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? objc_RUMTimeseriesCpuEventRUMConnectivity(root: root) : nil
+    }
+
+    public var context: objc_RUMTimeseriesCpuEventRUMEventAttributes? {
+        root.swiftModel.context != nil ? objc_RUMTimeseriesCpuEventRUMEventAttributes(root: root) : nil
+    }
+
+    public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    public var ddtags: String? {
+        root.swiftModel.ddtags
+    }
+
+    public var device: objc_RUMTimeseriesCpuEventDevice? {
+        root.swiftModel.device != nil ? objc_RUMTimeseriesCpuEventDevice(root: root) : nil
+    }
+
+    public var display: objc_RUMTimeseriesCpuEventDisplay? {
+        root.swiftModel.display != nil ? objc_RUMTimeseriesCpuEventDisplay(root: root) : nil
+    }
+
+    public var os: objc_RUMTimeseriesCpuEventOperatingSystem? {
+        root.swiftModel.os != nil ? objc_RUMTimeseriesCpuEventOperatingSystem(root: root) : nil
+    }
+
+    public var service: String? {
+        root.swiftModel.service
+    }
+
+    public var session: objc_RUMTimeseriesCpuEventSession {
+        objc_RUMTimeseriesCpuEventSession(root: root)
+    }
+
+    public var source: objc_RUMTimeseriesCpuEventSource {
+        .init(swift: root.swiftModel.source)
+    }
+
+    public var stream: objc_RUMTimeseriesCpuEventStream? {
+        root.swiftModel.stream != nil ? objc_RUMTimeseriesCpuEventStream(root: root) : nil
+    }
+
+    public var synthetics: objc_RUMTimeseriesCpuEventRUMSyntheticsTest? {
+        root.swiftModel.synthetics != nil ? objc_RUMTimeseriesCpuEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMTimeseriesCpuEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMTimeseriesCpuEventTAB(root: root) : nil
+    }
+
+    public var timeseries: objc_RUMTimeseriesCpuEventTimeseries {
+        objc_RUMTimeseriesCpuEventTimeseries(root: root)
+    }
+
+    public var type: String {
+        root.swiftModel.type
+    }
+
+    public var usr: objc_RUMTimeseriesCpuEventRUMUser? {
+        root.swiftModel.usr != nil ? objc_RUMTimeseriesCpuEventRUMUser(root: root) : nil
+    }
+
+    public var version: String? {
+        root.swiftModel.version
+    }
+
+    public var view: objc_RUMTimeseriesCpuEventView? {
+        root.swiftModel.view != nil ? objc_RUMTimeseriesCpuEventView(root: root) : nil
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventDD)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventDD: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
+    }
+
+    public var configuration: objc_RUMTimeseriesCpuEventDDConfiguration? {
+        root.swiftModel.dd.configuration != nil ? objc_RUMTimeseriesCpuEventDDConfiguration(root: root) : nil
+    }
+
+    public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+
+    public var sdkName: String? {
+        root.swiftModel.dd.sdkName
+    }
+
+    public var session: objc_RUMTimeseriesCpuEventDDSession? {
+        root.swiftModel.dd.session != nil ? objc_RUMTimeseriesCpuEventDDSession(root: root) : nil
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventDDConfiguration)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventDDConfiguration: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var profilingSampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
+    public var sessionReplaySampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
+    }
+
+    public var sessionSampleRate: NSNumber {
+        root.swiftModel.dd.configuration!.sessionSampleRate as NSNumber
+    }
+
+    public var traceSampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.traceSampleRate as NSNumber?
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventDDSession)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventDDSession: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var plan: objc_RUMTimeseriesCpuEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+
+    public var sessionPrecondition: objc_RUMTimeseriesCpuEventDDSessionRUMSessionPrecondition {
+        .init(swift: root.swiftModel.dd.session!.sessionPrecondition)
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventDDSessionPlan)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventDDSessionPlan: Int {
+    internal init(swift: RUMTimeseriesCpuEvent.DD.Session.Plan?) {
+        switch swift {
+        case nil: self = .none
+        case .plan1?: self = .plan1
+        case .plan2?: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMTimeseriesCpuEvent.DD.Session.Plan? {
+        switch self {
+        case .none: return nil
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case none
+    case plan1
+    case plan2
+}
+
+@objc(DDRUMTimeseriesCpuEventDDSessionRUMSessionPrecondition)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventDDSessionRUMSessionPrecondition: Int {
+    internal init(swift: RUMSessionPrecondition?) {
+        switch swift {
+        case nil: self = .none
+        case .userAppLaunch?: self = .userAppLaunch
+        case .inactivityTimeout?: self = .inactivityTimeout
+        case .maxDuration?: self = .maxDuration
+        case .backgroundLaunch?: self = .backgroundLaunch
+        case .prewarm?: self = .prewarm
+        case .fromNonInteractiveSession?: self = .fromNonInteractiveSession
+        case .explicitStop?: self = .explicitStop
+        }
+    }
+
+    internal var toSwift: RUMSessionPrecondition? {
+        switch self {
+        case .none: return nil
+        case .userAppLaunch: return .userAppLaunch
+        case .inactivityTimeout: return .inactivityTimeout
+        case .maxDuration: return .maxDuration
+        case .backgroundLaunch: return .backgroundLaunch
+        case .prewarm: return .prewarm
+        case .fromNonInteractiveSession: return .fromNonInteractiveSession
+        case .explicitStop: return .explicitStop
+        }
+    }
+
+    case none
+    case userAppLaunch
+    case inactivityTimeout
+    case maxDuration
+    case backgroundLaunch
+    case prewarm
+    case fromNonInteractiveSession
+    case explicitStop
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMAccount)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventRUMAccount: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.account!.id
+    }
+
+    public var name: String? {
+        root.swiftModel.account!.name
+    }
+
+    public var accountInfo: [String: Any] {
+        set { root.swiftModel.account!.accountInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.account!.accountInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventApplication)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventApplication: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var currentLocale: String? {
+        root.swiftModel.application.currentLocale
+    }
+
+    public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMCITest)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventRUMCITest: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMConnectivity)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventRUMConnectivity: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var cellular: objc_RUMTimeseriesCpuEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? objc_RUMTimeseriesCpuEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    public var effectiveType: objc_RUMTimeseriesCpuEventRUMConnectivityEffectiveType {
+        .init(swift: root.swiftModel.connectivity!.effectiveType)
+    }
+
+    public var interfaces: [Int]? {
+        root.swiftModel.connectivity!.interfaces?.map { objc_RUMTimeseriesCpuEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    public var status: objc_RUMTimeseriesCpuEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMConnectivityCellular)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventRUMConnectivityCellular: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMConnectivityEffectiveType)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventRUMConnectivityEffectiveType: Int {
+    internal init(swift: RUMConnectivity.EffectiveType?) {
+        switch swift {
+        case nil: self = .none
+        case .slow2g?: self = .slow2g
+        case .effectiveType2g?: self = .effectiveType2g
+        case .effectiveType3g?: self = .effectiveType3g
+        case .effectiveType4g?: self = .effectiveType4g
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.EffectiveType? {
+        switch self {
+        case .none: return nil
+        case .slow2g: return .slow2g
+        case .effectiveType2g: return .effectiveType2g
+        case .effectiveType3g: return .effectiveType3g
+        case .effectiveType4g: return .effectiveType4g
+        }
+    }
+
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMConnectivityInterfaces)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces?) {
+        switch swift {
+        case nil: self = .none
+        case .bluetooth?: self = .bluetooth
+        case .cellular?: self = .cellular
+        case .ethernet?: self = .ethernet
+        case .wifi?: self = .wifi
+        case .wimax?: self = .wimax
+        case .mixed?: self = .mixed
+        case .other?: self = .other
+        case .unknown?: self = .unknown
+        case .interfacesNone?: self = .interfacesNone
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces? {
+        switch self {
+        case .none: return nil
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .interfacesNone: return .interfacesNone
+        }
+    }
+
+    case none
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case interfacesNone
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMConnectivityStatus)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMEventAttributes)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventRUMEventAttributes: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var contextInfo: [String: Any] {
+        set { root.swiftModel.context!.contextInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.context!.contextInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventDevice)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventDevice: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var architecture: String? {
+        root.swiftModel.device!.architecture
+    }
+
+    public var batteryLevel: NSNumber? {
+        root.swiftModel.device!.batteryLevel as NSNumber?
+    }
+
+    public var brand: String? {
+        root.swiftModel.device!.brand
+    }
+
+    public var brightnessLevel: NSNumber? {
+        root.swiftModel.device!.brightnessLevel as NSNumber?
+    }
+
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
+    }
+
+    public var locale: String? {
+        root.swiftModel.device!.locale
+    }
+
+    public var locales: [String]? {
+        root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
+    }
+
+    public var model: String? {
+        root.swiftModel.device!.model
+    }
+
+    public var name: String? {
+        root.swiftModel.device!.name
+    }
+
+    public var powerSavingMode: NSNumber? {
+        root.swiftModel.device!.powerSavingMode as NSNumber?
+    }
+
+    public var timeZone: String? {
+        root.swiftModel.device!.timeZone
+    }
+
+    public var totalRam: NSNumber? {
+        root.swiftModel.device!.totalRam as NSNumber?
+    }
+
+    public var type: objc_RUMTimeseriesCpuEventDeviceDeviceType {
+        .init(swift: root.swiftModel.device!.type)
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventDeviceDeviceType)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventDeviceDeviceType: Int {
+    internal init(swift: Device.DeviceType?) {
+        switch swift {
+        case nil: self = .none
+        case .mobile?: self = .mobile
+        case .desktop?: self = .desktop
+        case .tablet?: self = .tablet
+        case .tv?: self = .tv
+        case .gamingConsole?: self = .gamingConsole
+        case .bot?: self = .bot
+        case .other?: self = .other
+        }
+    }
+
+    internal var toSwift: Device.DeviceType? {
+        switch self {
+        case .none: return nil
+        case .mobile: return .mobile
+        case .desktop: return .desktop
+        case .tablet: return .tablet
+        case .tv: return .tv
+        case .gamingConsole: return .gamingConsole
+        case .bot: return .bot
+        case .other: return .other
+        }
+    }
+
+    case none
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
+}
+
+@objc(DDRUMTimeseriesCpuEventDisplay)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventDisplay: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var viewport: objc_RUMTimeseriesCpuEventDisplayViewport? {
+        root.swiftModel.display!.viewport != nil ? objc_RUMTimeseriesCpuEventDisplayViewport(root: root) : nil
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventDisplayViewport)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventDisplayViewport: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var height: NSNumber {
+        root.swiftModel.display!.viewport!.height as NSNumber
+    }
+
+    public var width: NSNumber {
+        root.swiftModel.display!.viewport!.width as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventOperatingSystem)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventOperatingSystem: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var build: String? {
+        root.swiftModel.os!.build
+    }
+
+    public var name: String {
+        root.swiftModel.os!.name
+    }
+
+    public var version: String {
+        root.swiftModel.os!.version
+    }
+
+    public var versionMajor: String {
+        root.swiftModel.os!.versionMajor
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventSession)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventSession: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var hasReplay: NSNumber? {
+        root.swiftModel.session.hasReplay as NSNumber?
+    }
+
+    public var id: String {
+        root.swiftModel.session.id
+    }
+
+    public var type: objc_RUMTimeseriesCpuEventSessionRUMSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventSessionRUMSessionType)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventSessionRUMSessionType: Int {
+    internal init(swift: RUMSessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
+        }
+    }
+
+    internal var toSwift: RUMSessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
+        }
+    }
+
+    case user
+    case synthetics
+    case ciTest
+}
+
+@objc(DDRUMTimeseriesCpuEventSource)
+@_spi(objc)
+public enum objc_RUMTimeseriesCpuEventSource: Int {
+    internal init(swift: RUMTimeseriesCpuEvent.Source?) {
+        switch swift {
+        case nil: self = .none
+        case .android?: self = .android
+        case .ios?: self = .ios
+        case .browser?: self = .browser
+        case .flutter?: self = .flutter
+        case .reactNative?: self = .reactNative
+        case .roku?: self = .roku
+        case .unity?: self = .unity
+        case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
+        case .cpp?: self = .cpp
+        case .maui?: self = .maui
+        }
+    }
+
+    internal var toSwift: RUMTimeseriesCpuEvent.Source? {
+        switch self {
+        case .none: return nil
+        case .android: return .android
+        case .ios: return .ios
+        case .browser: return .browser
+        case .flutter: return .flutter
+        case .reactNative: return .reactNative
+        case .roku: return .roku
+        case .unity: return .unity
+        case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
+        case .cpp: return .cpp
+        case .maui: return .maui
+        }
+    }
+
+    case none
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+    case roku
+    case unity
+    case kotlinMultiplatform
+    case electron
+    case cpp
+    case maui
+}
+
+@objc(DDRUMTimeseriesCpuEventStream)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventStream: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.stream!.id
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMSyntheticsTest)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventRUMSyntheticsTest: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
+    }
+
+    public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
+
+    public var syntheticsInfo: [String: Any] {
+        set { root.swiftModel.synthetics!.syntheticsInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.synthetics!.syntheticsInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventTAB: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventTimeseries)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventTimeseries: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var data: objc_RUMTimeseriesCpuEventTimeseriesData {
+        objc_RUMTimeseriesCpuEventTimeseriesData(root: root)
+    }
+
+    public var end: NSNumber {
+        root.swiftModel.timeseries.end as NSNumber
+    }
+
+    public var id: String {
+        root.swiftModel.timeseries.id
+    }
+
+    public var name: String {
+        root.swiftModel.timeseries.name
+    }
+
+    public var schema: String {
+        root.swiftModel.timeseries.schema
+    }
+
+    public var start: NSNumber {
+        root.swiftModel.timeseries.start as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventTimeseriesData)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventTimeseriesData: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var timestamps: [NSNumber] {
+        root.swiftModel.timeseries.data.timestamps as [NSNumber]
+    }
+
+    public var values: objc_RUMTimeseriesCpuEventTimeseriesDataValues {
+        objc_RUMTimeseriesCpuEventTimeseriesDataValues(root: root)
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventTimeseriesDataValues)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventTimeseriesDataValues: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var cpuUsage: [NSNumber] {
+        root.swiftModel.timeseries.data.values.cpuUsage as [NSNumber]
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventRUMUser)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventRUMUser: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var anonymousId: String? {
+        root.swiftModel.usr!.anonymousId
+    }
+
+    public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    public var name: String? {
+        root.swiftModel.usr!.name
+    }
+
+    public var usrInfo: [String: Any] {
+        set { root.swiftModel.usr!.usrInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.usr!.usrInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMTimeseriesCpuEventView)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesCpuEventView: NSObject {
+    internal let root: objc_RUMTimeseriesCpuEvent
+
+    internal init(root: objc_RUMTimeseriesCpuEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.view!.id
+    }
+
+    public var name: String? {
+        set { root.swiftModel.view!.name = newValue }
+        get { root.swiftModel.view!.name }
+    }
+
+    public var referrer: String? {
+        set { root.swiftModel.view!.referrer = newValue }
+        get { root.swiftModel.view!.referrer }
+    }
+
+    public var url: String {
+        set { root.swiftModel.view!.url = newValue }
+        get { root.swiftModel.view!.url }
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEvent)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEvent: NSObject {
+    public internal(set) var swiftModel: RUMTimeseriesMemoryEvent
+    internal var root: objc_RUMTimeseriesMemoryEvent { self }
+
+    public init(swiftModel: RUMTimeseriesMemoryEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    public var dd: objc_RUMTimeseriesMemoryEventDD {
+        objc_RUMTimeseriesMemoryEventDD(root: root)
+    }
+
+    public var account: objc_RUMTimeseriesMemoryEventRUMAccount? {
+        root.swiftModel.account != nil ? objc_RUMTimeseriesMemoryEventRUMAccount(root: root) : nil
+    }
+
+    public var application: objc_RUMTimeseriesMemoryEventApplication {
+        objc_RUMTimeseriesMemoryEventApplication(root: root)
+    }
+
+    public var buildId: String? {
+        root.swiftModel.buildId
+    }
+
+    public var buildVersion: String? {
+        root.swiftModel.buildVersion
+    }
+
+    public var ciTest: objc_RUMTimeseriesMemoryEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? objc_RUMTimeseriesMemoryEventRUMCITest(root: root) : nil
+    }
+
+    public var connectivity: objc_RUMTimeseriesMemoryEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? objc_RUMTimeseriesMemoryEventRUMConnectivity(root: root) : nil
+    }
+
+    public var context: objc_RUMTimeseriesMemoryEventRUMEventAttributes? {
+        root.swiftModel.context != nil ? objc_RUMTimeseriesMemoryEventRUMEventAttributes(root: root) : nil
+    }
+
+    public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    public var ddtags: String? {
+        root.swiftModel.ddtags
+    }
+
+    public var device: objc_RUMTimeseriesMemoryEventDevice? {
+        root.swiftModel.device != nil ? objc_RUMTimeseriesMemoryEventDevice(root: root) : nil
+    }
+
+    public var display: objc_RUMTimeseriesMemoryEventDisplay? {
+        root.swiftModel.display != nil ? objc_RUMTimeseriesMemoryEventDisplay(root: root) : nil
+    }
+
+    public var os: objc_RUMTimeseriesMemoryEventOperatingSystem? {
+        root.swiftModel.os != nil ? objc_RUMTimeseriesMemoryEventOperatingSystem(root: root) : nil
+    }
+
+    public var service: String? {
+        root.swiftModel.service
+    }
+
+    public var session: objc_RUMTimeseriesMemoryEventSession {
+        objc_RUMTimeseriesMemoryEventSession(root: root)
+    }
+
+    public var source: objc_RUMTimeseriesMemoryEventSource {
+        .init(swift: root.swiftModel.source)
+    }
+
+    public var stream: objc_RUMTimeseriesMemoryEventStream? {
+        root.swiftModel.stream != nil ? objc_RUMTimeseriesMemoryEventStream(root: root) : nil
+    }
+
+    public var synthetics: objc_RUMTimeseriesMemoryEventRUMSyntheticsTest? {
+        root.swiftModel.synthetics != nil ? objc_RUMTimeseriesMemoryEventRUMSyntheticsTest(root: root) : nil
+    }
+
+    public var tab: objc_RUMTimeseriesMemoryEventTAB? {
+        root.swiftModel.tab != nil ? objc_RUMTimeseriesMemoryEventTAB(root: root) : nil
+    }
+
+    public var timeseries: objc_RUMTimeseriesMemoryEventTimeseries {
+        objc_RUMTimeseriesMemoryEventTimeseries(root: root)
+    }
+
+    public var type: String {
+        root.swiftModel.type
+    }
+
+    public var usr: objc_RUMTimeseriesMemoryEventRUMUser? {
+        root.swiftModel.usr != nil ? objc_RUMTimeseriesMemoryEventRUMUser(root: root) : nil
+    }
+
+    public var version: String? {
+        root.swiftModel.version
+    }
+
+    public var view: objc_RUMTimeseriesMemoryEventView? {
+        root.swiftModel.view != nil ? objc_RUMTimeseriesMemoryEventView(root: root) : nil
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventDD)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventDD: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
+    }
+
+    public var configuration: objc_RUMTimeseriesMemoryEventDDConfiguration? {
+        root.swiftModel.dd.configuration != nil ? objc_RUMTimeseriesMemoryEventDDConfiguration(root: root) : nil
+    }
+
+    public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+
+    public var sdkName: String? {
+        root.swiftModel.dd.sdkName
+    }
+
+    public var session: objc_RUMTimeseriesMemoryEventDDSession? {
+        root.swiftModel.dd.session != nil ? objc_RUMTimeseriesMemoryEventDDSession(root: root) : nil
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventDDConfiguration)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventDDConfiguration: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var profilingSampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
+    public var sessionReplaySampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
+    }
+
+    public var sessionSampleRate: NSNumber {
+        root.swiftModel.dd.configuration!.sessionSampleRate as NSNumber
+    }
+
+    public var traceSampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.traceSampleRate as NSNumber?
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventDDSession)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventDDSession: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var plan: objc_RUMTimeseriesMemoryEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+
+    public var sessionPrecondition: objc_RUMTimeseriesMemoryEventDDSessionRUMSessionPrecondition {
+        .init(swift: root.swiftModel.dd.session!.sessionPrecondition)
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventDDSessionPlan)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventDDSessionPlan: Int {
+    internal init(swift: RUMTimeseriesMemoryEvent.DD.Session.Plan?) {
+        switch swift {
+        case nil: self = .none
+        case .plan1?: self = .plan1
+        case .plan2?: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMTimeseriesMemoryEvent.DD.Session.Plan? {
+        switch self {
+        case .none: return nil
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case none
+    case plan1
+    case plan2
+}
+
+@objc(DDRUMTimeseriesMemoryEventDDSessionRUMSessionPrecondition)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventDDSessionRUMSessionPrecondition: Int {
+    internal init(swift: RUMSessionPrecondition?) {
+        switch swift {
+        case nil: self = .none
+        case .userAppLaunch?: self = .userAppLaunch
+        case .inactivityTimeout?: self = .inactivityTimeout
+        case .maxDuration?: self = .maxDuration
+        case .backgroundLaunch?: self = .backgroundLaunch
+        case .prewarm?: self = .prewarm
+        case .fromNonInteractiveSession?: self = .fromNonInteractiveSession
+        case .explicitStop?: self = .explicitStop
+        }
+    }
+
+    internal var toSwift: RUMSessionPrecondition? {
+        switch self {
+        case .none: return nil
+        case .userAppLaunch: return .userAppLaunch
+        case .inactivityTimeout: return .inactivityTimeout
+        case .maxDuration: return .maxDuration
+        case .backgroundLaunch: return .backgroundLaunch
+        case .prewarm: return .prewarm
+        case .fromNonInteractiveSession: return .fromNonInteractiveSession
+        case .explicitStop: return .explicitStop
+        }
+    }
+
+    case none
+    case userAppLaunch
+    case inactivityTimeout
+    case maxDuration
+    case backgroundLaunch
+    case prewarm
+    case fromNonInteractiveSession
+    case explicitStop
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMAccount)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventRUMAccount: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.account!.id
+    }
+
+    public var name: String? {
+        root.swiftModel.account!.name
+    }
+
+    public var accountInfo: [String: Any] {
+        set { root.swiftModel.account!.accountInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.account!.accountInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventApplication)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventApplication: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var currentLocale: String? {
+        root.swiftModel.application.currentLocale
+    }
+
+    public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMCITest)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventRUMCITest: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMConnectivity)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventRUMConnectivity: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var cellular: objc_RUMTimeseriesMemoryEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? objc_RUMTimeseriesMemoryEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    public var effectiveType: objc_RUMTimeseriesMemoryEventRUMConnectivityEffectiveType {
+        .init(swift: root.swiftModel.connectivity!.effectiveType)
+    }
+
+    public var interfaces: [Int]? {
+        root.swiftModel.connectivity!.interfaces?.map { objc_RUMTimeseriesMemoryEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    public var status: objc_RUMTimeseriesMemoryEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMConnectivityCellular)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventRUMConnectivityCellular: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMConnectivityEffectiveType)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventRUMConnectivityEffectiveType: Int {
+    internal init(swift: RUMConnectivity.EffectiveType?) {
+        switch swift {
+        case nil: self = .none
+        case .slow2g?: self = .slow2g
+        case .effectiveType2g?: self = .effectiveType2g
+        case .effectiveType3g?: self = .effectiveType3g
+        case .effectiveType4g?: self = .effectiveType4g
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.EffectiveType? {
+        switch self {
+        case .none: return nil
+        case .slow2g: return .slow2g
+        case .effectiveType2g: return .effectiveType2g
+        case .effectiveType3g: return .effectiveType3g
+        case .effectiveType4g: return .effectiveType4g
+        }
+    }
+
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMConnectivityInterfaces)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces?) {
+        switch swift {
+        case nil: self = .none
+        case .bluetooth?: self = .bluetooth
+        case .cellular?: self = .cellular
+        case .ethernet?: self = .ethernet
+        case .wifi?: self = .wifi
+        case .wimax?: self = .wimax
+        case .mixed?: self = .mixed
+        case .other?: self = .other
+        case .unknown?: self = .unknown
+        case .interfacesNone?: self = .interfacesNone
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces? {
+        switch self {
+        case .none: return nil
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .interfacesNone: return .interfacesNone
+        }
+    }
+
+    case none
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case interfacesNone
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMConnectivityStatus)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMEventAttributes)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventRUMEventAttributes: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var contextInfo: [String: Any] {
+        set { root.swiftModel.context!.contextInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.context!.contextInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventDevice)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventDevice: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var architecture: String? {
+        root.swiftModel.device!.architecture
+    }
+
+    public var batteryLevel: NSNumber? {
+        root.swiftModel.device!.batteryLevel as NSNumber?
+    }
+
+    public var brand: String? {
+        root.swiftModel.device!.brand
+    }
+
+    public var brightnessLevel: NSNumber? {
+        root.swiftModel.device!.brightnessLevel as NSNumber?
+    }
+
+    public var isLowRam: NSNumber? {
+        root.swiftModel.device!.isLowRam as NSNumber?
+    }
+
+    public var locale: String? {
+        root.swiftModel.device!.locale
+    }
+
+    public var locales: [String]? {
+        root.swiftModel.device!.locales
+    }
+
+    public var logicalCpuCount: NSNumber? {
+        root.swiftModel.device!.logicalCpuCount as NSNumber?
+    }
+
+    public var model: String? {
+        root.swiftModel.device!.model
+    }
+
+    public var name: String? {
+        root.swiftModel.device!.name
+    }
+
+    public var powerSavingMode: NSNumber? {
+        root.swiftModel.device!.powerSavingMode as NSNumber?
+    }
+
+    public var timeZone: String? {
+        root.swiftModel.device!.timeZone
+    }
+
+    public var totalRam: NSNumber? {
+        root.swiftModel.device!.totalRam as NSNumber?
+    }
+
+    public var type: objc_RUMTimeseriesMemoryEventDeviceDeviceType {
+        .init(swift: root.swiftModel.device!.type)
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventDeviceDeviceType)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventDeviceDeviceType: Int {
+    internal init(swift: Device.DeviceType?) {
+        switch swift {
+        case nil: self = .none
+        case .mobile?: self = .mobile
+        case .desktop?: self = .desktop
+        case .tablet?: self = .tablet
+        case .tv?: self = .tv
+        case .gamingConsole?: self = .gamingConsole
+        case .bot?: self = .bot
+        case .other?: self = .other
+        }
+    }
+
+    internal var toSwift: Device.DeviceType? {
+        switch self {
+        case .none: return nil
+        case .mobile: return .mobile
+        case .desktop: return .desktop
+        case .tablet: return .tablet
+        case .tv: return .tv
+        case .gamingConsole: return .gamingConsole
+        case .bot: return .bot
+        case .other: return .other
+        }
+    }
+
+    case none
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
+}
+
+@objc(DDRUMTimeseriesMemoryEventDisplay)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventDisplay: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var viewport: objc_RUMTimeseriesMemoryEventDisplayViewport? {
+        root.swiftModel.display!.viewport != nil ? objc_RUMTimeseriesMemoryEventDisplayViewport(root: root) : nil
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventDisplayViewport)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventDisplayViewport: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var height: NSNumber {
+        root.swiftModel.display!.viewport!.height as NSNumber
+    }
+
+    public var width: NSNumber {
+        root.swiftModel.display!.viewport!.width as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventOperatingSystem)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventOperatingSystem: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var build: String? {
+        root.swiftModel.os!.build
+    }
+
+    public var name: String {
+        root.swiftModel.os!.name
+    }
+
+    public var version: String {
+        root.swiftModel.os!.version
+    }
+
+    public var versionMajor: String {
+        root.swiftModel.os!.versionMajor
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventSession)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventSession: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var hasReplay: NSNumber? {
+        root.swiftModel.session.hasReplay as NSNumber?
+    }
+
+    public var id: String {
+        root.swiftModel.session.id
+    }
+
+    public var type: objc_RUMTimeseriesMemoryEventSessionRUMSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventSessionRUMSessionType)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventSessionRUMSessionType: Int {
+    internal init(swift: RUMSessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
+        }
+    }
+
+    internal var toSwift: RUMSessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
+        }
+    }
+
+    case user
+    case synthetics
+    case ciTest
+}
+
+@objc(DDRUMTimeseriesMemoryEventSource)
+@_spi(objc)
+public enum objc_RUMTimeseriesMemoryEventSource: Int {
+    internal init(swift: RUMTimeseriesMemoryEvent.Source?) {
+        switch swift {
+        case nil: self = .none
+        case .android?: self = .android
+        case .ios?: self = .ios
+        case .browser?: self = .browser
+        case .flutter?: self = .flutter
+        case .reactNative?: self = .reactNative
+        case .roku?: self = .roku
+        case .unity?: self = .unity
+        case .kotlinMultiplatform?: self = .kotlinMultiplatform
+        case .electron?: self = .electron
+        case .cpp?: self = .cpp
+        case .maui?: self = .maui
+        }
+    }
+
+    internal var toSwift: RUMTimeseriesMemoryEvent.Source? {
+        switch self {
+        case .none: return nil
+        case .android: return .android
+        case .ios: return .ios
+        case .browser: return .browser
+        case .flutter: return .flutter
+        case .reactNative: return .reactNative
+        case .roku: return .roku
+        case .unity: return .unity
+        case .kotlinMultiplatform: return .kotlinMultiplatform
+        case .electron: return .electron
+        case .cpp: return .cpp
+        case .maui: return .maui
+        }
+    }
+
+    case none
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+    case roku
+    case unity
+    case kotlinMultiplatform
+    case electron
+    case cpp
+    case maui
+}
+
+@objc(DDRUMTimeseriesMemoryEventStream)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventStream: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.stream!.id
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMSyntheticsTest)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventRUMSyntheticsTest: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
+    }
+
+    public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
+
+    public var syntheticsInfo: [String: Any] {
+        set { root.swiftModel.synthetics!.syntheticsInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.synthetics!.syntheticsInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventTAB)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventTAB: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.tab!.id
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventTimeseries)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventTimeseries: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var data: objc_RUMTimeseriesMemoryEventTimeseriesData {
+        objc_RUMTimeseriesMemoryEventTimeseriesData(root: root)
+    }
+
+    public var end: NSNumber {
+        root.swiftModel.timeseries.end as NSNumber
+    }
+
+    public var id: String {
+        root.swiftModel.timeseries.id
+    }
+
+    public var name: String {
+        root.swiftModel.timeseries.name
+    }
+
+    public var schema: String {
+        root.swiftModel.timeseries.schema
+    }
+
+    public var start: NSNumber {
+        root.swiftModel.timeseries.start as NSNumber
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventTimeseriesData)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventTimeseriesData: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var timestamps: [NSNumber] {
+        root.swiftModel.timeseries.data.timestamps as [NSNumber]
+    }
+
+    public var values: objc_RUMTimeseriesMemoryEventTimeseriesDataValues {
+        objc_RUMTimeseriesMemoryEventTimeseriesDataValues(root: root)
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventTimeseriesDataValues)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventTimeseriesDataValues: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var memoryFootprint: [NSNumber] {
+        root.swiftModel.timeseries.data.values.memoryFootprint as [NSNumber]
+    }
+
+    public var memoryPercent: [NSNumber] {
+        root.swiftModel.timeseries.data.values.memoryPercent as [NSNumber]
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventRUMUser)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventRUMUser: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var anonymousId: String? {
+        root.swiftModel.usr!.anonymousId
+    }
+
+    public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    public var name: String? {
+        root.swiftModel.usr!.name
+    }
+
+    public var usrInfo: [String: Any] {
+        set { root.swiftModel.usr!.usrInfo = newValue.dd.swiftAttributes }
+        get { root.swiftModel.usr!.usrInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDRUMTimeseriesMemoryEventView)
+@objcMembers
+@_spi(objc)
+public class objc_RUMTimeseriesMemoryEventView: NSObject {
+    internal let root: objc_RUMTimeseriesMemoryEvent
+
+    internal init(root: objc_RUMTimeseriesMemoryEvent) {
+        self.root = root
+    }
+
+    public var id: String {
+        root.swiftModel.view!.id
+    }
+
+    public var name: String? {
+        set { root.swiftModel.view!.name = newValue }
+        get { root.swiftModel.view!.name }
+    }
+
+    public var referrer: String? {
+        set { root.swiftModel.view!.referrer = newValue }
+        get { root.swiftModel.view!.referrer }
+    }
+
+    public var url: String {
+        set { root.swiftModel.view!.url = newValue }
+        get { root.swiftModel.view!.url }
     }
 }
 
@@ -6395,6 +8269,10 @@ public class objc_RUMViewEventDDConfiguration: NSObject {
 
     public var remoteConfigurationId: String? {
         root.swiftModel.dd.configuration!.remoteConfigurationId
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -6927,7 +8805,7 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -6943,7 +8821,7 @@ public enum objc_RUMViewEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -6957,7 +8835,7 @@ public enum objc_RUMViewEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -7315,7 +9193,7 @@ public enum objc_RUMViewEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -7332,7 +9210,7 @@ public enum objc_RUMViewEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -7347,7 +9225,7 @@ public enum objc_RUMViewEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -8554,6 +10432,10 @@ public class objc_RUMViewUpdateEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.remoteConfigurationId
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -9084,7 +10966,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -9100,7 +10982,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -9114,7 +10996,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -9472,7 +11354,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -9489,7 +11371,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -9504,7 +11386,7 @@ public enum objc_RUMViewUpdateEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -10672,6 +12554,10 @@ public class objc_RUMVitalAppLaunchEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -11125,7 +13011,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -11141,7 +13027,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -11155,7 +13041,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -11419,7 +13305,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -11436,7 +13322,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -11451,7 +13337,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -11826,6 +13712,10 @@ public class objc_RUMVitalDurationEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -12281,7 +14171,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -12297,7 +14187,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -12311,7 +14201,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -12575,7 +14465,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -12592,7 +14482,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -12607,7 +14497,7 @@ public enum objc_RUMVitalDurationEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -12921,6 +14811,10 @@ public class objc_RUMVitalOperationStepEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -13376,7 +15270,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -13392,7 +15286,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -13406,7 +15300,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -13670,7 +15564,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .unity?: self = .unity
         case .kotlinMultiplatform?: self = .kotlinMultiplatform
         case .electron?: self = .electron
-        case .rumCpp?: self = .rumCpp
+        case .cpp?: self = .cpp
         case .maui?: self = .maui
         }
     }
@@ -13687,7 +15581,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -13702,7 +15596,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -14090,7 +15984,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -14105,7 +15999,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -14118,7 +16012,7 @@ public enum objc_TelemetryConfigurationEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -14204,6 +16098,11 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
     public var betaEncodeCookieOptions: NSNumber? {
         set { root.swiftModel.telemetry.configuration.betaEncodeCookieOptions = newValue?.boolValue }
         get { root.swiftModel.telemetry.configuration.betaEncodeCookieOptions as NSNumber? }
+    }
+
+    public var betaTrackWebSockets: NSNumber? {
+        set { root.swiftModel.telemetry.configuration.betaTrackWebSockets = newValue?.boolValue }
+        get { root.swiftModel.telemetry.configuration.betaTrackWebSockets as NSNumber? }
     }
 
     public var compressIntakeRequests: NSNumber? {
@@ -14296,6 +16195,10 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
     public var reactVersion: String? {
         set { root.swiftModel.telemetry.configuration.reactVersion = newValue }
         get { root.swiftModel.telemetry.configuration.reactVersion }
+    }
+
+    public var remoteConfiguration: objc_TelemetryConfigurationEventTelemetryConfigurationRemoteConfiguration? {
+        root.swiftModel.telemetry.configuration.remoteConfiguration != nil ? objc_TelemetryConfigurationEventTelemetryConfigurationRemoteConfiguration(root: root) : nil
     }
 
     public var remoteConfigurationId: String? {
@@ -14540,6 +16443,10 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject {
         root.swiftModel.telemetry.configuration.useBeforeSend as NSNumber?
     }
 
+    public var useClientSideStats: NSNumber? {
+        root.swiftModel.telemetry.configuration.useClientSideStats as NSNumber?
+    }
+
     public var useCrossSiteSessionCookie: NSNumber? {
         root.swiftModel.telemetry.configuration.useCrossSiteSessionCookie as NSNumber?
     }
@@ -14674,6 +16581,47 @@ public class objc_TelemetryConfigurationEventTelemetryConfigurationPlugins: NSOb
     public var pluginsInfo: [String: Any] {
         set { root.swiftModel.pluginsInfo = newValue.dd.swiftAttributes }
         get { root.swiftModel.pluginsInfo.dd.objCAttributes }
+    }
+}
+
+@objc(DDTelemetryConfigurationEventTelemetryConfigurationRemoteConfiguration)
+@objcMembers
+@_spi(objc)
+public class objc_TelemetryConfigurationEventTelemetryConfigurationRemoteConfiguration: NSObject {
+    internal let root: objc_TelemetryConfigurationEvent
+
+    internal init(root: objc_TelemetryConfigurationEvent) {
+        self.root = root
+    }
+
+    public var configId: String? {
+        set { root.swiftModel.telemetry.configuration.remoteConfiguration!.configId = newValue }
+        get { root.swiftModel.telemetry.configuration.remoteConfiguration!.configId }
+    }
+
+    public var firstApplied: NSNumber? {
+        set { root.swiftModel.telemetry.configuration.remoteConfiguration!.firstApplied = newValue?.int64Value }
+        get { root.swiftModel.telemetry.configuration.remoteConfiguration!.firstApplied as NSNumber? }
+    }
+
+    public var lastModified: NSNumber? {
+        set { root.swiftModel.telemetry.configuration.remoteConfiguration!.lastModified = newValue?.int64Value }
+        get { root.swiftModel.telemetry.configuration.remoteConfiguration!.lastModified as NSNumber? }
+    }
+
+    public var lastSynced: NSNumber? {
+        set { root.swiftModel.telemetry.configuration.remoteConfiguration!.lastSynced = newValue?.int64Value }
+        get { root.swiftModel.telemetry.configuration.remoteConfiguration!.lastSynced as NSNumber? }
+    }
+
+    public var syncId: String? {
+        set { root.swiftModel.telemetry.configuration.remoteConfiguration!.syncId = newValue }
+        get { root.swiftModel.telemetry.configuration.remoteConfiguration!.syncId }
+    }
+
+    public var versionId: String? {
+        set { root.swiftModel.telemetry.configuration.remoteConfiguration!.versionId = newValue }
+        get { root.swiftModel.telemetry.configuration.remoteConfiguration!.versionId }
     }
 }
 
@@ -15113,7 +17061,7 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -15128,7 +17076,7 @@ public enum objc_TelemetryDebugEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -15141,7 +17089,7 @@ public enum objc_TelemetryDebugEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -15425,7 +17373,7 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .unity: self = .unity
         case .kotlinMultiplatform: self = .kotlinMultiplatform
         case .electron: self = .electron
-        case .rumCpp: self = .rumCpp
+        case .cpp: self = .cpp
         case .maui: self = .maui
         }
     }
@@ -15440,7 +17388,7 @@ public enum objc_TelemetryErrorEventSource: Int {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }
@@ -15453,7 +17401,7 @@ public enum objc_TelemetryErrorEventSource: Int {
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 }
 
@@ -15591,4 +17539,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/4ed60cbe47c30afcef051481a035adf88161d4b7
+// Generated from https://github.com/DataDog/rum-events-format/tree/0b3c97fd5f99d5bddb6a4ace637aff6a9d85c833

--- a/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModelsMapping.swift
@@ -58,7 +58,7 @@ internal extension RUMViewEvent.Source {
         case .unity: return .unity
         case .kotlinMultiplatform: return .kotlinMultiplatform
         case .electron: return .electron
-        case .rumCpp: return .rumCpp
+        case .cpp: return .cpp
         case .maui: return .maui
         }
     }

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -424,6 +424,7 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             premiumSampleRate: nil,
             reactNativeVersion: nil,
             reactVersion: nil,
+            remoteConfiguration: configuration.remoteConfiguration.map { .init($0) },
             replaySampleRate: nil,
             selectedTracingPropagators: nil,
             sessionPersistence: nil,
@@ -477,6 +478,19 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             useTracing: configuration.useTracing,
             useWorkerUrl: nil,
             viewTrackingStrategy: nil
+        )
+    }
+}
+
+private extension TelemetryConfigurationEvent.Telemetry.Configuration.RemoteConfiguration {
+    init(_ remoteConfiguration: DatadogInternal.ConfigurationTelemetry.RemoteConfiguration) {
+        self.init(
+            configId: remoteConfiguration.configId,
+            firstApplied: remoteConfiguration.firstApplied?.timeIntervalSince1970.dd.toInt64Milliseconds,
+            lastModified: remoteConfiguration.lastModified?.timeIntervalSince1970.dd.toInt64Milliseconds,
+            lastSynced: remoteConfiguration.lastSynced?.timeIntervalSince1970.dd.toInt64Milliseconds,
+            syncId: remoteConfiguration.syncId,
+            versionId: remoteConfiguration.versionId
         )
     }
 }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -430,6 +430,7 @@ public class objc_RUMActionEventDDActionTarget: NSObject
     public var width: NSNumber?
 public class objc_RUMActionEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -536,7 +537,7 @@ public enum objc_RUMActionEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMActionEventContainerView: NSObject
     public var id: String
@@ -595,7 +596,7 @@ public enum objc_RUMActionEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMActionEventStream: NSObject
     public var id: String
@@ -663,6 +664,7 @@ public class objc_RUMErrorEventDD: NSObject
     public var traceId: String?
 public class objc_RUMErrorEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -766,7 +768,7 @@ public enum objc_RUMErrorEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMErrorEventContainerView: NSObject
     public var id: String
@@ -984,7 +986,7 @@ public enum objc_RUMErrorEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMErrorEventStream: NSObject
     public var id: String
@@ -1047,6 +1049,7 @@ public class objc_RUMLongTaskEventDD: NSObject
     public var session: objc_RUMLongTaskEventDDSession?
 public class objc_RUMLongTaskEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -1150,7 +1153,7 @@ public enum objc_RUMLongTaskEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMLongTaskEventContainerView: NSObject
     public var id: String
@@ -1244,7 +1247,7 @@ public enum objc_RUMLongTaskEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMLongTaskEventStream: NSObject
     public var id: String
@@ -1308,6 +1311,7 @@ public class objc_RUMResourceEventDD: NSObject
     public var traceId: String?
 public class objc_RUMResourceEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -1383,7 +1387,7 @@ public enum objc_RUMResourceEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMResourceEventContainerView: NSObject
     public var id: String
@@ -1434,6 +1438,7 @@ public class objc_RUMResourceEventResource: NSObject
     public var firstByte: objc_RUMResourceEventResourceFirstByte?
     public var graphql: objc_RUMResourceEventResourceRUMGraphql?
     public var id: String?
+    public var localCacheHit: NSNumber?
     public var method: objc_RUMResourceEventResourceRUMMethod
     public var `protocol`: String?
     public var provider: objc_RUMResourceEventResourceProvider?
@@ -1573,7 +1578,7 @@ public enum objc_RUMResourceEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMResourceEventStream: NSObject
     public var id: String
@@ -1591,6 +1596,371 @@ public class objc_RUMResourceEventRUMUser: NSObject
     public var name: String?
     public var usrInfo: [String: Any]
 public class objc_RUMResourceEventView: NSObject
+    public var id: String
+    public var name: String?
+    public var referrer: String?
+    public var url: String
+public class objc_RUMTimeseriesCpuEvent: NSObject
+    public internal(set) var swiftModel: RUMTimeseriesCpuEvent
+    public init(swiftModel: RUMTimeseriesCpuEvent)
+    public var dd: objc_RUMTimeseriesCpuEventDD
+    public var account: objc_RUMTimeseriesCpuEventRUMAccount?
+    public var application: objc_RUMTimeseriesCpuEventApplication
+    public var buildId: String?
+    public var buildVersion: String?
+    public var ciTest: objc_RUMTimeseriesCpuEventRUMCITest?
+    public var connectivity: objc_RUMTimeseriesCpuEventRUMConnectivity?
+    public var context: objc_RUMTimeseriesCpuEventRUMEventAttributes?
+    public var date: NSNumber
+    public var ddtags: String?
+    public var device: objc_RUMTimeseriesCpuEventDevice?
+    public var display: objc_RUMTimeseriesCpuEventDisplay?
+    public var os: objc_RUMTimeseriesCpuEventOperatingSystem?
+    public var service: String?
+    public var session: objc_RUMTimeseriesCpuEventSession
+    public var source: objc_RUMTimeseriesCpuEventSource
+    public var stream: objc_RUMTimeseriesCpuEventStream?
+    public var synthetics: objc_RUMTimeseriesCpuEventRUMSyntheticsTest?
+    public var tab: objc_RUMTimeseriesCpuEventTAB?
+    public var timeseries: objc_RUMTimeseriesCpuEventTimeseries
+    public var type: String
+    public var usr: objc_RUMTimeseriesCpuEventRUMUser?
+    public var version: String?
+    public var view: objc_RUMTimeseriesCpuEventView?
+public class objc_RUMTimeseriesCpuEventDD: NSObject
+    public var browserSdkVersion: String?
+    public var configuration: objc_RUMTimeseriesCpuEventDDConfiguration?
+    public var formatVersion: NSNumber
+    public var sdkName: String?
+    public var session: objc_RUMTimeseriesCpuEventDDSession?
+public class objc_RUMTimeseriesCpuEventDDConfiguration: NSObject
+    public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
+    public var sessionReplaySampleRate: NSNumber?
+    public var sessionSampleRate: NSNumber
+    public var traceSampleRate: NSNumber?
+public class objc_RUMTimeseriesCpuEventDDSession: NSObject
+    public var plan: objc_RUMTimeseriesCpuEventDDSessionPlan
+    public var sessionPrecondition: objc_RUMTimeseriesCpuEventDDSessionRUMSessionPrecondition
+public enum objc_RUMTimeseriesCpuEventDDSessionPlan: Int
+    case none
+    case plan1
+    case plan2
+public enum objc_RUMTimeseriesCpuEventDDSessionRUMSessionPrecondition: Int
+    case none
+    case userAppLaunch
+    case inactivityTimeout
+    case maxDuration
+    case backgroundLaunch
+    case prewarm
+    case fromNonInteractiveSession
+    case explicitStop
+public class objc_RUMTimeseriesCpuEventRUMAccount: NSObject
+    public var id: String
+    public var name: String?
+    public var accountInfo: [String: Any]
+public class objc_RUMTimeseriesCpuEventApplication: NSObject
+    public var currentLocale: String?
+    public var id: String
+public class objc_RUMTimeseriesCpuEventRUMCITest: NSObject
+    public var testExecutionId: String
+public class objc_RUMTimeseriesCpuEventRUMConnectivity: NSObject
+    public var cellular: objc_RUMTimeseriesCpuEventRUMConnectivityCellular?
+    public var effectiveType: objc_RUMTimeseriesCpuEventRUMConnectivityEffectiveType
+    public var interfaces: [Int]?
+    public var status: objc_RUMTimeseriesCpuEventRUMConnectivityStatus
+public class objc_RUMTimeseriesCpuEventRUMConnectivityCellular: NSObject
+    public var carrierName: String?
+    public var technology: String?
+public enum objc_RUMTimeseriesCpuEventRUMConnectivityEffectiveType: Int
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+public enum objc_RUMTimeseriesCpuEventRUMConnectivityInterfaces: Int
+    case none
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case interfacesNone
+public enum objc_RUMTimeseriesCpuEventRUMConnectivityStatus: Int
+    case connected
+    case notConnected
+    case maybe
+public class objc_RUMTimeseriesCpuEventRUMEventAttributes: NSObject
+    public var contextInfo: [String: Any]
+public class objc_RUMTimeseriesCpuEventDevice: NSObject
+    public var architecture: String?
+    public var batteryLevel: NSNumber?
+    public var brand: String?
+    public var brightnessLevel: NSNumber?
+    public var isLowRam: NSNumber?
+    public var locale: String?
+    public var locales: [String]?
+    public var logicalCpuCount: NSNumber?
+    public var model: String?
+    public var name: String?
+    public var powerSavingMode: NSNumber?
+    public var timeZone: String?
+    public var totalRam: NSNumber?
+    public var type: objc_RUMTimeseriesCpuEventDeviceDeviceType
+public enum objc_RUMTimeseriesCpuEventDeviceDeviceType: Int
+    case none
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
+public class objc_RUMTimeseriesCpuEventDisplay: NSObject
+    public var viewport: objc_RUMTimeseriesCpuEventDisplayViewport?
+public class objc_RUMTimeseriesCpuEventDisplayViewport: NSObject
+    public var height: NSNumber
+    public var width: NSNumber
+public class objc_RUMTimeseriesCpuEventOperatingSystem: NSObject
+    public var build: String?
+    public var name: String
+    public var version: String
+    public var versionMajor: String
+public class objc_RUMTimeseriesCpuEventSession: NSObject
+    public var hasReplay: NSNumber?
+    public var id: String
+    public var type: objc_RUMTimeseriesCpuEventSessionRUMSessionType
+public enum objc_RUMTimeseriesCpuEventSessionRUMSessionType: Int
+    case user
+    case synthetics
+    case ciTest
+public enum objc_RUMTimeseriesCpuEventSource: Int
+    case none
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+    case roku
+    case unity
+    case kotlinMultiplatform
+    case electron
+    case cpp
+    case maui
+public class objc_RUMTimeseriesCpuEventStream: NSObject
+    public var id: String
+public class objc_RUMTimeseriesCpuEventRUMSyntheticsTest: NSObject
+    public var injected: NSNumber?
+    public var resultId: String
+    public var testId: String
+    public var syntheticsInfo: [String: Any]
+public class objc_RUMTimeseriesCpuEventTAB: NSObject
+    public var id: String
+public class objc_RUMTimeseriesCpuEventTimeseries: NSObject
+    public var data: objc_RUMTimeseriesCpuEventTimeseriesData
+    public var end: NSNumber
+    public var id: String
+    public var name: String
+    public var schema: String
+    public var start: NSNumber
+public class objc_RUMTimeseriesCpuEventTimeseriesData: NSObject
+    public var timestamps: [NSNumber]
+    public var values: objc_RUMTimeseriesCpuEventTimeseriesDataValues
+public class objc_RUMTimeseriesCpuEventTimeseriesDataValues: NSObject
+    public var cpuUsage: [NSNumber]
+public class objc_RUMTimeseriesCpuEventRUMUser: NSObject
+    public var anonymousId: String?
+    public var email: String?
+    public var id: String?
+    public var name: String?
+    public var usrInfo: [String: Any]
+public class objc_RUMTimeseriesCpuEventView: NSObject
+    public var id: String
+    public var name: String?
+    public var referrer: String?
+    public var url: String
+public class objc_RUMTimeseriesMemoryEvent: NSObject
+    public internal(set) var swiftModel: RUMTimeseriesMemoryEvent
+    public init(swiftModel: RUMTimeseriesMemoryEvent)
+    public var dd: objc_RUMTimeseriesMemoryEventDD
+    public var account: objc_RUMTimeseriesMemoryEventRUMAccount?
+    public var application: objc_RUMTimeseriesMemoryEventApplication
+    public var buildId: String?
+    public var buildVersion: String?
+    public var ciTest: objc_RUMTimeseriesMemoryEventRUMCITest?
+    public var connectivity: objc_RUMTimeseriesMemoryEventRUMConnectivity?
+    public var context: objc_RUMTimeseriesMemoryEventRUMEventAttributes?
+    public var date: NSNumber
+    public var ddtags: String?
+    public var device: objc_RUMTimeseriesMemoryEventDevice?
+    public var display: objc_RUMTimeseriesMemoryEventDisplay?
+    public var os: objc_RUMTimeseriesMemoryEventOperatingSystem?
+    public var service: String?
+    public var session: objc_RUMTimeseriesMemoryEventSession
+    public var source: objc_RUMTimeseriesMemoryEventSource
+    public var stream: objc_RUMTimeseriesMemoryEventStream?
+    public var synthetics: objc_RUMTimeseriesMemoryEventRUMSyntheticsTest?
+    public var tab: objc_RUMTimeseriesMemoryEventTAB?
+    public var timeseries: objc_RUMTimeseriesMemoryEventTimeseries
+    public var type: String
+    public var usr: objc_RUMTimeseriesMemoryEventRUMUser?
+    public var version: String?
+    public var view: objc_RUMTimeseriesMemoryEventView?
+public class objc_RUMTimeseriesMemoryEventDD: NSObject
+    public var browserSdkVersion: String?
+    public var configuration: objc_RUMTimeseriesMemoryEventDDConfiguration?
+    public var formatVersion: NSNumber
+    public var sdkName: String?
+    public var session: objc_RUMTimeseriesMemoryEventDDSession?
+public class objc_RUMTimeseriesMemoryEventDDConfiguration: NSObject
+    public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
+    public var sessionReplaySampleRate: NSNumber?
+    public var sessionSampleRate: NSNumber
+    public var traceSampleRate: NSNumber?
+public class objc_RUMTimeseriesMemoryEventDDSession: NSObject
+    public var plan: objc_RUMTimeseriesMemoryEventDDSessionPlan
+    public var sessionPrecondition: objc_RUMTimeseriesMemoryEventDDSessionRUMSessionPrecondition
+public enum objc_RUMTimeseriesMemoryEventDDSessionPlan: Int
+    case none
+    case plan1
+    case plan2
+public enum objc_RUMTimeseriesMemoryEventDDSessionRUMSessionPrecondition: Int
+    case none
+    case userAppLaunch
+    case inactivityTimeout
+    case maxDuration
+    case backgroundLaunch
+    case prewarm
+    case fromNonInteractiveSession
+    case explicitStop
+public class objc_RUMTimeseriesMemoryEventRUMAccount: NSObject
+    public var id: String
+    public var name: String?
+    public var accountInfo: [String: Any]
+public class objc_RUMTimeseriesMemoryEventApplication: NSObject
+    public var currentLocale: String?
+    public var id: String
+public class objc_RUMTimeseriesMemoryEventRUMCITest: NSObject
+    public var testExecutionId: String
+public class objc_RUMTimeseriesMemoryEventRUMConnectivity: NSObject
+    public var cellular: objc_RUMTimeseriesMemoryEventRUMConnectivityCellular?
+    public var effectiveType: objc_RUMTimeseriesMemoryEventRUMConnectivityEffectiveType
+    public var interfaces: [Int]?
+    public var status: objc_RUMTimeseriesMemoryEventRUMConnectivityStatus
+public class objc_RUMTimeseriesMemoryEventRUMConnectivityCellular: NSObject
+    public var carrierName: String?
+    public var technology: String?
+public enum objc_RUMTimeseriesMemoryEventRUMConnectivityEffectiveType: Int
+    case none
+    case slow2g
+    case effectiveType2g
+    case effectiveType3g
+    case effectiveType4g
+public enum objc_RUMTimeseriesMemoryEventRUMConnectivityInterfaces: Int
+    case none
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case interfacesNone
+public enum objc_RUMTimeseriesMemoryEventRUMConnectivityStatus: Int
+    case connected
+    case notConnected
+    case maybe
+public class objc_RUMTimeseriesMemoryEventRUMEventAttributes: NSObject
+    public var contextInfo: [String: Any]
+public class objc_RUMTimeseriesMemoryEventDevice: NSObject
+    public var architecture: String?
+    public var batteryLevel: NSNumber?
+    public var brand: String?
+    public var brightnessLevel: NSNumber?
+    public var isLowRam: NSNumber?
+    public var locale: String?
+    public var locales: [String]?
+    public var logicalCpuCount: NSNumber?
+    public var model: String?
+    public var name: String?
+    public var powerSavingMode: NSNumber?
+    public var timeZone: String?
+    public var totalRam: NSNumber?
+    public var type: objc_RUMTimeseriesMemoryEventDeviceDeviceType
+public enum objc_RUMTimeseriesMemoryEventDeviceDeviceType: Int
+    case none
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
+public class objc_RUMTimeseriesMemoryEventDisplay: NSObject
+    public var viewport: objc_RUMTimeseriesMemoryEventDisplayViewport?
+public class objc_RUMTimeseriesMemoryEventDisplayViewport: NSObject
+    public var height: NSNumber
+    public var width: NSNumber
+public class objc_RUMTimeseriesMemoryEventOperatingSystem: NSObject
+    public var build: String?
+    public var name: String
+    public var version: String
+    public var versionMajor: String
+public class objc_RUMTimeseriesMemoryEventSession: NSObject
+    public var hasReplay: NSNumber?
+    public var id: String
+    public var type: objc_RUMTimeseriesMemoryEventSessionRUMSessionType
+public enum objc_RUMTimeseriesMemoryEventSessionRUMSessionType: Int
+    case user
+    case synthetics
+    case ciTest
+public enum objc_RUMTimeseriesMemoryEventSource: Int
+    case none
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+    case roku
+    case unity
+    case kotlinMultiplatform
+    case electron
+    case cpp
+    case maui
+public class objc_RUMTimeseriesMemoryEventStream: NSObject
+    public var id: String
+public class objc_RUMTimeseriesMemoryEventRUMSyntheticsTest: NSObject
+    public var injected: NSNumber?
+    public var resultId: String
+    public var testId: String
+    public var syntheticsInfo: [String: Any]
+public class objc_RUMTimeseriesMemoryEventTAB: NSObject
+    public var id: String
+public class objc_RUMTimeseriesMemoryEventTimeseries: NSObject
+    public var data: objc_RUMTimeseriesMemoryEventTimeseriesData
+    public var end: NSNumber
+    public var id: String
+    public var name: String
+    public var schema: String
+    public var start: NSNumber
+public class objc_RUMTimeseriesMemoryEventTimeseriesData: NSObject
+    public var timestamps: [NSNumber]
+    public var values: objc_RUMTimeseriesMemoryEventTimeseriesDataValues
+public class objc_RUMTimeseriesMemoryEventTimeseriesDataValues: NSObject
+    public var memoryFootprint: [NSNumber]
+    public var memoryPercent: [NSNumber]
+public class objc_RUMTimeseriesMemoryEventRUMUser: NSObject
+    public var anonymousId: String?
+    public var email: String?
+    public var id: String?
+    public var name: String?
+    public var usrInfo: [String: Any]
+public class objc_RUMTimeseriesMemoryEventView: NSObject
     public var id: String
     public var name: String?
     public var referrer: String?
@@ -1640,6 +2010,7 @@ public class objc_RUMViewEventDDCLS: NSObject
 public class objc_RUMViewEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
     public var remoteConfigurationId: String?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var startSessionReplayRecordingManually: NSNumber?
@@ -1749,7 +2120,7 @@ public enum objc_RUMViewEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMViewEventContainerView: NSObject
     public var id: String
@@ -1824,7 +2195,7 @@ public enum objc_RUMViewEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMViewEventStream: NSObject
     public var bitrate: NSNumber?
@@ -2067,6 +2438,7 @@ public class objc_RUMViewUpdateEventDDCLS: NSObject
 public class objc_RUMViewUpdateEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
     public var remoteConfigurationId: String?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var startSessionReplayRecordingManually: NSNumber?
@@ -2176,7 +2548,7 @@ public enum objc_RUMViewUpdateEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMViewUpdateEventContainerView: NSObject
     public var id: String
@@ -2251,7 +2623,7 @@ public enum objc_RUMViewUpdateEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMViewUpdateEventStream: NSObject
     public var bitrate: NSNumber?
@@ -2486,6 +2858,7 @@ public class objc_RUMVitalAppLaunchEventDD: NSObject
     public var session: objc_RUMVitalAppLaunchEventDDSession?
 public class objc_RUMVitalAppLaunchEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -2581,7 +2954,7 @@ public enum objc_RUMVitalAppLaunchEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMVitalAppLaunchEventContainerView: NSObject
     public var id: String
@@ -2640,7 +3013,7 @@ public enum objc_RUMVitalAppLaunchEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMVitalAppLaunchEventStream: NSObject
     public var id: String
@@ -2716,6 +3089,7 @@ public class objc_RUMVitalDurationEventDD: NSObject
     public var session: objc_RUMVitalDurationEventDDSession?
 public class objc_RUMVitalDurationEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -2811,7 +3185,7 @@ public enum objc_RUMVitalDurationEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMVitalDurationEventContainerView: NSObject
     public var id: String
@@ -2870,7 +3244,7 @@ public enum objc_RUMVitalDurationEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMVitalDurationEventStream: NSObject
     public var id: String
@@ -2935,6 +3309,7 @@ public class objc_RUMVitalOperationStepEventDD: NSObject
     public var session: objc_RUMVitalOperationStepEventDDSession?
 public class objc_RUMVitalOperationStepEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -3030,7 +3405,7 @@ public enum objc_RUMVitalOperationStepEventContainerSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMVitalOperationStepEventContainerView: NSObject
     public var id: String
@@ -3089,7 +3464,7 @@ public enum objc_RUMVitalOperationStepEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_RUMVitalOperationStepEventStream: NSObject
     public var id: String
@@ -3166,7 +3541,7 @@ public enum objc_TelemetryConfigurationEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_TelemetryConfigurationEventTelemetry: NSObject
     public var configuration: objc_TelemetryConfigurationEventTelemetryConfiguration
@@ -3185,6 +3560,7 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject
     public var batchUploadFrequency: NSNumber?
     public var betaEnableViewUpdates: NSNumber?
     public var betaEncodeCookieOptions: NSNumber?
+    public var betaTrackWebSockets: NSNumber?
     public var compressIntakeRequests: NSNumber?
     public var dartVersion: String?
     public var defaultPrivacyLevel: String?
@@ -3205,6 +3581,7 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject
     public var propagateTraceBaggage: NSNumber?
     public var reactNativeVersion: String?
     public var reactVersion: String?
+    public var remoteConfiguration: objc_TelemetryConfigurationEventTelemetryConfigurationRemoteConfiguration?
     public var remoteConfigurationId: String?
     public var replaySampleRate: NSNumber?
     public var sdkVersion: String?
@@ -3257,6 +3634,7 @@ public class objc_TelemetryConfigurationEventTelemetryConfiguration: NSObject
     public var useAllowedTracingUrls: NSNumber?
     public var useAllowedTrackingOrigins: NSNumber?
     public var useBeforeSend: NSNumber?
+    public var useClientSideStats: NSNumber?
     public var useCrossSiteSessionCookie: NSNumber?
     public var useExcludedActivityUrls: NSNumber?
     public var useFirstPartyHosts: NSNumber?
@@ -3281,6 +3659,13 @@ public class objc_TelemetryConfigurationEventTelemetryConfigurationForwardReport
 public class objc_TelemetryConfigurationEventTelemetryConfigurationPlugins: NSObject
     public var name: String
     public var pluginsInfo: [String: Any]
+public class objc_TelemetryConfigurationEventTelemetryConfigurationRemoteConfiguration: NSObject
+    public var configId: String?
+    public var firstApplied: NSNumber?
+    public var lastModified: NSNumber?
+    public var lastSynced: NSNumber?
+    public var syncId: String?
+    public var versionId: String?
 public enum objc_TelemetryConfigurationEventTelemetryConfigurationSelectedTracingPropagators: Int
     case none
     case datadog
@@ -3367,7 +3752,7 @@ public enum objc_TelemetryDebugEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_TelemetryDebugEventTelemetry: NSObject
     public var device: objc_TelemetryDebugEventTelemetryRUMTelemetryDevice?
@@ -3426,7 +3811,7 @@ public enum objc_TelemetryErrorEventSource: Int
     case unity
     case kotlinMultiplatform
     case electron
-    case rumCpp
+    case cpp
     case maui
 public class objc_TelemetryErrorEventTelemetry: NSObject
     public var device: objc_TelemetryErrorEventTelemetryRUMTelemetryDevice?


### PR DESCRIPTION
> [!NOTE]
> Size of the PR is due to schema generated changes 

### What and why?

Attaches remote configuration propagation metadata (config_id, version_id, last_modified, last_synced, first_applied, sync_id) to the SDK's once-per-session configuration telemetry, so we can observe remote config sync and apply behavior in production. This reuses the existing configuration telemetry event rather than adding new metrics, since it's already capped to once per session. See the [RFC - Remote Configuration Parameters](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/6675005886) (internal).

### How?

- Cache, metadata, and configuration are merged into a single `RemoteConfigurationCache` envelope, persisted atomically in one file. A write failure now fails the sync instead of leaving a partial cache behind.
- `RemoteConfigurationProvider` reports sync, decode, and cache errors through `telemetry.error(...)` instead of its completion handler, which is now a plain `(RemoteConfiguration) -> Void`.
- The propagation metadata is reported into `ConfigurationTelemetry.RemoteConfiguration`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs
