### PR TITLE
[PANA-8388] Regenerate Session Replay models

### DIFF
--- a/DatadogSessionReplay/Sources/Models/SRDataModels.swift
+++ b/DatadogSessionReplay/Sources/Models/SRDataModels.swift
@@ -3134,4 +3134,4 @@ public enum SRWireframe: Codable {
     }
 }
 #endif
-// Generated from https://github.com/DataDog/rum-events-format/tree/d2f86dff0df3336f9b942f680281bd0b6c4d2788
+// Generated from https://github.com/DataDog/rum-events-format/tree/7cd262a46caa5a3927eda082757eb30673f2b5aa


### PR DESCRIPTION
### What and why?

Regenerates the Session Replay models from `rum-events-format/master` at `7cd262a4`, which includes [rum-events-format#424](https://github.com/DataDog/rum-events-format/pull/424). That change reorders `slotId` in the schema to preserve Android constructor compatibility.

### How?

The Swift output was already correctly ordered, so only the generated schema provenance changed.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
