### PR TITLE
[FFL-2891] Add configurable Flags initialization deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [IMPROVEMENT] Add an overall initialization deadline to `DatadogFlags`, configurable with `initializationTimeout`.
 - [FEATURE] Add support for UK1 Datadog Site. See [#3087][]
 - [FIX] onSessionStart is now called only after sampling information used by WebView Tracking is in place, avoiding missing traces in early requests. See [#3104][]
 - [FIX] Fix crash when defining `onSessionStart` in RUM configuration in Swift 6 projects. See [#3106][]

--- a/DatadogFlags/Sources/Client/FlagAssignmentsFetcher.swift
+++ b/DatadogFlags/Sources/Client/FlagAssignmentsFetcher.swift
@@ -8,10 +8,11 @@ import Foundation
 import DatadogInternal
 
 internal protocol FlagAssignmentsFetching {
+    @discardableResult
     func flagAssignments(
         for evaluationContext: FlagsEvaluationContext,
         completion: @escaping (Result<[String: FlagAssignment], FlagsError>) -> Void
-    )
+    ) -> () -> Void
 }
 
 internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
@@ -19,7 +20,7 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
     let customHeaders: [String: String]?
 
     private let featureScope: any FeatureScope
-    private let fetch: (URLRequest, @escaping (Result<Data, Error>) -> Void) -> Void
+    private let fetch: (URLRequest, @escaping (Result<Data, Error>) -> Void) -> () -> Void
 
     private static let decoder = JSONDecoder()
 
@@ -45,7 +46,7 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
         customEndpoint: URL?,
         customHeaders: [String: String]?,
         featureScope: any FeatureScope,
-        fetch: @escaping (URLRequest, @escaping (Result<Data, Error>) -> Void) -> Void
+        fetch: @escaping (URLRequest, @escaping (Result<Data, Error>) -> Void) -> () -> Void
     ) {
         self.customEndpoint = customEndpoint
         self.customHeaders = customHeaders
@@ -53,11 +54,16 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
         self.fetch = fetch
     }
 
+    @discardableResult
     func flagAssignments(
         for evaluationContext: FlagsEvaluationContext,
         completion: @escaping (Result<[String: FlagAssignment], FlagsError>) -> Void
-    ) {
+    ) -> () -> Void {
+        let cancellation = Cancellation()
         featureScope.context { [weak self] context in
+            guard !cancellation.isCancelled else {
+                return
+            }
             guard let self else {
                 completion(.failure(.clientNotInitialized))
                 return
@@ -69,7 +75,7 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
                     context: context,
                     customHeaders: self.customHeaders
                 )
-                self.fetch(request) { [featureScope] result in
+                let cancelFetch = self.fetch(request) { [featureScope] result in
                     switch result {
                     case .success(let data):
                         do {
@@ -107,16 +113,59 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
                         completion(.failure(.networkError(error)))
                     }
                 }
+                cancellation.set(cancelFetch)
             } catch let error {
                 DD.logger.error("Failed to encode flag assignments request body.", error: error)
                 featureScope.telemetry.error("Failed to encode flag assignments request body.", error: error)
                 completion(.failure(.invalidConfiguration))
             }
         }
+        return cancellation.cancel
     }
 
     private func url(with context: DatadogContext) -> URL {
         customEndpoint ?? context.site.flagsEndpoint().appendingPathComponent("precompute-assignments")
+    }
+}
+
+private final class Cancellation {
+    private struct State {
+        var isCancelled = false
+        var cancel: (() -> Void)?
+    }
+
+    @ReadWriteLock
+    private var state = State()
+
+    var isCancelled: Bool {
+        state.isCancelled
+    }
+
+    func set(_ cancel: @escaping () -> Void) {
+        var shouldCancel = false
+        _state.mutate { state in
+            if state.isCancelled {
+                shouldCancel = true
+            } else {
+                state.cancel = cancel
+            }
+        }
+        if shouldCancel {
+            cancel()
+        }
+    }
+
+    func cancel() {
+        var cancellation: (() -> Void)?
+        _state.mutate { state in
+            guard !state.isCancelled else {
+                return
+            }
+            state.isCancelled = true
+            cancellation = state.cancel
+            state.cancel = nil
+        }
+        cancellation?()
     }
 }
 
@@ -148,7 +197,7 @@ extension URLSession {
     fileprivate func fetch(
         _ request: URLRequest,
         completion: @escaping (Result<Data, Error>) -> Void
-    ) {
+    ) -> () -> Void {
         let task = self.dataTask(with: request) { data, response, error in
             if let error {
                 completion(.failure(error))
@@ -167,5 +216,6 @@ extension URLSession {
             completion(.success(data))
         }
         task.resume()
+        return task.cancel
     }
 }

--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -185,7 +185,8 @@ public final class FlagsClient {
                 clientName: name,
                 flagAssignmentsFetcher: feature.flagAssignmentsFetcher,
                 dateProvider: SystemDateProvider(),
-                featureScope: featureScope
+                featureScope: featureScope,
+                initializationTimeout: feature.initializationTimeout
             ),
             exposureLogger: feature.makeExposureLogger(featureScope),
             evaluationLogger: feature.makeEvaluationLogger(featureScope),

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -37,6 +37,8 @@ internal final class FlagsRepository {
     private let flagAssignmentsFetcher: any FlagAssignmentsFetching
     private let dateProvider: any DateProvider
     private let featureScope: any FeatureScope
+    private let initializationTimeout: TimeInterval
+    private let timeoutQueue: DispatchQueue
 
     @ReadWriteLock
     private var flagsData: FlagsData?
@@ -54,6 +56,7 @@ internal final class FlagsRepository {
 
     private struct DiskReadState {
         var isComplete = false
+        var shouldIgnoreResult = false
         var pendingCallbacks: [() -> Void] = []
     }
 
@@ -66,12 +69,16 @@ internal final class FlagsRepository {
         clientName: String,
         flagAssignmentsFetcher: any FlagAssignmentsFetching,
         dateProvider: any DateProvider,
-        featureScope: any FeatureScope
+        featureScope: any FeatureScope,
+        initializationTimeout: TimeInterval = 5.0,
+        timeoutQueue: DispatchQueue = .global(qos: .utility)
     ) {
         self.clientName = clientName
         self.flagAssignmentsFetcher = flagAssignmentsFetcher
         self.dateProvider = dateProvider
         self.featureScope = featureScope
+        self.initializationTimeout = initializationTimeout
+        self.timeoutQueue = timeoutQueue
         readState()
     }
 
@@ -88,10 +95,15 @@ internal final class FlagsRepository {
 
             // Mark complete and grab pending callbacks atomically
             var callbacks: [() -> Void] = []
+            var shouldIgnoreResult = false
             self._diskReadState.mutate { state in
+                shouldIgnoreResult = state.shouldIgnoreResult
                 state.isComplete = true
                 callbacks = state.pendingCallbacks
                 state.pendingCallbacks = []
+            }
+            if shouldIgnoreResult {
+                self.flagsData = nil
             }
 
             // Signal semaphore for blocking getters (on elevated queue to avoid priority inversion)
@@ -132,6 +144,17 @@ internal final class FlagsRepository {
         }
     }
 
+    private func ignorePendingFlagsDataRead() -> Bool {
+        var isComplete = false
+        _diskReadState.mutate { state in
+            isComplete = state.isComplete
+            if !state.isComplete {
+                state.shouldIgnoreResult = true
+            }
+        }
+        return isComplete
+    }
+
     private func writeState() {
         guard let flagsData else {
             return
@@ -162,19 +185,52 @@ extension FlagsRepository: FlagsRepositoryProtocol {
         _ context: FlagsEvaluationContext,
         completion: @escaping (Result<Void, FlagsError>) -> Void
     ) {
-        // Chain after disk read completes to ensure correct hadFlags determination
-        whenFlagsDataRead { [weak self] in
+        let operation = InitializationOperation()
+        let timeout = DispatchWorkItem { [weak self, operation] in
+            guard operation.timeOut() else {
+                return
+            }
             guard let self else {
                 completion(.failure(.clientNotInitialized))
                 return
             }
 
-            let hadFlags = self.flagsData != nil
-            let cachedContext = self.flagsData?.context
+            let canUseCachedAssignments = self.ignorePendingFlagsDataRead()
+            self.completeWithFailure(
+                .networkError(URLError(.timedOut)),
+                for: context,
+                canUseCachedAssignments: canUseCachedAssignments,
+                completion: completion
+            )
+        }
+        timeoutQueue.asyncAfter(
+            deadline: .now() + initializationTimeout,
+            execute: timeout
+        )
+
+        // Chain after disk read completes to ensure correct hadFlags determination
+        whenFlagsDataRead { [weak self] in
+            guard let self else {
+                if operation.complete() {
+                    timeout.cancel()
+                    completion(.failure(.clientNotInitialized))
+                }
+                return
+            }
+
+            guard operation.isPending else {
+                return
+            }
+
             let versionAtStart = self.flagsDataVersion
             self.stateManager.updateState(.reconciling)
 
-            self.flagAssignmentsFetcher.flagAssignments(for: context) { [weak self] result in
+            let cancelFetch = self.flagAssignmentsFetcher.flagAssignments(for: context) { [weak self] result in
+                guard operation.complete() else {
+                    return
+                }
+                timeout.cancel()
+
                 switch result {
                 case .success(let flags):
                     guard let self else {
@@ -198,23 +254,33 @@ extension FlagsRepository: FlagsRepositoryProtocol {
                         completion(.failure(error))
                         return
                     }
-                    // State must be updated before calling completion —
-                    // dd-openfeature-provider-swift checks currentState in the callback.
-                    // Only use cached flags if they match the requested context to avoid
-                    // serving flags from a different user/context.
-                    if hadFlags && cachedContext == context {
-                        self?.stateManager.updateState(.stale)
-                    } else {
-                        // Clear cached data to prevent cross-context flag leakage.
-                        // Without this, flagAssignment() could return the previous
-                        // user's flags while in .error state.
-                        self?.flagsData = nil
-                        self?.stateManager.updateState(.error)
-                    }
-                    completion(.failure(error))
+                    self?.completeWithFailure(error, for: context, completion: completion)
                 }
             }
+            operation.setCancellation(cancelFetch)
         }
+    }
+
+    private func completeWithFailure(
+        _ error: FlagsError,
+        for context: FlagsEvaluationContext,
+        canUseCachedAssignments: Bool = true,
+        completion: @escaping (Result<Void, FlagsError>) -> Void
+    ) {
+        // State must be updated before calling completion —
+        // dd-openfeature-provider-swift checks currentState in the callback.
+        // Only use cached flags if they match the requested context to avoid
+        // serving flags from a different user/context.
+        if canUseCachedAssignments && flagsData?.context == context {
+            stateManager.updateState(.stale)
+        } else {
+            // Clear cached data to prevent cross-context flag leakage.
+            // Without this, flagAssignment() could return the previous
+            // user's flags while in .error state.
+            flagsData = nil
+            stateManager.updateState(.error)
+        }
+        completion(.failure(error))
     }
 
     func reset() {
@@ -224,5 +290,64 @@ extension FlagsRepository: FlagsRepositoryProtocol {
         featureScope.flagsDataStore.removeFlagsData(forClientNamed: clientName)
         flagsData = nil
         stateManager.updateState(.notReady)
+    }
+}
+
+private final class InitializationOperation {
+    private struct State {
+        var isComplete = false
+        var shouldCancel = false
+        var cancellation: (() -> Void)?
+    }
+
+    @ReadWriteLock
+    private var state = State()
+
+    var isPending: Bool {
+        !state.isComplete
+    }
+
+    func setCancellation(_ cancellation: @escaping () -> Void) {
+        var shouldCancel = false
+        _state.mutate { state in
+            if state.shouldCancel {
+                shouldCancel = true
+            } else if !state.isComplete {
+                state.cancellation = cancellation
+            }
+        }
+        if shouldCancel {
+            cancellation()
+        }
+    }
+
+    func complete() -> Bool {
+        var didComplete = false
+        _state.mutate { state in
+            guard !state.isComplete else {
+                return
+            }
+            state.isComplete = true
+            state.cancellation = nil
+            didComplete = true
+        }
+        return didComplete
+    }
+
+    func timeOut() -> Bool {
+        var didTimeOut = false
+        var cancellation: (() -> Void)?
+        _state.mutate { state in
+            guard !state.isComplete else {
+                return
+            }
+            state.isComplete = true
+            state.shouldCancel = true
+            cancellation = state.cancellation
+            state.cancellation = nil
+            didTimeOut = true
+        }
+        cancellation?()
+        return didTimeOut
     }
 }

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -11,11 +11,13 @@ internal struct FlagsFeature: DatadogRemoteFeature {
     static let name = "flags"
 
     private enum Constants {
+        static let defaultInitializationTimeout: TimeInterval = 5.0
         static let minEvaluationFlushInterval: TimeInterval = 1.0
         static let maxEvaluationFlushInterval: TimeInterval = 60.0
     }
 
     let flagAssignmentsFetcher: any FlagAssignmentsFetching
+    let initializationTimeout: TimeInterval
     let requestBuilder: any FeatureRequestBuilder
     let messageReceiver: any FeatureMessageReceiver
     let clientRegistry: FlagsClientRegistry
@@ -36,6 +38,15 @@ internal struct FlagsFeature: DatadogRemoteFeature {
             customHeaders: configuration.customFlagsHeaders,
             featureScope: featureScope
         )
+        if configuration.initializationTimeout.isFinite && configuration.initializationTimeout > 0 {
+            initializationTimeout = configuration.initializationTimeout
+        } else {
+            DD.logger.warn(
+                "`Flags.Configuration.initializationTimeout` must be finite and greater than zero. "
+                    + "A value of \(Constants.defaultInitializationTimeout)s will be used."
+            )
+            initializationTimeout = Constants.defaultInitializationTimeout
+        }
         requestBuilder = ExposureRequestBuilder(
             customIntakeURL: configuration.customExposureEndpoint,
             telemetry: featureScope.telemetry

--- a/DatadogFlags/Sources/Flags.swift
+++ b/DatadogFlags/Sources/Flags.swift
@@ -58,6 +58,17 @@ public enum Flags {
         /// Default: `nil`.
         public var customFlagsHeaders: [String: String]?
 
+        /// The maximum amount of time allowed for initializing flag assignments.
+        ///
+        /// This deadline covers loading cached assignments, requesting fresh assignments,
+        /// decoding the response, and updating the client state. When the deadline expires,
+        /// the client uses matching cached assignments if available, or coded defaults otherwise.
+        ///
+        /// Values must be finite and greater than zero. Invalid values use the default.
+        ///
+        /// Default: `5.0` seconds.
+        public var initializationTimeout: TimeInterval
+
         /// Custom server url for sending Flags exposure data.
         ///
         /// Default: `nil`.
@@ -102,6 +113,7 @@ public enum Flags {
         ///   - gracefulModeEnabled: Controls error handling behavior for API misuse. Default: `true`.
         ///   - customFlagsEndpoint: Custom server URL for retrieving flag assignments. Default: `nil`.
         ///   - customFlagsHeaders: Additional HTTP headers for requests to `customFlagsEndpoint`. Default: `nil`.
+        ///   - initializationTimeout: Maximum time allowed for initializing flag assignments. Default: `5.0` seconds.
         ///   - customExposureEndpoint: Custom server URL for sending exposure data. Default: `nil`.
         ///   - trackExposures: Enables exposure logging to the exposures intake endpoint. Default: `true`.
         ///   - customEvaluationEndpoint: Custom server URL for sending evaluation data. Default: `nil`.
@@ -112,6 +124,7 @@ public enum Flags {
             gracefulModeEnabled: Bool = true,
             customFlagsEndpoint: URL? = nil,
             customFlagsHeaders: [String: String]? = nil,
+            initializationTimeout: TimeInterval = 5.0,
             customExposureEndpoint: URL? = nil,
             trackExposures: Bool = true,
             customEvaluationEndpoint: URL? = nil,
@@ -122,6 +135,7 @@ public enum Flags {
             self.gracefulModeEnabled = gracefulModeEnabled
             self.customFlagsEndpoint = customFlagsEndpoint
             self.customFlagsHeaders = customFlagsHeaders
+            self.initializationTimeout = initializationTimeout
             self.customExposureEndpoint = customExposureEndpoint
             self.trackExposures = trackExposures
             self.customEvaluationEndpoint = customEvaluationEndpoint

--- a/DatadogFlags/Tests/Client/FlagAssignmentsFetcherTests.swift
+++ b/DatadogFlags/Tests/Client/FlagAssignmentsFetcherTests.swift
@@ -25,6 +25,7 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
             fetch: { request, completion in
                 capturedRequest = request
                 completion(.success(.mockAnyFlagAssignmentsResponse()))
+                return {}
             }
         )
         let completed = expectation(description: "completed")
@@ -54,6 +55,7 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
             featureScope: featureScope,
             fetch: { _, completion in
                 completion(.failure(URLError(.notConnectedToInternet)))
+                return {}
             }
         )
         let completedWithNetworkError = expectation(description: "completedWithNetworkError")
@@ -79,6 +81,7 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
             featureScope: featureScope,
             fetch: { _, completion in
                 completion(.success(Data()))
+                return {}
             }
         )
         let completedWithInvalidResponseError = expectation(description: "completedWithInvalidResponseError")
@@ -105,6 +108,7 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
             fetch: { request, completion in
                 capturedRequest = request
                 completion(.success(.mockAnyFlagAssignmentsResponse()))
+                return {}
             }
         )
 
@@ -119,6 +123,26 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         waitForExpectations(timeout: 0)
         XCTAssertEqual(capturedRequest?.url, customEndpoint)
         XCTAssertEqual(capturedRequest?.allHTTPHeaderFields?["X-Custom-Header"], "custom-value")
+    }
+
+    func testCancellationCancelsFetch() {
+        // Given
+        let cancelled = expectation(description: "cancelled")
+        let fetcher = FlagAssignmentsFetcher(
+            customEndpoint: nil,
+            customHeaders: [:],
+            featureScope: featureScope,
+            fetch: { _, _ in
+                return { cancelled.fulfill() }
+            }
+        )
+
+        // When
+        let cancel = fetcher.flagAssignments(for: .mockAny()) { _ in }
+        cancel()
+
+        // Then
+        waitForExpectations(timeout: 0)
     }
 
     func testFlagsEndpointForAllSites() {

--- a/DatadogFlags/Tests/Client/FlagsClientMocks.swift
+++ b/DatadogFlags/Tests/Client/FlagsClientMocks.swift
@@ -187,6 +187,7 @@ final class FlagAssignmentsFetcherMock: FlagAssignmentsFetching {
             @escaping (Result<[String: FlagAssignment], FlagsError>) -> Void
         ) -> Void
     )?
+    var cancellation: () -> Void
 
     init(
         flagAssignmentsStub: (
@@ -194,16 +195,20 @@ final class FlagAssignmentsFetcherMock: FlagAssignmentsFetching {
                 FlagsEvaluationContext,
                 @escaping (Result<[String: FlagAssignment], FlagsError>) -> Void
             ) -> Void
-        )? = nil
+        )? = nil,
+        cancellation: @escaping () -> Void = {}
     ) {
         self.flagAssignmentsStub = flagAssignmentsStub
+        self.cancellation = cancellation
     }
 
+    @discardableResult
     func flagAssignments(
         for evaluationContext: FlagsEvaluationContext,
         completion: @escaping (Result<[String: FlagAssignment], FlagsError>) -> Void
-    ) {
+    ) -> () -> Void {
         flagAssignmentsStub?(evaluationContext, completion)
+        return cancellation
     }
 }
 

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -476,4 +476,153 @@ final class FlagsRepositoryTests: XCTestCase {
         waitForExpectations(timeout: 0)
         XCTAssertEqual(stateInCompletion, .error)
     }
+
+    // MARK: - Initialization Deadline
+
+    func testInitializationTimesOutWhileReadingCache() throws {
+        // Given
+        let dataStore = DelayedReadDataStoreMock()
+        let featureScope = FeatureScopeMock(dataStore: dataStore)
+        var didFetchAssignments = false
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, _ in
+                didFetchAssignments = true
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 0
+        )
+        let completed = expectation(description: "completed")
+        var capturedResult: Result<Void, FlagsError>?
+
+        // When
+        flagsRepository.setEvaluationContext(.mockAny()) { result in
+            capturedResult = result
+            completed.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertFalse(didFetchAssignments)
+        XCTAssertEqual(flagsRepository.state.currentState, .error)
+        assertTimedOut(capturedResult)
+
+        // A cache result arriving after the deadline must not become visible.
+        let lateCachedData = FlagsData(
+            flags: ["late": .mockAny()],
+            context: .mockAny(),
+            date: .mockAny()
+        )
+        let encodedData = try JSONEncoder().encode(lateCachedData)
+        dataStore.completeRead(with: .value(encodedData, dataStoreDefaultKeyVersion))
+        XCTAssertNil(flagsRepository.context)
+        XCTAssertNil(flagsRepository.flagAssignment(for: "late"))
+    }
+
+    func testInitializationTimeoutUsesMatchingCachedFlags() throws {
+        // Given
+        let context = FlagsEvaluationContext.mockAny()
+        let cachedData = FlagsData(
+            flags: ["cached": .mockAny()],
+            context: context,
+            date: .mockAny()
+        )
+        try featureScope.dataStoreMock.setValue(
+            JSONEncoder().encode(cachedData),
+            forKey: .mockAny()
+        )
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, _ in },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 0
+        )
+        let completed = expectation(description: "completed")
+        var capturedResult: Result<Void, FlagsError>?
+
+        // When
+        flagsRepository.setEvaluationContext(context) { result in
+            capturedResult = result
+            completed.fulfill()
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(flagsRepository.state.currentState, .stale)
+        XCTAssertNotNil(flagsRepository.flagAssignment(for: "cached"))
+        assertTimedOut(capturedResult)
+    }
+
+    func testInitializationTimeoutCancelsFetchAndIgnoresLateResponse() {
+        // Given
+        var fetchCompletion: ((Result<[String: FlagAssignment], FlagsError>) -> Void)?
+        let cancelled = expectation(description: "cancelled")
+        let fetcher = FlagAssignmentsFetcherMock(
+            flagAssignmentsStub: { _, completion in
+                fetchCompletion = completion
+            },
+            cancellation: {
+                cancelled.fulfill()
+            }
+        )
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: fetcher,
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 0.01
+        )
+        let completed = expectation(description: "completed")
+        var completionCount = 0
+        var capturedResult: Result<Void, FlagsError>?
+
+        // When
+        flagsRepository.setEvaluationContext(.mockAny()) { result in
+            completionCount += 1
+            capturedResult = result
+            completed.fulfill()
+        }
+
+        // Then
+        wait(for: [completed, cancelled], timeout: 1)
+        XCTAssertEqual(flagsRepository.state.currentState, .error)
+        assertTimedOut(capturedResult)
+
+        fetchCompletion?(.success(["late": .mockAny()]))
+        XCTAssertEqual(completionCount, 1)
+        XCTAssertNil(flagsRepository.flagAssignment(for: "late"))
+        XCTAssertEqual(flagsRepository.state.currentState, .error)
+    }
+
+    private func assertTimedOut(
+        _ result: Result<Void, FlagsError>?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .failure(.networkError(let error)) = result,
+              (error as? URLError)?.code == .timedOut else {
+            XCTFail("Expected a timed-out network error", file: file, line: line)
+            return
+        }
+    }
+}
+
+private final class DelayedReadDataStoreMock: DataStore {
+    private var readCallback: ((DataStoreValueResult) -> Void)?
+
+    func setValue(_ value: Data, forKey key: String, version: DataStoreKeyVersion) {}
+
+    func value(forKey key: String, callback: @escaping (DataStoreValueResult) -> Void) {
+        readCallback = callback
+    }
+
+    func removeValue(forKey key: String) {}
+    func clearAllData() {}
+    func flush() {}
+
+    func completeRead(with result: DataStoreValueResult) {
+        readCallback?(result)
+    }
 }

--- a/DatadogFlags/Tests/FlagsTests.swift
+++ b/DatadogFlags/Tests/FlagsTests.swift
@@ -15,6 +15,7 @@ final class FlagsTests: XCTestCase {
 
         // Then
         XCTAssertNil(config.customExposureEndpoint)
+        XCTAssertEqual(config.initializationTimeout, 5.0)
     }
 
     func testWhenNotEnabled() {
@@ -41,6 +42,7 @@ final class FlagsTests: XCTestCase {
         var config = Flags.Configuration()
         config.customFlagsEndpoint = .mockRandom()
         config.customFlagsHeaders = .mockRandom()
+        config.initializationTimeout = 2.5
         config.customExposureEndpoint = .mockRandom()
         let core = FeatureRegistrationCoreMock()
 
@@ -53,7 +55,21 @@ final class FlagsTests: XCTestCase {
         XCTAssertEqual(flags.performanceOverride?.maxObjectsInFile, 50)
         XCTAssertEqual(flagAssignmentFetcher.customEndpoint, config.customFlagsEndpoint)
         XCTAssertEqual(flagAssignmentFetcher.customHeaders, config.customFlagsHeaders)
+        XCTAssertEqual(flags.initializationTimeout, config.initializationTimeout)
         let requestBuilder = try XCTUnwrap(flags.requestBuilder as? ExposureRequestBuilder)
         XCTAssertEqual(requestBuilder.customIntakeURL, config.customExposureEndpoint)
+    }
+
+    func testInvalidInitializationTimeoutUsesDefault() throws {
+        // Given
+        let config = Flags.Configuration(initializationTimeout: 0)
+        let core = FeatureRegistrationCoreMock()
+
+        // When
+        Flags.enable(with: config, in: core)
+
+        // Then
+        let flags = try XCTUnwrap(core.get(feature: FlagsFeature.self))
+        XCTAssertEqual(flags.initializationTimeout, 5.0)
     }
 }

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1602,13 +1602,14 @@ public enum Flags
         public var gracefulModeEnabled: Bool
         public var customFlagsEndpoint: URL?
         public var customFlagsHeaders: [String: String]?
+        public var initializationTimeout: TimeInterval
         public var customExposureEndpoint: URL?
         public var trackExposures: Bool
         public var customEvaluationEndpoint: URL?
         public var trackEvaluations: Bool
         public var evaluationFlushInterval: TimeInterval
         public var rumIntegrationEnabled: Bool
-        public init(gracefulModeEnabled: Bool = true,customFlagsEndpoint: URL? = nil,customFlagsHeaders: [String: String]? = nil,customExposureEndpoint: URL? = nil,trackExposures: Bool = true,customEvaluationEndpoint: URL? = nil,trackEvaluations: Bool = true,evaluationFlushInterval: TimeInterval = 10.0,rumIntegrationEnabled: Bool = true)
+        public init(gracefulModeEnabled: Bool = true,customFlagsEndpoint: URL? = nil,customFlagsHeaders: [String: String]? = nil,initializationTimeout: TimeInterval = 5.0,customExposureEndpoint: URL? = nil,trackExposures: Bool = true,customEvaluationEndpoint: URL? = nil,trackEvaluations: Bool = true,evaluationFlushInterval: TimeInterval = 10.0,rumIntegrationEnabled: Bool = true)
     public static func enable(with configuration: Flags.Configuration = .init(),in core: DatadogCoreProtocol = CoreRegistry.default)
 public enum AnyValue: Equatable, Hashable
     case string(String)


### PR DESCRIPTION
### What and why?

Add a configurable overall deadline for initializing `DatadogFlags` assignments.

The default five-second deadline prevents client initialization from waiting indefinitely when persisted storage or the assignment request stalls. Users can customize it through `Flags.Configuration.initializationTimeout`.

### How?

- Start one deadline before reading cached assignments.
- Apply it across cache loading, assignment fetching, response decoding, and state updates.
- Cancel an in-flight assignment request when the deadline expires.
- Ignore cache and network results arriving after the deadline.
- Continue using matching cached assignments in the stale state; otherwise use coded defaults.
- Validate custom timeout values and fall back to five seconds for non-positive or non-finite values.
- Add coverage for cache delays, request cancellation, late responses, cached fallback, configuration, and API surface.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - N/A; `DatadogFlags` has no Objective-C configuration surface
- [x] Run `make api-surface` when adding new APIs

Validation completed:
- All 117 DatadogFlags tests pass in Swift 5 compatibility mode.
- Lint passes.
- API surface generation passes.

The default Swift 6 test build is currently blocked by an unrelated existing `DatadogTrace` OpenTelemetry `Sendable` compilation issue.
