### PR TITLE
chore: Guard profile absence telemetry to sampled-in sessions

### DIFF
--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -376,7 +376,9 @@ private extension DatadogProfiler {
     func sendProfile() {
         previousCustomProfilingStartDate = dateProvider.now
         guard let profile = dd_profiler_flush_and_get_profile() else {
-            telemetryController.sendNoProfile(for: operation)
+            if shouldReportProfileAbsence {
+                telemetryController.sendNoProfile(for: operation)
+            }
             cleanUpState()
             return
         }
@@ -389,7 +391,7 @@ private extension DatadogProfiler {
                 hangs: hangs,
                 longTasks: longTasks
             )
-        } else {
+        } else if quotaChecker.isRejectedByQuota || shouldReportProfileAbsence {
             telemetryController.sendProfileDropped(for: operation, reason: profileDropReason)
         }
 
@@ -405,6 +407,12 @@ private extension DatadogProfiler {
 
     var profileDropReason: ProfilingSessionMetric.ProfileDropReason {
         quotaChecker.isRejectedByQuota ? .quotaRejected(quotaChecker.quotaResult?.reason) : .noProfiledEvents
+    }
+
+    // Report only when continuous profiling is actually running.
+    var shouldReportProfileAbsence: Bool {
+        profilingSamplerProvider.isContinuousProfilingConfigured
+            && profilingSamplerProvider.continuousProfilingSampled != false
     }
 
     var canWriteProfile: Bool {


### PR DESCRIPTION
### What and why?

This PR stops sampled-out sessions from emitting useless profiling telemetry. It mainly targets the custom profiling flow which isn't a shipping product and the metrics are just noise.

### How?

It gates `sendNoProfile` and the `noProfiledEvents` drop behind a `shouldReportProfileAbsence` check (continuous configured and not sampled out). Quota rejection and oversized-profile signals still report.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
