### PR TITLE
RUM-17879 Tie TimeseriesSessionCollector lifecycle to RUM session lifetime

### DIFF
--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -139,7 +139,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
 
         let sessionSampleRate = configuration.debugSDK ? 100 : configuration.sessionSampleRate
 
-        let timeseriesCollector: TimeseriesSessionCollector? = configuration.enableTimeseries ? TimeseriesSessionCollector(
+        let timeseriesCollector: TimeseriesCollecting? = configuration.enableTimeseries ? TimeseriesSessionCollector(
             memoryReader: VitalMemoryReader(),
             featureScope: featureScope,
             batchSize: configuration.timeseriesBatchSize,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -23,6 +23,10 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
 
     let anonymousIdentifierManager: AnonymousIdentifierManaging
 
+    /// Collects memory/CPU timeseries samples during the RUM session, if enabled. Retained here so it can be
+    /// flushed alongside other instrumentation in `flush()`.
+    private let timeseriesCollector: TimeseriesCollecting?
+
     /// Used by WebViewTracking to obtain the RUM session sampler synchronously.
     @ReadWriteLock
     private(set) var rumSessionSampler: DeterministicSampler?
@@ -135,16 +139,14 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
 
         let sessionSampleRate = configuration.debugSDK ? 100 : configuration.sessionSampleRate
 
-        let timeseriesCollector: TimeseriesSessionCollector? = configuration.enableTimeseries ? vitalsReaders.map {
-            TimeseriesSessionCollector(
-                memoryReader: $0.memory,
-                featureScope: featureScope,
-                batchSize: configuration.timeseriesBatchSize,
-                ciTest: ciTest,
-                syntheticsTest: syntheticsTest,
-                sessionSampleRate: Double(sessionSampleRate)
-            )
-        } : nil
+        let timeseriesCollector: TimeseriesSessionCollector? = configuration.enableTimeseries ? TimeseriesSessionCollector(
+            memoryReader: VitalMemoryReader(),
+            featureScope: featureScope,
+            batchSize: configuration.timeseriesBatchSize,
+            ciTest: ciTest,
+            syntheticsTest: syntheticsTest,
+            sessionSampleRate: Double(sessionSampleRate)
+        ) : nil
 
         let dependencies = RUMScopeDependencies(
             featureScope: featureScope,
@@ -222,6 +224,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         )
 
         timeseriesCollector?.activeContextReader = monitor
+        self.timeseriesCollector = timeseriesCollector
 
         if let refreshRateVital = dependencies.vitalsReaders?.refreshRate as? RenderLoopReader {
             dependencies.renderLoopObserver?.register(refreshRateVital)
@@ -421,6 +424,7 @@ extension RUMFeature: Flushable {
     /// **blocks the caller thread**
     func flush() {
         instrumentation.appHangs?.flush()
+        timeseriesCollector?.flush()
     }
 }
 

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -225,7 +225,6 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         )
 
         timeseriesCollector?.activeContextReader = monitor
-        timeseriesCollector?.sessionActivityReader = monitor
         self.timeseriesCollector = timeseriesCollector
 
         if let refreshRateVital = dependencies.vitalsReaders?.refreshRate as? RenderLoopReader {

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -225,6 +225,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         )
 
         timeseriesCollector?.activeContextReader = monitor
+        timeseriesCollector?.sessionActivityReader = monitor
         self.timeseriesCollector = timeseriesCollector
 
         if let refreshRateVital = dependencies.vitalsReaders?.refreshRate as? RenderLoopReader {

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -145,7 +145,8 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             batchSize: configuration.timeseriesBatchSize,
             ciTest: ciTest,
             syntheticsTest: syntheticsTest,
-            sessionSampleRate: Double(sessionSampleRate)
+            sessionSampleRate: Double(sessionSampleRate),
+            now: { configuration.dateProvider.now }
         ) : nil
 
         let dependencies = RUMScopeDependencies(

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -571,7 +571,6 @@ extension RUM.Configuration {
     ///   - trackSlowFrames: Enables the collection of slow frames (view hitches). Default: `true`.
     ///   - telemetrySampleRate: The sampling rate for SDK internal telemetry utilized by Datadog. Must be a value between `0` and `100`. Default: `20`.
     ///   - collectAccessibility: Determines whether accessibility data should be collected and included in RUM view events. Default: `false`.
-    ///   - enableTimeseries: Enables collection of memory and CPU timeseries events. Default: `false`.
     ///   - timeseriesBatchSize: The number of samples collected before a timeseries batch is flushed. Default: `120`.
     ///   - featureFlags: Experimental feature flags.
     /// 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -331,7 +331,7 @@ extension RUM {
         /// Enables collection of memory and CPU timeseries events.
         ///
         /// When enabled, memory footprint and CPU usage are sampled every second and uploaded as
-        /// timeseries events scoped to the RUM session. Requires `vitalsUpdateFrequency` to be set.
+        /// timeseries events scoped to the RUM session.
         ///
         /// Default: `false`.
         @_spi(Experimental)

--- a/DatadogRUM/Sources/RUMEvent/RUMEventSanitizer.swift
+++ b/DatadogRUM/Sources/RUMEvent/RUMEventSanitizer.swift
@@ -91,3 +91,7 @@ extension RUMResourceEvent: RUMSanitizableEvent {}
 extension RUMErrorEvent: RUMSanitizableEvent {}
 
 extension RUMLongTaskEvent: RUMSanitizableEvent {}
+
+extension RUMTimeseriesMemoryEvent: RUMSanitizableEvent {}
+
+extension RUMTimeseriesCpuEvent: RUMSanitizableEvent {}

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -107,6 +107,15 @@ internal protocol RUMActiveContextReader: AnyObject {
     var activeView: (id: String?, path: String?, name: String?) { get }
 }
 
+/// Exposes the active session's lifetime state for readers that operate outside the `RUMCommand` pipeline
+/// (e.g. the timer-driven `TimeseriesSessionCollector`), so they can evaluate `RUMSessionScope`'s own
+/// expiry rules against a live, single source of truth instead of maintaining a shadow copy of that state.
+internal protocol RUMSessionActivityReader: AnyObject {
+    /// The active session's ID, start time, and time of last RUM interaction, or `nil` values if there is
+    /// no active session. Safe to read from any thread.
+    var sessionActivity: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?) { get }
+}
+
 internal class Monitor: RUMCommandSubscriber {
     /// RUM feature scope.
     let featureScope: FeatureScope
@@ -121,6 +130,9 @@ internal class Monitor: RUMCommandSubscriber {
 
     @ReadWriteLock
     private var activeViewSnapshot: (id: String?, path: String?, name: String?) = (nil, nil, nil)
+
+    @ReadWriteLock
+    private var sessionActivitySnapshot: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?) = (nil, nil, nil)
 
     private let fatalErrorContext: FatalErrorContextNotifying
     private let rumUUIDGenerator: RUMUUIDGenerator
@@ -162,8 +174,14 @@ internal class Monitor: RUMCommandSubscriber {
                     path: viewContext.activeViewPath,
                     name: viewContext.activeViewName
                 )
+                self.sessionActivitySnapshot = (
+                    sessionID: activeSession.sessionUUID.toRUMDataFormat,
+                    sessionStartTime: activeSession.sessionStartTime,
+                    lastInteractionTime: activeSession.lastInteractionTime
+                )
             } else {
                 self.activeViewSnapshot = (nil, nil, nil)
+                self.sessionActivitySnapshot = (nil, nil, nil)
             }
         }
 
@@ -221,6 +239,10 @@ internal class Monitor: RUMCommandSubscriber {
 extension Monitor: RUMActiveContextReader {
     var globalAttributes: [AttributeKey: AttributeValue] { attributes }
     var activeView: (id: String?, path: String?, name: String?) { activeViewSnapshot }
+}
+
+extension Monitor: RUMSessionActivityReader {
+    var sessionActivity: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?) { sessionActivitySnapshot }
 }
 
 /// Declares `Monitor` conformance to public `RUMMonitorProtocol`.

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -98,22 +98,20 @@ internal typealias RUMErrorCategory = RUMErrorEvent.Error.Category
 
 /// Exposes monitor state for readers that operate outside the `RUMCommand` pipeline
 /// (e.g. the timer-driven `TimeseriesSessionCollector`), which otherwise have no access to
-/// `command.globalAttributes` or the scope tree's active view.
+/// `command.globalAttributes`, the scope tree's active view, or `RUMSessionScope`'s own session
+/// lifetime rules.
 internal protocol RUMActiveContextReader: AnyObject {
     /// The current global attributes set through `addAttribute(forKey:value:)` / `addAttributes(_:)`.
-    /// Safe to read from any thread.
+    /// Conformers must guarantee this is safe to read from any thread.
     var globalAttributes: [AttributeKey: AttributeValue] { get }
-    /// The currently active view, if any. Safe to read from any thread.
+    /// The currently active view, if any. Conformers must guarantee this is safe to read from any thread.
     var activeView: (id: String?, path: String?, name: String?) { get }
-}
-
-/// Exposes the active session's lifetime state for readers that operate outside the `RUMCommand` pipeline
-/// (e.g. the timer-driven `TimeseriesSessionCollector`), so they can evaluate `RUMSessionScope`'s own
-/// expiry rules against a live, single source of truth instead of maintaining a shadow copy of that state.
-internal protocol RUMSessionActivityReader: AnyObject {
-    /// The active session's ID, start time, and time of last RUM interaction, or `nil` values if there is
-    /// no active session. Safe to read from any thread.
-    var sessionActivity: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?) { get }
+    /// Whether the session identified by `sessionID` has expired (exceeded its max duration or inactivity
+    /// timeout) as of `date`, evaluated against a live, single source of truth instead of a shadow copy of
+    /// that state. Returns `false` if `sessionID` doesn't match the currently active session (e.g. a session
+    /// transition is still propagating), so callers should treat that as "skip the check for now", not
+    /// "not expired". Conformers must guarantee this is safe to call from any thread.
+    func isSessionExpired(sessionID: String, at date: Date) -> Bool
 }
 
 internal class Monitor: RUMCommandSubscriber {
@@ -239,10 +237,17 @@ internal class Monitor: RUMCommandSubscriber {
 extension Monitor: RUMActiveContextReader {
     var globalAttributes: [AttributeKey: AttributeValue] { attributes }
     var activeView: (id: String?, path: String?, name: String?) { activeViewSnapshot }
-}
 
-extension Monitor: RUMSessionActivityReader {
-    var sessionActivity: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?) { sessionActivitySnapshot }
+    func isSessionExpired(sessionID: String, at date: Date) -> Bool {
+        let activity = sessionActivitySnapshot
+        guard activity.sessionID == sessionID,
+              let sessionStartTime = activity.sessionStartTime,
+              let lastInteractionTime = activity.lastInteractionTime else {
+            return false
+        }
+        return RUMSessionScope.hasExpired(sessionStartTime: sessionStartTime, currentTime: date)
+            || RUMSessionScope.hasTimedOut(lastInteractionTime: lastInteractionTime, currentTime: date)
+    }
 }
 
 /// Declares `Monitor` conformance to public `RUMMonitorProtocol`.

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -156,7 +156,7 @@ internal class Monitor: RUMCommandSubscriber {
             }
 
             if let activeSession = self.applicationScope.activeSession {
-                let viewContext = activeSession.viewScopes.last?.context ?? activeSession.context
+                let viewContext = activeSession.viewScopes.last(where: { $0.isActiveView })?.context ?? activeSession.context
                 self.activeViewSnapshot = (
                     id: viewContext.activeViewID?.toRUMDataFormat,
                     path: viewContext.activeViewPath,
@@ -178,7 +178,8 @@ internal class Monitor: RUMCommandSubscriber {
                     return nil
                 }
 
-                let context = activeSession.viewScopes.last?.context ?? activeSession.context
+                let activeViewScope = activeSession.viewScopes.last(where: { $0.isActiveView })
+                let context = activeViewScope?.context ?? activeSession.context
 
                 return RUMCoreContext(
                     applicationID: context.rumApplicationID,
@@ -186,7 +187,7 @@ internal class Monitor: RUMCommandSubscriber {
                     sessionSampler: activeSession.sampler,
                     viewID: context.activeViewID?.toRUMDataFormat,
                     userActionID: context.activeUserActionID?.toRUMDataFormat,
-                    viewServerTimeOffset: activeSession.viewScopes.last?.serverTimeOffset,
+                    viewServerTimeOffset: activeViewScope?.serverTimeOffset,
                     viewPath: context.activeViewPath,
                     viewName: context.activeViewName
                 )

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -15,6 +15,20 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         static let sessionMaxDuration: TimeInterval = 4 * 60 * 60 // 4 hours
     }
 
+    /// Whether a session is timed out due to inactivity, given the time of its last interaction.
+    /// Shared with `TimeseriesSessionCollector`, which self-enforces this same rule from a live
+    /// `RUMSessionActivityReader` snapshot instead of reacting to `RUMCommand`s.
+    static func hasTimedOut(lastInteractionTime: Date, currentTime: Date) -> Bool {
+        currentTime.timeIntervalSince(lastInteractionTime) >= Constants.sessionTimeoutDuration
+    }
+
+    /// Whether a session has exceeded its maximum duration, given its start time.
+    /// Shared with `TimeseriesSessionCollector`, which self-enforces this same rule from a live
+    /// `RUMSessionActivityReader` snapshot instead of reacting to `RUMCommand`s.
+    static func hasExpired(sessionStartTime: Date, currentTime: Date) -> Bool {
+        currentTime.timeIntervalSince(sessionStartTime) >= Constants.sessionMaxDuration
+    }
+
     /// The reason of ending a session.
     enum EndReason: String {
         /// The session timed out because it received no interaction for x minutes.
@@ -95,9 +109,11 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// If this is the very first session created in the current app process (`false` for session created upon expiration of a previous one).
     let isInitialSession: Bool
     /// The start time of this Session, measured in device date. In initial session this is the time of SDK init.
-    private let sessionStartTime: Date
+    /// Exposed internally (not `private`) so `Monitor` can snapshot it for `RUMSessionActivityReader`.
+    let sessionStartTime: Date
     /// Time of the last RUM interaction noticed by this Session.
-    private var lastInteractionTime: Date
+    /// Exposed internally (not `private`) so `Monitor` can snapshot it for `RUMSessionActivityReader`.
+    private(set) var lastInteractionTime: Date
     /// Indicates whether the "ApplicationLaunch" view was active when the app entered the background.
     private var hadApplicationLaunchViewWhenEnteringBackground: Bool? = nil
     /// The reason why this session has ended or `nil` if it is still active.
@@ -175,8 +191,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             dependencies.timeseriesCollector?.start(
                 sessionID: sessionUUID.toRUMDataFormat,
                 applicationID: dependencies.rumApplicationID,
-                sessionType: dependencies.sessionType,
-                startTime: startTime
+                sessionType: dependencies.sessionType
             )
             if !context.applicationStateHistory.currentState.isRunningInForeground {
                 dependencies.timeseriesCollector?.pause(sessionID: sessionUUID.toRUMDataFormat)
@@ -257,7 +272,6 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         if command.isUserInteraction {
             lastInteractionTime = command.time
-            dependencies.timeseriesCollector?.noteActivity(sessionID: sessionUUID.toRUMDataFormat, at: command.time)
         }
 
         if !sampler.isSampled {
@@ -498,12 +512,10 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     }
 
     private func hasTimedOut(currentTime: Date) -> Bool {
-        let timeElapsedSinceLastInteraction = currentTime.timeIntervalSince(lastInteractionTime)
-        return timeElapsedSinceLastInteraction >= Constants.sessionTimeoutDuration
+        Self.hasTimedOut(lastInteractionTime: lastInteractionTime, currentTime: currentTime)
     }
 
     private func hasExpired(currentTime: Date) -> Bool {
-        let sessionDuration = currentTime.timeIntervalSince(sessionStartTime)
-        return sessionDuration >= Constants.sessionMaxDuration
+        Self.hasExpired(sessionStartTime: sessionStartTime, currentTime: currentTime)
     }
 }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -102,7 +102,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     private var hadApplicationLaunchViewWhenEnteringBackground: Bool? = nil
     /// The reason why this session has ended or `nil` if it is still active.
     private(set) var endReason: EndReason? {
-        didSet { if endReason != nil { dependencies.timeseriesCollector?.stop(sessionID: sessionUUID.rawValue.uuidString.lowercased()) } }
+        didSet { if endReason != nil { dependencies.timeseriesCollector?.stop(sessionID: sessionUUID.toRUMDataFormat) } }
     }
 
     /// Counter to track the index of views in this session. Starts at 0 for the first view.
@@ -173,13 +173,13 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         if sampler.isSampled {
             dependencies.timeseriesCollector?.start(
-                sessionID: sessionUUID.rawValue.uuidString.lowercased(),
+                sessionID: sessionUUID.toRUMDataFormat,
                 applicationID: dependencies.rumApplicationID,
                 sessionType: dependencies.sessionType,
                 startTime: startTime
             )
             if !context.applicationStateHistory.currentState.isRunningInForeground {
-                dependencies.timeseriesCollector?.pause(sessionID: sessionUUID.rawValue.uuidString.lowercased())
+                dependencies.timeseriesCollector?.pause(sessionID: sessionUUID.toRUMDataFormat)
             }
         }
     }
@@ -257,7 +257,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         if command.isUserInteraction {
             lastInteractionTime = command.time
-            dependencies.timeseriesCollector?.noteActivity(sessionID: sessionUUID.rawValue.uuidString.lowercased(), at: command.time)
+            dependencies.timeseriesCollector?.noteActivity(sessionID: sessionUUID.toRUMDataFormat, at: command.time)
         }
 
         if !sampler.isSampled {
@@ -288,13 +288,13 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             case let appLifecycleCommand as RUMHandleAppLifecycleEventCommand where appLifecycleCommand.event == .didEnterBackground:
                 hadApplicationLaunchViewWhenEnteringBackground = activeView?.viewPath == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL
                 appLaunchManager.process(command, context: context, writer: writer)
-                dependencies.timeseriesCollector?.pause(sessionID: sessionUUID.rawValue.uuidString.lowercased())
+                dependencies.timeseriesCollector?.pause(sessionID: sessionUUID.toRUMDataFormat)
             case let appLifecycleCommand as RUMHandleAppLifecycleEventCommand where appLifecycleCommand.event == .willEnterForeground:
                 if hadApplicationLaunchViewWhenEnteringBackground == true {
                     startApplicationLaunchView(on: appLifecycleCommand, context: context, writer: writer)
                 }
                 hadApplicationLaunchViewWhenEnteringBackground = nil
-                dependencies.timeseriesCollector?.resume(sessionID: sessionUUID.rawValue.uuidString.lowercased())
+                dependencies.timeseriesCollector?.resume(sessionID: sessionUUID.toRUMDataFormat)
 
             case let operationStepVitalCommand as RUMOperationStepVitalCommand:
                 // Forward command to the feature operation manager

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -102,7 +102,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     private var hadApplicationLaunchViewWhenEnteringBackground: Bool? = nil
     /// The reason why this session has ended or `nil` if it is still active.
     private(set) var endReason: EndReason? {
-        didSet { if endReason != nil { dependencies.timeseriesCollector?.stop() } }
+        didSet { if endReason != nil { dependencies.timeseriesCollector?.stop(sessionID: sessionUUID.rawValue.uuidString.lowercased()) } }
     }
 
     /// Counter to track the index of views in this session. Starts at 0 for the first view.
@@ -175,10 +175,11 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             dependencies.timeseriesCollector?.start(
                 sessionID: sessionUUID.rawValue.uuidString.lowercased(),
                 applicationID: dependencies.rumApplicationID,
-                sessionType: dependencies.sessionType
+                sessionType: dependencies.sessionType,
+                startTime: startTime
             )
             if !context.applicationStateHistory.currentState.isRunningInForeground {
-                dependencies.timeseriesCollector?.pause()
+                dependencies.timeseriesCollector?.pause(sessionID: sessionUUID.rawValue.uuidString.lowercased())
             }
         }
     }
@@ -256,6 +257,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         if command.isUserInteraction {
             lastInteractionTime = command.time
+            dependencies.timeseriesCollector?.noteActivity(sessionID: sessionUUID.rawValue.uuidString.lowercased(), at: command.time)
         }
 
         if !sampler.isSampled {
@@ -286,13 +288,13 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             case let appLifecycleCommand as RUMHandleAppLifecycleEventCommand where appLifecycleCommand.event == .didEnterBackground:
                 hadApplicationLaunchViewWhenEnteringBackground = activeView?.viewPath == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL
                 appLaunchManager.process(command, context: context, writer: writer)
-                dependencies.timeseriesCollector?.pause()
+                dependencies.timeseriesCollector?.pause(sessionID: sessionUUID.rawValue.uuidString.lowercased())
             case let appLifecycleCommand as RUMHandleAppLifecycleEventCommand where appLifecycleCommand.event == .willEnterForeground:
                 if hadApplicationLaunchViewWhenEnteringBackground == true {
                     startApplicationLaunchView(on: appLifecycleCommand, context: context, writer: writer)
                 }
                 hadApplicationLaunchViewWhenEnteringBackground = nil
-                dependencies.timeseriesCollector?.resume()
+                dependencies.timeseriesCollector?.resume(sessionID: sessionUUID.rawValue.uuidString.lowercased())
 
             case let operationStepVitalCommand as RUMOperationStepVitalCommand:
                 // Forward command to the feature operation manager

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -16,15 +16,11 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     }
 
     /// Whether a session is timed out due to inactivity, given the time of its last interaction.
-    /// Shared with `TimeseriesSessionCollector`, which self-enforces this same rule from a live
-    /// `RUMSessionActivityReader` snapshot instead of reacting to `RUMCommand`s.
     static func hasTimedOut(lastInteractionTime: Date, currentTime: Date) -> Bool {
         currentTime.timeIntervalSince(lastInteractionTime) >= Constants.sessionTimeoutDuration
     }
 
     /// Whether a session has exceeded its maximum duration, given its start time.
-    /// Shared with `TimeseriesSessionCollector`, which self-enforces this same rule from a live
-    /// `RUMSessionActivityReader` snapshot instead of reacting to `RUMCommand`s.
     static func hasExpired(sessionStartTime: Date, currentTime: Date) -> Bool {
         currentTime.timeIntervalSince(sessionStartTime) >= Constants.sessionMaxDuration
     }
@@ -109,10 +105,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     /// If this is the very first session created in the current app process (`false` for session created upon expiration of a previous one).
     let isInitialSession: Bool
     /// The start time of this Session, measured in device date. In initial session this is the time of SDK init.
-    /// Exposed internally (not `private`) so `Monitor` can snapshot it for `RUMSessionActivityReader`.
     let sessionStartTime: Date
     /// Time of the last RUM interaction noticed by this Session.
-    /// Exposed internally (not `private`) so `Monitor` can snapshot it for `RUMSessionActivityReader`.
     private(set) var lastInteractionTime: Date
     /// Indicates whether the "ApplicationLaunch" view was active when the app entered the background.
     private var hadApplicationLaunchViewWhenEnteringBackground: Bool? = nil

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -9,6 +9,9 @@ import DatadogInternal
 
 /// Defines the interface for collecting timeseries data during a RUM session.
 internal protocol TimeseriesCollecting: AnyObject {
+    /// Provides global custom attributes and the active view at sample time. Set by `RUMFeature` once `Monitor`
+    /// is constructed, since the collector is created before it.
+    var activeContextReader: RUMActiveContextReader? { get set }
     func start(sessionID: String, applicationID: String, sessionType: RUMSessionType, startTime: Date)
     func pause(sessionID: String)
     func resume(sessionID: String)
@@ -55,9 +58,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private let sessionSampleRate: Double
     private let sanitizer = RUMEventSanitizer()
 
-    /// Provides global custom attributes and the active view at sample time. Set by `RUMFeature` once `Monitor`
-    /// is constructed, since the collector is created before it. `Monitor`'s conformance is safe to read from
-    /// any thread.
+    /// `Monitor`'s conformance is safe to read from any thread.
     weak var activeContextReader: RUMActiveContextReader?
 
     private var memoryBuffer: [MemorySample] = []

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -16,6 +16,8 @@ internal protocol TimeseriesCollecting: AnyObject {
     /// Reports that a RUM interaction was just processed, so the collector can self-enforce
     /// the session inactivity timeout even if no further commands ever arrive to call `stop(sessionID:)`.
     func noteActivity(sessionID: String, at time: Date)
+    /// Synchronously flushes any buffered samples. **Blocks the caller thread.**
+    func flush()
 }
 
 /// Collects memory and CPU samples at configurable intervals (default: 1 s) during a RUM session and flushes them
@@ -51,6 +53,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private let ciTest: RUMCITest?
     private let syntheticsTest: RUMSyntheticsTest?
     private let sessionSampleRate: Double
+    private let sanitizer = RUMEventSanitizer()
 
     /// Provides global custom attributes and the active view at sample time. Set by `RUMFeature` once `Monitor`
     /// is constructed, since the collector is created before it. `Monitor`'s conformance is safe to read from
@@ -64,6 +67,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private var sessionType: RUMSessionType = .user
     private var timer: DispatchSourceTimer?
     private var isPaused: Bool = false
+    /// The view ID of the samples currently buffered, so a view change can trigger a flush before
+    /// mixing samples from two different views into the same batch. `nil` means either no view was
+    /// active yet, or no sample has been buffered since the last flush.
+    private var currentBatchViewID: String?
     /// The start time of the current session, used to self-enforce `RUMSessionScope.Constants.sessionMaxDuration`
     /// even if the RUM command pipeline never notifies this collector of the session's expiry.
     private var sessionStartTime: Date = .distantPast
@@ -163,6 +170,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.memoryBuffer = []
             self.cpuBuffer = []
             self.isPaused = false
+            self.currentBatchViewID = nil
 
             self.timer?.cancel()
             self.timer = self.makeTimer()
@@ -212,6 +220,14 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.isPaused = false
             self.flushMemory()
             self.flushCPU()
+        }
+    }
+
+    /// Synchronously flushes any buffered samples without stopping or pausing sampling. **Blocks the caller thread.**
+    func flush() {
+        queue.sync {
+            flushMemory()
+            flushCPU()
         }
     }
 
@@ -272,6 +288,15 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let viewID = activeView?.id
         let viewPath = activeView?.path
         let viewName = activeView?.name
+
+        // Flush before mixing samples from two different views into the same batch, so each batch
+        // (and the RUM view it's attributed to) reflects a single view rather than whichever view
+        // happened to be active at the last sample or at flush time.
+        if viewID != currentBatchViewID {
+            flushMemory()
+            flushCPU()
+        }
+        currentBatchViewID = viewID
 
         if let bytes = memoryReader.readVitalData() {
             let footprintKB = bytes / 1_024
@@ -362,7 +387,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 version: context.version,
                 view: view.map { .init(id: $0.id, name: $0.name, url: $0.path) }
             )
-            writer.write(value: event)
+            writer.write(value: self.sanitizer.sanitize(event: event))
         }
     }
 
@@ -426,7 +451,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 version: context.version,
                 view: view.map { .init(id: $0.id, name: $0.name, url: $0.path) }
             )
-            writer.write(value: event)
+            writer.write(value: self.sanitizer.sanitize(event: event))
         }
     }
 }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -191,6 +191,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             guard let self = self, self.sessionID == sessionID else {
                 return
             }
+            // Clear this before the idempotency check below: even if the timer already self-stopped
+            // (so this call is a no-op as far as the timer goes), backgrounding must still prevent a
+            // later `noteActivity` from treating the self-stop as recoverable and resuming the timer.
+            self.selfStoppedDueToExpiry = false
             if self.isPaused || self.timer == nil {
                 return
             }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -12,13 +12,14 @@ internal protocol TimeseriesCollecting: AnyObject {
     /// Provides global custom attributes and the active view at sample time. Set by `RUMFeature` once `Monitor`
     /// is constructed, since the collector is created before it.
     var activeContextReader: RUMActiveContextReader? { get set }
-    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType, startTime: Date)
+    /// Provides the active session's start time and last-interaction time at sample time, so the collector can
+    /// self-enforce `RUMSessionScope`'s own expiry rules without maintaining a shadow copy of that state.
+    /// Set by `RUMFeature` once `Monitor` is constructed, since the collector is created before it.
+    var sessionActivityReader: RUMSessionActivityReader? { get set }
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType)
     func pause(sessionID: String)
     func resume(sessionID: String)
     func stop(sessionID: String)
-    /// Reports that a RUM interaction was just processed, so the collector can self-enforce
-    /// the session inactivity timeout even if no further commands ever arrive to call `stop(sessionID:)`.
-    func noteActivity(sessionID: String, at time: Date)
     /// Synchronously flushes any buffered samples. **Blocks the caller thread.**
     func flush()
 }
@@ -60,6 +61,8 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
 
     /// `Monitor`'s conformance is safe to read from any thread.
     weak var activeContextReader: RUMActiveContextReader?
+    /// `Monitor`'s conformance is safe to read from any thread.
+    weak var sessionActivityReader: RUMSessionActivityReader?
 
     private var memoryBuffer: [MemorySample] = []
     private var cpuBuffer: [CPUSample] = []
@@ -68,21 +71,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private var sessionType: RUMSessionType = .user
     private var timer: DispatchSourceTimer?
     private var isPaused: Bool = false
-    /// Set when `sample()` self-stops the timer because it locally observed the session as expired.
-    /// `noteActivity(sessionID:at:)` uses this to distinguish "self-stopped, may need to resume if that
-    /// expiry check raced with a genuine activity update" from an explicit `stop(sessionID:)` call, which
-    /// must never be resumed by a later (possibly stale) `noteActivity` call for the same session.
-    private var selfStoppedDueToExpiry = false
     /// The view ID of the samples currently buffered, so a view change can trigger a flush before
     /// mixing samples from two different views into the same batch. `nil` means either no view was
     /// active yet, or no sample has been buffered since the last flush.
     private var currentBatchViewID: String?
-    /// The start time of the current session, used to self-enforce `RUMSessionScope.Constants.sessionMaxDuration`
-    /// even if the RUM command pipeline never notifies this collector of the session's expiry.
-    private var sessionStartTime: Date = .distantPast
-    /// The time of the last RUM interaction reported via `noteActivity(sessionID:at:)`, used to self-enforce
-    /// `RUMSessionScope.Constants.sessionTimeoutDuration` even when the app goes idle with no RUM commands.
-    private var lastActivityTime: Date = .distantPast
     private let now: () -> Date
 
     /// All buffer mutations and timer events run on this queue.
@@ -161,7 +153,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     }
 
     /// Resets state, flips the compression coin, and starts the sampling timer for the new session.
-    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType, startTime: Date = Date()) {
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType) {
         queue.async { [weak self] in
             guard let self = self else {
                 return
@@ -171,13 +163,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.sessionID = sessionID
             self.applicationID = applicationID
             self.sessionType = sessionType
-            self.sessionStartTime = startTime
-            self.lastActivityTime = startTime
             self.memoryBuffer = []
             self.cpuBuffer = []
             self.isPaused = false
             self.currentBatchViewID = nil
-            self.selfStoppedDueToExpiry = false
 
             self.timer?.cancel()
             self.timer = self.makeTimer()
@@ -197,12 +186,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             }
             self.timer?.cancel()
             self.timer = nil
-            // Record the paused state even if the timer had already self-stopped (e.g. an inactivity
-            // self-stop racing with this call): `noteActivity` must not treat that self-stop as
-            // recoverable while backgrounded, and `resume(sessionID:)` on foregrounding must still be
-            // able to restart sampling for this still-active session.
             self.isPaused = true
-            self.selfStoppedDueToExpiry = false
             self.flushMemory()
             self.flushCPU()
         }
@@ -230,7 +214,6 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.timer?.cancel()
             self.timer = nil
             self.isPaused = false
-            self.selfStoppedDueToExpiry = false
             self.flushMemory()
             self.flushCPU()
         }
@@ -241,27 +224,6 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         queue.sync {
             flushMemory()
             flushCPU()
-        }
-    }
-
-    /// Records that a RUM interaction happened, resetting the inactivity clock this collector uses to
-    /// self-enforce `RUMSessionScope.Constants.sessionTimeoutDuration` (see `sample()`).
-    /// No-ops if `sessionID` no longer matches the currently active session.
-    func noteActivity(sessionID: String, at time: Date) {
-        queue.async { [weak self] in
-            guard let self = self, self.sessionID == sessionID else {
-                return
-            }
-            self.lastActivityTime = time
-
-            // This activity update can race with `sample()`'s self-stop check: both run on `queue`, so if a
-            // timer tick was already enqueued when this activity happened, it can self-stop on stale
-            // `lastActivityTime` just before this block runs. Since the session is still genuinely active,
-            // resume sampling now rather than leaving this collector silently stopped until the next session.
-            if self.selfStoppedDueToExpiry && !self.isPaused {
-                self.selfStoppedDueToExpiry = false
-                self.timer = self.makeTimer()
-            }
         }
     }
 
@@ -295,12 +257,16 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         // has expired without any RUM command arriving to call `stop(sessionID:)` (e.g. the app went
         // idle with no user interaction). This is a safety net only — it does not affect RUM's own
         // session state, it just stops this collector from uploading data past session expiry.
-        let sessionExceededMaxDuration = currentDate.timeIntervalSince(sessionStartTime) >= RUMSessionScope.Constants.sessionMaxDuration
-        let sessionExceededInactivityTimeout = currentDate.timeIntervalSince(lastActivityTime) >= RUMSessionScope.Constants.sessionTimeoutDuration
-        if sessionExceededMaxDuration || sessionExceededInactivityTimeout {
-            // Only the inactivity check can race with `noteActivity(sessionID:at:)` (see its comment) — max
-            // duration is a hard cap unrelated to activity timing, so it should never be resumed.
-            selfStoppedDueToExpiry = sessionExceededInactivityTimeout && !sessionExceededMaxDuration
+        //
+        // Pulled fresh from `sessionActivityReader` on every tick, rather than from a locally pushed
+        // copy, so there's a single live source of truth and no race with how/when that state is updated.
+        // If the reader's session doesn't match (e.g. a session transition is still propagating), skip
+        // the check for this tick rather than guessing.
+        let activity = sessionActivityReader?.sessionActivity
+        if let activity = activity, activity.sessionID == sessionID,
+           let sessionStartTime = activity.sessionStartTime, let lastInteractionTime = activity.lastInteractionTime,
+           RUMSessionScope.hasExpired(sessionStartTime: sessionStartTime, currentTime: currentDate)
+            || RUMSessionScope.hasTimedOut(lastInteractionTime: lastInteractionTime, currentTime: currentDate) {
             timer?.cancel()
             timer = nil
             flushMemory()

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -67,6 +67,11 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private var sessionType: RUMSessionType = .user
     private var timer: DispatchSourceTimer?
     private var isPaused: Bool = false
+    /// Set when `sample()` self-stops the timer because it locally observed the session as expired.
+    /// `noteActivity(sessionID:at:)` uses this to distinguish "self-stopped, may need to resume if that
+    /// expiry check raced with a genuine activity update" from an explicit `stop(sessionID:)` call, which
+    /// must never be resumed by a later (possibly stale) `noteActivity` call for the same session.
+    private var selfStoppedDueToExpiry = false
     /// The view ID of the samples currently buffered, so a view change can trigger a flush before
     /// mixing samples from two different views into the same batch. `nil` means either no view was
     /// active yet, or no sample has been buffered since the last flush.
@@ -171,6 +176,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.cpuBuffer = []
             self.isPaused = false
             self.currentBatchViewID = nil
+            self.selfStoppedDueToExpiry = false
 
             self.timer?.cancel()
             self.timer = self.makeTimer()
@@ -218,6 +224,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.timer?.cancel()
             self.timer = nil
             self.isPaused = false
+            self.selfStoppedDueToExpiry = false
             self.flushMemory()
             self.flushCPU()
         }
@@ -240,6 +247,15 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 return
             }
             self.lastActivityTime = time
+
+            // This activity update can race with `sample()`'s self-stop check: both run on `queue`, so if a
+            // timer tick was already enqueued when this activity happened, it can self-stop on stale
+            // `lastActivityTime` just before this block runs. Since the session is still genuinely active,
+            // resume sampling now rather than leaving this collector silently stopped until the next session.
+            if self.selfStoppedDueToExpiry && !self.isPaused {
+                self.selfStoppedDueToExpiry = false
+                self.timer = self.makeTimer()
+            }
         }
     }
 
@@ -276,6 +292,9 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let sessionExceededMaxDuration = currentDate.timeIntervalSince(sessionStartTime) >= RUMSessionScope.Constants.sessionMaxDuration
         let sessionExceededInactivityTimeout = currentDate.timeIntervalSince(lastActivityTime) >= RUMSessionScope.Constants.sessionTimeoutDuration
         if sessionExceededMaxDuration || sessionExceededInactivityTimeout {
+            // Only the inactivity check can race with `noteActivity(sessionID:at:)` (see its comment) — max
+            // duration is a hard cap unrelated to activity timing, so it should never be resumed.
+            selfStoppedDueToExpiry = sessionExceededInactivityTimeout && !sessionExceededMaxDuration
             timer?.cancel()
             timer = nil
             flushMemory()

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -191,16 +191,17 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             guard let self = self, self.sessionID == sessionID else {
                 return
             }
-            // Clear this before the idempotency check below: even if the timer already self-stopped
-            // (so this call is a no-op as far as the timer goes), backgrounding must still prevent a
-            // later `noteActivity` from treating the self-stop as recoverable and resuming the timer.
-            self.selfStoppedDueToExpiry = false
-            if self.isPaused || self.timer == nil {
+            if self.isPaused {
                 return
             }
             self.timer?.cancel()
             self.timer = nil
+            // Record the paused state even if the timer had already self-stopped (e.g. an inactivity
+            // self-stop racing with this call): `noteActivity` must not treat that self-stop as
+            // recoverable while backgrounded, and `resume(sessionID:)` on foregrounding must still be
+            // able to restart sampling for this still-active session.
             self.isPaused = true
+            self.selfStoppedDueToExpiry = false
             self.flushMemory()
             self.flushCPU()
         }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -9,10 +9,13 @@ import DatadogInternal
 
 /// Defines the interface for collecting timeseries data during a RUM session.
 internal protocol TimeseriesCollecting: AnyObject {
-    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType)
-    func pause()
-    func resume()
-    func stop()
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType, startTime: Date)
+    func pause(sessionID: String)
+    func resume(sessionID: String)
+    func stop(sessionID: String)
+    /// Reports that a RUM interaction was just processed, so the collector can self-enforce
+    /// the session inactivity timeout even if no further commands ever arrive to call `stop(sessionID:)`.
+    func noteActivity(sessionID: String, at time: Date)
 }
 
 /// Collects memory and CPU samples at configurable intervals (default: 1 s) during a RUM session and flushes them
@@ -61,6 +64,13 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private var sessionType: RUMSessionType = .user
     private var timer: DispatchSourceTimer?
     private var isPaused: Bool = false
+    /// The start time of the current session, used to self-enforce `RUMSessionScope.Constants.sessionMaxDuration`
+    /// even if the RUM command pipeline never notifies this collector of the session's expiry.
+    private var sessionStartTime: Date = .distantPast
+    /// The time of the last RUM interaction reported via `noteActivity(sessionID:at:)`, used to self-enforce
+    /// `RUMSessionScope.Constants.sessionTimeoutDuration` even when the app goes idle with no RUM commands.
+    private var lastActivityTime: Date = .distantPast
+    private let now: () -> Date
 
     /// All buffer mutations and timer events run on this queue.
     private let queue = DispatchQueue(label: "com.datadoghq.timeseries-collector", qos: .utility)
@@ -74,7 +84,8 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         totalRAM: Double = Double(ProcessInfo.processInfo.physicalMemory),
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
-        sessionSampleRate: Double = 100
+        sessionSampleRate: Double = 100,
+        now: @escaping () -> Date = Date.init
     ) {
         self.memoryReader = memoryReader
         self.batchSize = max(2, batchSize)
@@ -85,6 +96,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         self.syntheticsTest = syntheticsTest
         self.sessionSampleRate = sessionSampleRate
         self.cpuUsageProvider = cpuUsageProvider ?? { TimeseriesSessionCollector.processCPU() }
+        self.now = now
     }
 
     deinit {
@@ -136,7 +148,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     }
 
     /// Resets state, flips the compression coin, and starts the sampling timer for the new session.
-    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType) {
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType, startTime: Date = Date()) {
         queue.async { [weak self] in
             guard let self = self else {
                 return
@@ -146,6 +158,8 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.sessionID = sessionID
             self.applicationID = applicationID
             self.sessionType = sessionType
+            self.sessionStartTime = startTime
+            self.lastActivityTime = startTime
             self.memoryBuffer = []
             self.cpuBuffer = []
             self.isPaused = false
@@ -156,9 +170,11 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     }
 
     /// Suspends sampling and flushes buffered data. Session state is preserved for `resume()`. Idempotent.
-    func pause() {
+    /// No-ops if `sessionID` no longer matches the currently active session (e.g. a call left over from a
+    /// session that has since ended and been replaced — see `RUMSessionScope.Constants` for expiry rules).
+    func pause(sessionID: String) {
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self = self, self.sessionID == sessionID else {
                 return
             }
             if self.isPaused || self.timer == nil {
@@ -173,9 +189,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     }
 
     /// Resumes sampling after `pause()`. Idempotent — only takes effect if currently paused.
-    func resume() {
+    /// No-ops if `sessionID` no longer matches the currently active session.
+    func resume(sessionID: String) {
         queue.async { [weak self] in
-            guard let self = self, self.isPaused else {
+            guard let self = self, self.sessionID == sessionID, self.isPaused else {
                 return
             }
             self.isPaused = false
@@ -184,9 +201,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     }
 
     /// Stops sampling and flushes any remaining buffered data points.
-    func stop() {
+    /// No-ops if `sessionID` no longer matches the currently active session.
+    func stop(sessionID: String) {
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self = self, self.sessionID == sessionID else {
                 return
             }
             self.timer?.cancel()
@@ -194,6 +212,18 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.isPaused = false
             self.flushMemory()
             self.flushCPU()
+        }
+    }
+
+    /// Records that a RUM interaction happened, resetting the inactivity clock this collector uses to
+    /// self-enforce `RUMSessionScope.Constants.sessionTimeoutDuration` (see `sample()`).
+    /// No-ops if `sessionID` no longer matches the currently active session.
+    func noteActivity(sessionID: String, at time: Date) {
+        queue.async { [weak self] in
+            guard let self = self, self.sessionID == sessionID else {
+                return
+            }
+            self.lastActivityTime = time
         }
     }
 
@@ -221,7 +251,23 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     // MARK: - Private
 
     private func sample() {
-        let now = Int64.ddWithNoOverflow(Date().timeIntervalSince1970 * 1_000_000_000)
+        let currentDate = now()
+
+        // Self-enforce the same session lifetime rules `RUMSessionScope` uses, in case this session
+        // has expired without any RUM command arriving to call `stop(sessionID:)` (e.g. the app went
+        // idle with no user interaction). This is a safety net only — it does not affect RUM's own
+        // session state, it just stops this collector from uploading data past session expiry.
+        let sessionExceededMaxDuration = currentDate.timeIntervalSince(sessionStartTime) >= RUMSessionScope.Constants.sessionMaxDuration
+        let sessionExceededInactivityTimeout = currentDate.timeIntervalSince(lastActivityTime) >= RUMSessionScope.Constants.sessionTimeoutDuration
+        if sessionExceededMaxDuration || sessionExceededInactivityTimeout {
+            timer?.cancel()
+            timer = nil
+            flushMemory()
+            flushCPU()
+            return
+        }
+
+        let timestamp = Int64.ddWithNoOverflow(currentDate.timeIntervalSince1970 * 1_000_000_000)
         let activeView = activeContextReader?.activeView
         let viewID = activeView?.id
         let viewPath = activeView?.path
@@ -232,7 +278,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             let memoryPercent = totalRAM > 0 ? bytes / totalRAM * 100 : 0
             memoryBuffer.append(
                 MemorySample(
-                    timestamp: now,
+                    timestamp: timestamp,
                     footprintKB: footprintKB,
                     percent: memoryPercent,
                     viewID: viewID,
@@ -246,7 +292,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         }
 
         if let cpuUsage = cpuUsageProvider() {
-            cpuBuffer.append(CPUSample(timestamp: now, usage: cpuUsage, viewID: viewID, viewPath: viewPath, viewName: viewName))
+            cpuBuffer.append(CPUSample(timestamp: timestamp, usage: cpuUsage, viewID: viewID, viewPath: viewPath, viewName: viewName))
             if cpuBuffer.count >= batchSize {
                 flushCPU()
             }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -9,13 +9,11 @@ import DatadogInternal
 
 /// Defines the interface for collecting timeseries data during a RUM session.
 internal protocol TimeseriesCollecting: AnyObject {
-    /// Provides global custom attributes and the active view at sample time. Set by `RUMFeature` once `Monitor`
-    /// is constructed, since the collector is created before it.
+    /// Provides global custom attributes, the active view, and the active session's expiry state at sample
+    /// time, so the collector can self-enforce `RUMSessionScope`'s own expiry rules without maintaining a
+    /// shadow copy of that state. Set by `RUMFeature` once `Monitor` is constructed, since the collector is
+    /// created before it.
     var activeContextReader: RUMActiveContextReader? { get set }
-    /// Provides the active session's start time and last-interaction time at sample time, so the collector can
-    /// self-enforce `RUMSessionScope`'s own expiry rules without maintaining a shadow copy of that state.
-    /// Set by `RUMFeature` once `Monitor` is constructed, since the collector is created before it.
-    var sessionActivityReader: RUMSessionActivityReader? { get set }
     func start(sessionID: String, applicationID: String, sessionType: RUMSessionType)
     func pause(sessionID: String)
     func resume(sessionID: String)
@@ -61,8 +59,6 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
 
     /// `Monitor`'s conformance is safe to read from any thread.
     weak var activeContextReader: RUMActiveContextReader?
-    /// `Monitor`'s conformance is safe to read from any thread.
-    weak var sessionActivityReader: RUMSessionActivityReader?
 
     private var memoryBuffer: [MemorySample] = []
     private var cpuBuffer: [CPUSample] = []
@@ -258,15 +254,9 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         // idle with no user interaction). This is a safety net only — it does not affect RUM's own
         // session state, it just stops this collector from uploading data past session expiry.
         //
-        // Pulled fresh from `sessionActivityReader` on every tick, rather than from a locally pushed
+        // Pulled fresh from `activeContextReader` on every tick, rather than from a locally pushed
         // copy, so there's a single live source of truth and no race with how/when that state is updated.
-        // If the reader's session doesn't match (e.g. a session transition is still propagating), skip
-        // the check for this tick rather than guessing.
-        let activity = sessionActivityReader?.sessionActivity
-        if let activity = activity, activity.sessionID == sessionID,
-           let sessionStartTime = activity.sessionStartTime, let lastInteractionTime = activity.lastInteractionTime,
-           RUMSessionScope.hasExpired(sessionStartTime: sessionStartTime, currentTime: currentDate)
-            || RUMSessionScope.hasTimedOut(lastInteractionTime: lastInteractionTime, currentTime: currentDate) {
+        if activeContextReader?.isSessionExpired(sessionID: sessionID, at: currentDate) == true {
             timer?.cancel()
             timer = nil
             flushMemory()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -870,21 +870,41 @@ private class TimeseriesCollectorSpy: TimeseriesCollecting {
     var pauseCallCount = 0
     var resumeCallCount = 0
     var stopCallCount = 0
+    var noteActivityCallCount = 0
     var lastStartedSessionID: String?
     var lastStartedApplicationID: String?
     var lastStartedSessionType: RUMSessionType?
+    var lastStartedStartTime: Date?
+    var lastStoppedSessionID: String?
+    var lastPausedSessionID: String?
+    var lastResumedSessionID: String?
+    var lastNoteActivitySessionID: String?
 
-    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType) {
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType, startTime: Date) {
         startCallCount += 1
         lastStartedSessionID = sessionID
         lastStartedApplicationID = applicationID
         lastStartedSessionType = sessionType
+        lastStartedStartTime = startTime
     }
 
-    func pause() { pauseCallCount += 1 }
-    func resume() { resumeCallCount += 1 }
+    func pause(sessionID: String) {
+        pauseCallCount += 1
+        lastPausedSessionID = sessionID
+    }
 
-    func stop() {
+    func resume(sessionID: String) {
+        resumeCallCount += 1
+        lastResumedSessionID = sessionID
+    }
+
+    func stop(sessionID: String) {
         stopCallCount += 1
+        lastStoppedSessionID = sessionID
+    }
+
+    func noteActivity(sessionID: String, at time: Date) {
+        noteActivityCallCount += 1
+        lastNoteActivitySessionID = sessionID
     }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -867,7 +867,6 @@ class RUMSessionScopeTests: XCTestCase {
 
 private class TimeseriesCollectorSpy: TimeseriesCollecting {
     weak var activeContextReader: RUMActiveContextReader?
-    weak var sessionActivityReader: RUMSessionActivityReader?
     var startCallCount = 0
     var pauseCallCount = 0
     var resumeCallCount = 0

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -867,26 +867,23 @@ class RUMSessionScopeTests: XCTestCase {
 
 private class TimeseriesCollectorSpy: TimeseriesCollecting {
     weak var activeContextReader: RUMActiveContextReader?
+    weak var sessionActivityReader: RUMSessionActivityReader?
     var startCallCount = 0
     var pauseCallCount = 0
     var resumeCallCount = 0
     var stopCallCount = 0
-    var noteActivityCallCount = 0
     var lastStartedSessionID: String?
     var lastStartedApplicationID: String?
     var lastStartedSessionType: RUMSessionType?
-    var lastStartedStartTime: Date?
     var lastStoppedSessionID: String?
     var lastPausedSessionID: String?
     var lastResumedSessionID: String?
-    var lastNoteActivitySessionID: String?
 
-    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType, startTime: Date) {
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType) {
         startCallCount += 1
         lastStartedSessionID = sessionID
         lastStartedApplicationID = applicationID
         lastStartedSessionType = sessionType
-        lastStartedStartTime = startTime
     }
 
     func pause(sessionID: String) {
@@ -902,11 +899,6 @@ private class TimeseriesCollectorSpy: TimeseriesCollecting {
     func stop(sessionID: String) {
         stopCallCount += 1
         lastStoppedSessionID = sessionID
-    }
-
-    func noteActivity(sessionID: String, at time: Date) {
-        noteActivityCallCount += 1
-        lastNoteActivitySessionID = sessionID
     }
 
     var flushCallCount = 0

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -907,4 +907,10 @@ private class TimeseriesCollectorSpy: TimeseriesCollecting {
         noteActivityCallCount += 1
         lastNoteActivitySessionID = sessionID
     }
+
+    var flushCallCount = 0
+
+    func flush() {
+        flushCallCount += 1
+    }
 }

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -866,6 +866,7 @@ class RUMSessionScopeTests: XCTestCase {
 // MARK: - Test Helpers
 
 private class TimeseriesCollectorSpy: TimeseriesCollecting {
+    weak var activeContextReader: RUMActiveContextReader?
     var startCallCount = 0
     var pauseCallCount = 0
     var resumeCallCount = 0

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -824,7 +824,9 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.activeContextReader = contextReader
 
         let startTime = clock.date
-        collector.start(sessionID: "session-expired", applicationID: "app-1", sessionType: .user, startTime: startTime)
+        let activityReader = RUMSessionActivityReaderMock(sessionID: "session-expired", sessionStartTime: startTime, lastInteractionTime: startTime)
+        collector.sessionActivityReader = activityReader
+        collector.start(sessionID: "session-expired", applicationID: "app-1", sessionType: .user)
 
         let beforeExpiryExpectation = self.expectation(description: "samples collected before expiry")
         beforeExpiryExpectation.assertForOverFulfill = false
@@ -832,8 +834,11 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         waitForExpectations(timeout: 2)
         XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Batch should not be flushed while the session is still within its max duration")
 
-        // When — advance the (injected) clock past the session's max duration, without ever calling stop()
+        // When — advance the (injected) clock and the activity reader's snapshot past the session's max
+        // duration, mirroring how `Monitor` refreshes its snapshot on every processed command, without ever
+        // calling stop() directly
         clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionMaxDuration)
+        activityReader.sessionActivity.lastInteractionTime = clock.date
         let selfStopExpectation = self.expectation(description: "self-stop settled")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
         waitForExpectations(timeout: 2)
@@ -867,7 +872,9 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.activeContextReader = contextReader
 
         let startTime = clock.date
-        collector.start(sessionID: "session-idle", applicationID: "app-1", sessionType: .user, startTime: startTime)
+        let activityReader = RUMSessionActivityReaderMock(sessionID: "session-idle", sessionStartTime: startTime, lastInteractionTime: startTime)
+        collector.sessionActivityReader = activityReader
+        collector.start(sessionID: "session-idle", applicationID: "app-1", sessionType: .user)
 
         let beforeTimeoutExpectation = self.expectation(description: "samples collected before timeout")
         beforeTimeoutExpectation.assertForOverFulfill = false
@@ -875,7 +882,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         waitForExpectations(timeout: 2)
         XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty)
 
-        // When — advance the clock past the inactivity timeout without ever calling noteActivity(sessionID:at:)
+        // When — advance the clock past the inactivity timeout while the activity reader's `lastInteractionTime`
+        // stays fixed at `startTime` (i.e. no RUM interaction was ever processed)
         clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
         let selfStopExpectation = self.expectation(description: "self-stop settled")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
@@ -885,7 +893,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected the collector to self-flush once idle past the inactivity timeout")
     }
 
-    func testNoteActivity_preventsSelfStopWithinTimeoutWindow() {
+    func testWhenActivityReaderReportsRecentInteraction_preventsSelfStopWithinTimeoutWindow() {
         // Given
         memoryReader.vitalData = 1_000_000
         let clock = MutableClock()
@@ -902,11 +910,14 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.activeContextReader = contextReader
 
         let startTime = clock.date
-        collector.start(sessionID: "session-active", applicationID: "app-1", sessionType: .user, startTime: startTime)
+        let activityReader = RUMSessionActivityReaderMock(sessionID: "session-active", sessionStartTime: startTime, lastInteractionTime: startTime)
+        collector.sessionActivityReader = activityReader
+        collector.start(sessionID: "session-active", applicationID: "app-1", sessionType: .user)
 
-        // When — activity is reported right before what would have been the inactivity timeout, resetting the clock
+        // When — a RUM interaction is reported right before what would have been the inactivity timeout,
+        // resetting the clock the reader exposes to `sample()`
         clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
-        collector.noteActivity(sessionID: "session-active", at: clock.date)
+        activityReader.sessionActivity.lastInteractionTime = clock.date
         clock.date = clock.date.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
 
         let expectation = self.expectation(description: "still sampling")
@@ -914,130 +925,9 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
         waitForExpectations(timeout: 2)
 
-        // Then — sampling continued since activity reset the inactivity clock before it lapsed
+        // Then — sampling continued since the reader's last interaction time reset the inactivity clock before it lapsed
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected sampling to continue since activity reset the inactivity clock")
         collector.stop(sessionID: "session-active")
-    }
-
-    func testNoteActivity_resumesSamplingAfterRacingWithSelfStop() {
-        // Given
-        memoryReader.vitalData = 1_000_000
-        let clock = MutableClock()
-        let collector = TimeseriesSessionCollector(
-            memoryReader: memoryReader,
-            featureScope: featureScope,
-            batchSize: 100, // won't auto-flush — only self-expiry/explicit flush triggers the flush
-            samplingInterval: 0.05,
-            cpuUsageProvider: { nil },
-            totalRAM: 4_000_000_000,
-            now: clock.now
-        )
-        let contextReader = RUMActiveContextReaderMock()
-        collector.activeContextReader = contextReader
-
-        let startTime = clock.date
-        collector.start(sessionID: "session-race", applicationID: "app-1", sessionType: .user, startTime: startTime)
-
-        let beforeTimeoutExpectation = self.expectation(description: "samples collected before timeout")
-        beforeTimeoutExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { beforeTimeoutExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-
-        // When — the session goes idle past the inactivity timeout, so `sample()` self-stops the timer...
-        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
-        let selfStopExpectation = self.expectation(description: "self-stop settled")
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-        let countAfterSelfStop = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
-        XCTAssertGreaterThan(countAfterSelfStop, 0, "Expected the collector to have self-stopped due to inactivity")
-
-        // ...but a RUM interaction actually happened around the same time: the command pipeline still calls
-        // `noteActivity(sessionID:at:)` even though this collector already self-stopped on stale state — this
-        // is the race between `sample()`'s self-stop check and `noteActivity` enqueued on the same serial queue.
-        collector.noteActivity(sessionID: "session-race", at: clock.date)
-
-        // Then — sampling resumes rather than staying silently stopped for the rest of the (still active) session
-        let resumeExpectation = self.expectation(description: "sampling resumed after race")
-        resumeExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-        collector.flush()
-        XCTAssertGreaterThan(
-            featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count,
-            countAfterSelfStop,
-            "Expected sampling to resume and produce new batches after noteActivity raced with the self-stop"
-        )
-
-        collector.stop(sessionID: "session-race")
-    }
-
-    func testPause_afterSelfStopDueToExpiry_preventsLaterNoteActivityFromResuming() {
-        // Given
-        memoryReader.vitalData = 1_000_000
-        let clock = MutableClock()
-        let collector = TimeseriesSessionCollector(
-            memoryReader: memoryReader,
-            featureScope: featureScope,
-            batchSize: 100, // won't auto-flush — only self-expiry/explicit flush triggers the flush
-            samplingInterval: 0.05,
-            cpuUsageProvider: { nil },
-            totalRAM: 4_000_000_000,
-            now: clock.now
-        )
-        let contextReader = RUMActiveContextReaderMock()
-        collector.activeContextReader = contextReader
-
-        let startTime = clock.date
-        collector.start(sessionID: "session-backgrounded", applicationID: "app-1", sessionType: .user, startTime: startTime)
-
-        let beforeTimeoutExpectation = self.expectation(description: "samples collected before timeout")
-        beforeTimeoutExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { beforeTimeoutExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-
-        // When — the session goes idle past the inactivity timeout, so `sample()` self-stops the timer
-        // (nil-ing it out) just before the app is backgrounded...
-        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
-        let selfStopExpectation = self.expectation(description: "self-stop settled")
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-        let countAfterSelfStop = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
-        XCTAssertGreaterThan(countAfterSelfStop, 0, "Expected the collector to have self-stopped due to inactivity")
-
-        // ...and `didEnterBackground` is processed right after — with the timer already nil from the
-        // self-stop, this must still record the paused state, not silently no-op.
-        collector.pause(sessionID: "session-backgrounded")
-
-        // ...but a stale/racing RUM interaction for the same session still reaches `noteActivity` afterwards.
-        collector.noteActivity(sessionID: "session-backgrounded", at: clock.date)
-
-        // Then — sampling must stay stopped since the app is backgrounded, not resume behind the scenes
-        let settleExpectation = self.expectation(description: "settle after pause + noteActivity")
-        settleExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { settleExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-        collector.flush()
-        XCTAssertEqual(
-            featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count,
-            countAfterSelfStop,
-            "Expected sampling to remain stopped since the app was backgrounded, despite the racing noteActivity call"
-        )
-
-        // And — a later `willEnterForeground` resume must still be able to restart sampling for this
-        // still-active session, even though the timer was already nil going into `pause(sessionID:)`.
-        collector.resume(sessionID: "session-backgrounded")
-        let resumeExpectation = self.expectation(description: "sampling resumed on foreground")
-        resumeExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-        collector.flush()
-        XCTAssertGreaterThan(
-            featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count,
-            countAfterSelfStop,
-            "Expected sampling to resume once the app returns to the foreground"
-        )
-
-        collector.stop(sessionID: "session-backgrounded")
     }
 
     // MARK: - Session-ID guard against stale calls
@@ -1115,6 +1005,14 @@ private class RUMActiveContextReaderMock: RUMActiveContextReader {
     ) {
         self.globalAttributes = globalAttributes
         self.activeView = activeView
+    }
+}
+
+private class RUMSessionActivityReaderMock: RUMSessionActivityReader {
+    var sessionActivity: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?)
+
+    init(sessionID: String? = nil, sessionStartTime: Date? = nil, lastInteractionTime: Date? = nil) {
+        self.sessionActivity = (sessionID, sessionStartTime, lastInteractionTime)
     }
 }
 

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -919,6 +919,58 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-active")
     }
 
+    func testNoteActivity_resumesSamplingAfterRacingWithSelfStop() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let clock = MutableClock()
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush — only self-expiry/explicit flush triggers the flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000,
+            now: clock.now
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        let startTime = clock.date
+        collector.start(sessionID: "session-race", applicationID: "app-1", sessionType: .user, startTime: startTime)
+
+        let beforeTimeoutExpectation = self.expectation(description: "samples collected before timeout")
+        beforeTimeoutExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { beforeTimeoutExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // When — the session goes idle past the inactivity timeout, so `sample()` self-stops the timer...
+        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let selfStopExpectation = self.expectation(description: "self-stop settled")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        let countAfterSelfStop = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+        XCTAssertGreaterThan(countAfterSelfStop, 0, "Expected the collector to have self-stopped due to inactivity")
+
+        // ...but a RUM interaction actually happened around the same time: the command pipeline still calls
+        // `noteActivity(sessionID:at:)` even though this collector already self-stopped on stale state — this
+        // is the race between `sample()`'s self-stop check and `noteActivity` enqueued on the same serial queue.
+        collector.noteActivity(sessionID: "session-race", at: clock.date)
+
+        // Then — sampling resumes rather than staying silently stopped for the rest of the (still active) session
+        let resumeExpectation = self.expectation(description: "sampling resumed after race")
+        resumeExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        collector.flush()
+        XCTAssertGreaterThan(
+            featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count,
+            countAfterSelfStop,
+            "Expected sampling to resume and produce new batches after noteActivity raced with the self-stop"
+        )
+
+        collector.stop(sessionID: "session-race")
+    }
+
     // MARK: - Session-ID guard against stale calls
 
     func testStaleStopCall_afterNewSessionStarted_doesNotStopNewSession() {

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -820,12 +820,9 @@ class TimeseriesSessionCollectorTests: XCTestCase {
             totalRAM: 4_000_000_000,
             now: clock.now
         )
-        let contextReader = RUMActiveContextReaderMock()
-        collector.activeContextReader = contextReader
-
         let startTime = clock.date
-        let activityReader = RUMSessionActivityReaderMock(sessionID: "session-expired", sessionStartTime: startTime, lastInteractionTime: startTime)
-        collector.sessionActivityReader = activityReader
+        let contextReader = RUMActiveContextReaderMock(sessionID: "session-expired", sessionStartTime: startTime, lastInteractionTime: startTime)
+        collector.activeContextReader = contextReader
         collector.start(sessionID: "session-expired", applicationID: "app-1", sessionType: .user)
 
         let beforeExpiryExpectation = self.expectation(description: "samples collected before expiry")
@@ -838,7 +835,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         // duration, mirroring how `Monitor` refreshes its snapshot on every processed command, without ever
         // calling stop() directly
         clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionMaxDuration)
-        activityReader.sessionActivity.lastInteractionTime = clock.date
+        contextReader.sessionActivity.lastInteractionTime = clock.date
         let selfStopExpectation = self.expectation(description: "self-stop settled")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
         waitForExpectations(timeout: 2)
@@ -868,12 +865,9 @@ class TimeseriesSessionCollectorTests: XCTestCase {
             totalRAM: 4_000_000_000,
             now: clock.now
         )
-        let contextReader = RUMActiveContextReaderMock()
-        collector.activeContextReader = contextReader
-
         let startTime = clock.date
-        let activityReader = RUMSessionActivityReaderMock(sessionID: "session-idle", sessionStartTime: startTime, lastInteractionTime: startTime)
-        collector.sessionActivityReader = activityReader
+        let contextReader = RUMActiveContextReaderMock(sessionID: "session-idle", sessionStartTime: startTime, lastInteractionTime: startTime)
+        collector.activeContextReader = contextReader
         collector.start(sessionID: "session-idle", applicationID: "app-1", sessionType: .user)
 
         let beforeTimeoutExpectation = self.expectation(description: "samples collected before timeout")
@@ -906,18 +900,15 @@ class TimeseriesSessionCollectorTests: XCTestCase {
             totalRAM: 4_000_000_000,
             now: clock.now
         )
-        let contextReader = RUMActiveContextReaderMock()
-        collector.activeContextReader = contextReader
-
         let startTime = clock.date
-        let activityReader = RUMSessionActivityReaderMock(sessionID: "session-active", sessionStartTime: startTime, lastInteractionTime: startTime)
-        collector.sessionActivityReader = activityReader
+        let contextReader = RUMActiveContextReaderMock(sessionID: "session-active", sessionStartTime: startTime, lastInteractionTime: startTime)
+        collector.activeContextReader = contextReader
         collector.start(sessionID: "session-active", applicationID: "app-1", sessionType: .user)
 
         // When — a RUM interaction is reported right before what would have been the inactivity timeout,
         // resetting the clock the reader exposes to `sample()`
         clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
-        activityReader.sessionActivity.lastInteractionTime = clock.date
+        contextReader.sessionActivity.lastInteractionTime = clock.date
         clock.date = clock.date.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
 
         let expectation = self.expectation(description: "still sampling")
@@ -998,21 +989,28 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 private class RUMActiveContextReaderMock: RUMActiveContextReader {
     var globalAttributes: [AttributeKey: AttributeValue]
     var activeView: (id: String?, path: String?, name: String?)
+    var sessionActivity: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?)
 
     init(
         globalAttributes: [AttributeKey: AttributeValue] = [:],
-        activeView: (id: String?, path: String?, name: String?) = (.mockAny(), .mockAny(), nil)
+        activeView: (id: String?, path: String?, name: String?) = (.mockAny(), .mockAny(), nil),
+        sessionID: String? = nil,
+        sessionStartTime: Date? = nil,
+        lastInteractionTime: Date? = nil
     ) {
         self.globalAttributes = globalAttributes
         self.activeView = activeView
-    }
-}
-
-private class RUMSessionActivityReaderMock: RUMSessionActivityReader {
-    var sessionActivity: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?)
-
-    init(sessionID: String? = nil, sessionStartTime: Date? = nil, lastInteractionTime: Date? = nil) {
         self.sessionActivity = (sessionID, sessionStartTime, lastInteractionTime)
+    }
+
+    func isSessionExpired(sessionID: String, at date: Date) -> Bool {
+        guard sessionActivity.sessionID == sessionID,
+              let sessionStartTime = sessionActivity.sessionStartTime,
+              let lastInteractionTime = sessionActivity.lastInteractionTime else {
+            return false
+        }
+        return RUMSessionScope.hasExpired(sessionStartTime: sessionStartTime, currentTime: date)
+            || RUMSessionScope.hasTimedOut(lastInteractionTime: lastInteractionTime, currentTime: date)
     }
 }
 

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -38,7 +38,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-abc", applicationID: "app-123", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-abc")
 
         // Then
         let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -78,7 +78,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-abc", applicationID: "app-123", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-abc")
 
         // Then
         let events = featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self)
@@ -117,7 +117,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-both", applicationID: "app-both", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-both")
 
         // Then
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events")
@@ -153,7 +153,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-offset", applicationID: "app-offset", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-offset")
 
         // Then — date and data point timestamps are server-adjusted
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -187,7 +187,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-rn", applicationID: "app-rn", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-rn")
 
         // Then
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -217,7 +217,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-view", applicationID: "app-view", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-view")
 
         // Then
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -248,7 +248,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-view-name", applicationID: "app-view-name", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-view-name")
 
         // Then
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -279,7 +279,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-has-replay", applicationID: "app-has-replay", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-has-replay")
 
         // Then
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -310,7 +310,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-sample-rate", applicationID: "app-sample-rate", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-sample-rate")
 
         // Then
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -344,7 +344,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         contextReader.activeView = (nil, nil, nil)
 
         let syncExpectation = self.expectation(description: "stop completed")
-        collector.stop()
+        collector.stop(sessionID: "session-ending-view")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
@@ -375,7 +375,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-no-view", applicationID: "app-no-view", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-no-view")
 
         // Then — no view context means the batch is still written, just with `view: nil`, not dropped
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -414,7 +414,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
         XCTAssertFalse(events.isEmpty, "Expected session-1 partial buffer to be flushed on re-start")
         XCTAssertEqual(events[0].session.id, "session-1")
-        collector.stop()
+        collector.stop(sessionID: "session-2")
     }
 
     // MARK: - Flush on stop
@@ -441,7 +441,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         waitForExpectations(timeout: 2)
 
         let syncExpectation = self.expectation(description: "stop completed")
-        collector.stop()
+        collector.stop(sessionID: "session-xyz")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
@@ -476,7 +476,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         waitForExpectations(timeout: 2)
 
         let syncExpectation = self.expectation(description: "stop completed")
-        collector.stop()
+        collector.stop(sessionID: "session-xyz")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
@@ -506,7 +506,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-abc", applicationID: "app-123", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-abc")
 
         // Then
         XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty)
@@ -544,7 +544,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         // Flush second session
         let stopExpectation = self.expectation(description: "stop completed")
-        collector.stop()
+        collector.stop(sessionID: "session-2")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { stopExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
@@ -581,7 +581,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         // When — pause and wait for more potential samples
         let pauseExpectation = self.expectation(description: "pause settled")
-        collector.pause()
+        collector.pause(sessionID: "session-pause")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { pauseExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
@@ -591,7 +591,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         let countAfterSettle = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
         XCTAssertEqual(countAfterPause, countAfterSettle, "No further events should be written while paused")
-        collector.stop()
+        collector.stop(sessionID: "session-pause")
     }
 
     func testWhenResumedAfterPause_itContinuesSampling() {
@@ -610,7 +610,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.start(sessionID: "session-resume", applicationID: "app-1", sessionType: .user)
 
         let pauseExpectation = self.expectation(description: "pause settled")
-        collector.pause()
+        collector.pause(sessionID: "session-resume")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { pauseExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
@@ -619,10 +619,10 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         // When — resume and let samples accumulate
         let resumeExpectation = self.expectation(description: "resumed samples collected")
         resumeExpectation.assertForOverFulfill = false
-        collector.resume()
+        collector.resume(sessionID: "session-resume")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeExpectation.fulfill() }
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-resume")
 
         // Then — new events were written after resume
         let countAfterResume = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
@@ -655,14 +655,14 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         // When — pause on backgrounding
         let afterPauseExpectation = self.expectation(description: "sampling stopped after pause")
         afterPauseExpectation.assertForOverFulfill = false
-        collector.pause()
+        collector.pause(sessionID: "session-bg")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { afterPauseExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
         // Then — no new events accumulate while paused
         let countAfterPause = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
         XCTAssertEqual(countAfterPause, countBeforePause, "Sampling should stop while backgrounded, regardless of trackBackgroundEvents")
-        collector.stop()
+        collector.stop(sessionID: "session-bg")
     }
 
     func testWhenPauseCalledBeforeStart_itIsNoOp() {
@@ -676,8 +676,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         )
 
         // When / Then — should not crash
-        collector.pause()
-        collector.resume()
+        collector.pause(sessionID: "")
+        collector.resume(sessionID: "")
 
         let settleExpectation = self.expectation(description: "settle")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { settleExpectation.fulfill() }
@@ -724,7 +724,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-common", applicationID: "app-common", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-common")
 
         // Then
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -762,7 +762,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-context", applicationID: "app-context", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-context")
 
         // Then
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -791,7 +791,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         collector.start(sessionID: "session-abc", applicationID: "app-123", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop()
+        collector.stop(sessionID: "session-abc")
 
         // Then
         let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
@@ -803,6 +803,184 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(timestamps, timestamps.sorted(), "Timestamps should be monotonically increasing")
         XCTAssertEqual(event.timeseries.start, timestamps.first)
         XCTAssertEqual(event.timeseries.end, timestamps.last)
+    }
+
+    // MARK: - Session lifetime self-enforcement
+
+    func testWhenSessionExceedsMaxDuration_itSelfStopsAndFlushes() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let clock = MutableClock()
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush — only self-expiry triggers the flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000,
+            now: clock.now
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        let startTime = clock.date
+        collector.start(sessionID: "session-expired", applicationID: "app-1", sessionType: .user, startTime: startTime)
+
+        let beforeExpiryExpectation = self.expectation(description: "samples collected before expiry")
+        beforeExpiryExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { beforeExpiryExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Batch should not be flushed while the session is still within its max duration")
+
+        // When — advance the (injected) clock past the session's max duration, without ever calling stop()
+        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionMaxDuration)
+        let selfStopExpectation = self.expectation(description: "self-stop settled")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — the buffered samples were flushed once the session exceeded max duration
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty, "Expected the collector to self-flush once the session exceeded max duration")
+        let countAfterSelfStop = events.count
+
+        // And — no further samples accumulate afterwards (the timer was cancelled)
+        let settleExpectation = self.expectation(description: "no further samples after self-stop")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { settleExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        XCTAssertEqual(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count, countAfterSelfStop, "No further batches should be written after self-stop")
+    }
+
+    func testWhenNoActivityWithinTimeoutWindow_itSelfStopsAndFlushes() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let clock = MutableClock()
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush — only self-expiry triggers the flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000,
+            now: clock.now
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        let startTime = clock.date
+        collector.start(sessionID: "session-idle", applicationID: "app-1", sessionType: .user, startTime: startTime)
+
+        let beforeTimeoutExpectation = self.expectation(description: "samples collected before timeout")
+        beforeTimeoutExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { beforeTimeoutExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty)
+
+        // When — advance the clock past the inactivity timeout without ever calling noteActivity(sessionID:at:)
+        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let selfStopExpectation = self.expectation(description: "self-stop settled")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected the collector to self-flush once idle past the inactivity timeout")
+    }
+
+    func testNoteActivity_preventsSelfStopWithinTimeoutWindow() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let clock = MutableClock()
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000,
+            now: clock.now
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        let startTime = clock.date
+        collector.start(sessionID: "session-active", applicationID: "app-1", sessionType: .user, startTime: startTime)
+
+        // When — activity is reported right before what would have been the inactivity timeout, resetting the clock
+        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
+        collector.noteActivity(sessionID: "session-active", at: clock.date)
+        clock.date = clock.date.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
+
+        let expectation = self.expectation(description: "still sampling")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — sampling continued since activity reset the inactivity clock before it lapsed
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected sampling to continue since activity reset the inactivity clock")
+        collector.stop(sessionID: "session-active")
+    }
+
+    // MARK: - Session-ID guard against stale calls
+
+    func testStaleStopCall_afterNewSessionStarted_doesNotStopNewSession() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        collector.start(sessionID: "session-old", applicationID: "app-1", sessionType: .user)
+        collector.start(sessionID: "session-new", applicationID: "app-1", sessionType: .user)
+
+        // When — a stale stop() call for the already-replaced session arrives
+        collector.stop(sessionID: "session-old")
+
+        // Then — sampling for the new session continues uninterrupted
+        let expectation = self.expectation(description: "new session still sampling")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty, "Expected the new session to keep sampling despite a stale stop() call for the old session")
+        XCTAssertEqual(events.last?.session.id, "session-new")
+        collector.stop(sessionID: "session-new")
+    }
+
+    func testStalePauseCall_afterNewSessionStarted_doesNotPauseNewSession() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        collector.start(sessionID: "session-old", applicationID: "app-1", sessionType: .user)
+        collector.start(sessionID: "session-new", applicationID: "app-1", sessionType: .user)
+
+        // When — a stale pause() call for the already-replaced session arrives
+        collector.pause(sessionID: "session-old")
+
+        // Then — the new session keeps sampling, unaffected
+        let expectation = self.expectation(description: "new session still sampling despite stale pause")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected sampling to continue since the stale pause() targeted a different session")
+        collector.stop(sessionID: "session-new")
     }
 }
 
@@ -817,6 +995,18 @@ private class RUMActiveContextReaderMock: RUMActiveContextReader {
         self.globalAttributes = globalAttributes
         self.activeView = activeView
     }
+}
+
+/// A `Date` provider whose current time can be advanced manually, used to deterministically test the
+/// collector's self-enforced session expiry without waiting on real wall-clock durations.
+private class MutableClock {
+    var date: Date
+
+    init(date: Date = Date()) {
+        self.date = date
+    }
+
+    func now() -> Date { date }
 }
 
 #endif

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -971,6 +971,59 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-race")
     }
 
+    func testPause_afterSelfStopDueToExpiry_preventsLaterNoteActivityFromResuming() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let clock = MutableClock()
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush — only self-expiry/explicit flush triggers the flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000,
+            now: clock.now
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        let startTime = clock.date
+        collector.start(sessionID: "session-backgrounded", applicationID: "app-1", sessionType: .user, startTime: startTime)
+
+        let beforeTimeoutExpectation = self.expectation(description: "samples collected before timeout")
+        beforeTimeoutExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { beforeTimeoutExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // When — the session goes idle past the inactivity timeout, so `sample()` self-stops the timer
+        // (nil-ing it out) just before the app is backgrounded...
+        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        let selfStopExpectation = self.expectation(description: "self-stop settled")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        let countAfterSelfStop = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count
+        XCTAssertGreaterThan(countAfterSelfStop, 0, "Expected the collector to have self-stopped due to inactivity")
+
+        // ...and `didEnterBackground` is processed right after — with the timer already nil from the
+        // self-stop, this must still record the paused state, not silently no-op.
+        collector.pause(sessionID: "session-backgrounded")
+
+        // ...but a stale/racing RUM interaction for the same session still reaches `noteActivity` afterwards.
+        collector.noteActivity(sessionID: "session-backgrounded", at: clock.date)
+
+        // Then — sampling must stay stopped since the app is backgrounded, not resume behind the scenes
+        let settleExpectation = self.expectation(description: "settle after pause + noteActivity")
+        settleExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { settleExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        collector.flush()
+        XCTAssertEqual(
+            featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count,
+            countAfterSelfStop,
+            "Expected sampling to remain stopped since the app was backgrounded, despite the racing noteActivity call"
+        )
+    }
+
     // MARK: - Session-ID guard against stale calls
 
     func testStaleStopCall_afterNewSessionStarted_doesNotStopNewSession() {

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -1022,6 +1022,22 @@ class TimeseriesSessionCollectorTests: XCTestCase {
             countAfterSelfStop,
             "Expected sampling to remain stopped since the app was backgrounded, despite the racing noteActivity call"
         )
+
+        // And — a later `willEnterForeground` resume must still be able to restart sampling for this
+        // still-active session, even though the timer was already nil going into `pause(sessionID:)`.
+        collector.resume(sessionID: "session-backgrounded")
+        let resumeExpectation = self.expectation(description: "sampling resumed on foreground")
+        resumeExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+        collector.flush()
+        XCTAssertGreaterThan(
+            featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).count,
+            countAfterSelfStop,
+            "Expected sampling to resume once the app returns to the foreground"
+        )
+
+        collector.stop(sessionID: "session-backgrounded")
     }
 
     // MARK: - Session-ID guard against stale calls


### PR DESCRIPTION
### What and why?

Ties `TimeseriesSessionCollector`'s lifecycle to the RUM session's actual lifetime, addressing PR #3085 review comments #6/#11/#15: previously, an idle app with no RUM commands kept the collector sampling and uploading CPU/memory batches past the session's real 4h max-duration/15m inactivity expiry, since those checks only ran inside `RUMSessionScope.process(command:)`. The collector also had no protection against stale start/pause/resume/stop calls arriving out of order across session transitions.

Also removes a stale `enableTimeseries` doc-comment line in `RUMConfiguration.swift` left over from #3108 (per simaoseica-dd's nit).

Additionally addresses the remaining actionable PR #3085 review comments:
- Decouples `enableTimeseries` from `vitalsUpdateFrequency` — the collector now uses its own `VitalMemoryReader()` and is gated solely on `configuration.enableTimeseries`, instead of silently no-oping when `vitalsUpdateFrequency` is `.never`.
- Fixes `Monitor.process(command:)` snapshotting a stopped-but-retained view instead of the genuinely active one (`viewScopes.last` didn't filter on `isActiveView`).
- Splits a timeseries batch when the active view changes mid-batch, so a flushed event is never attributed to a mix of two views.
- Routes timeseries events through `RUMEventSanitizer` before writing, matching every other RUM event type (view/action/resource/error/long-task).
- Flushes buffered timeseries samples when the RUM feature's `flush()` is called, alongside App Hangs.

### Review checklist
- [x] Tests added (5 new for session lifecycle: self-stop on max duration, self-stop on inactivity, `noteActivity` preventing premature self-stop, stale-sessionID rejection for `stop`/`pause`; existing 28 `TimeseriesSessionCollectorTests` updated/passing for the sanitizer, view-change-split, and flush changes)
- [x] Commit references RUM-17879
- [ ] CHANGELOG — not user-facing (internal collector behavior, gated behind `@_spi(Experimental)`)
- [ ] Objective-C interface — no new public API
- [ ] `make api-surface` — no public signature changes
