### PR TITLE
fix: Expose an ObjC setter for consolePrint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [FIX] onSessionStart is now called only after sampling information used by WebView Tracking is in place, avoiding missing traces in early requests. See [#3104][]
 - [FIX] Fix crash when defining `onSessionStart` in RUM configuration in Swift 6 projects. See [#3106][]
 - [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
+- [IMPROVEMENT] Expose `setConsolePrint` to Objective-C, allowing ObjC client code to redirect SDK console output. See [#3120][]
 
 # 3.14.0 / 15-07-2026
 

--- a/DatadogCore/Tests/Objc/DDInternalLoggerTests.swift
+++ b/DatadogCore/Tests/Objc/DDInternalLoggerTests.swift
@@ -66,6 +66,26 @@ class DDInternalLoggerTests: XCTestCase {
         XCTAssertEqual(error.stack, stack)
     }
 
+    func testSetConsolePrintReplacesTheGlobalPrintFunction() {
+        // Given
+        let originalConsolePrint = DatadogInternal.consolePrint
+        defer { DatadogInternal.consolePrint = originalConsolePrint }
+
+        var capturedMessage: String? = nil
+        var capturedLevel: objc_CoreLoggerLevel? = nil
+
+        // When
+        objc_InternalLogger.setConsolePrint { message, level in
+            capturedMessage = message
+            capturedLevel = level
+        }
+        DatadogInternal.consolePrint("test message", .warn)
+
+        // Then
+        XCTAssertEqual(capturedMessage, "test message")
+        XCTAssertEqual(capturedLevel, .warn)
+    }
+
     func testWhenTelemetryIsSentThroughObjc_thenItForwardsToDDTelemetry() throws {
         CoreRegistry.register(default: core)
         defer { CoreRegistry.unregisterDefault() }

--- a/DatadogInternal/Sources/Telemetry/InternalLogger+objc.swift
+++ b/DatadogInternal/Sources/Telemetry/InternalLogger+objc.swift
@@ -23,6 +23,20 @@ public final class objc_InternalLogger: NSObject {
         DatadogInternal.consolePrint(message, coreLoggerLevel)
     }
 
+    /// Replaces the global `consolePrint` function used by the SDK to emit internal log messages.
+    @objc
+    public static func setConsolePrint(_ block: @escaping (String, objc_CoreLoggerLevel) -> Void) {
+        DatadogInternal.consolePrint = { message, level in
+            let objcLevel: objc_CoreLoggerLevel = switch level {
+            case .debug: .debug
+            case .warn: .warn
+            case .error: .error
+            case .critical: .critical
+            }
+            block(message, objcLevel)
+        }
+    }
+
     @objc
     public static func telemetryDebug(id: String, message: String) {
         CoreRegistry.default.telemetry.debug(id: id, message: message)


### PR DESCRIPTION
 ## Background

 ### InternalLogger produces private messages to OSLog

The SDK logs diagnostic output to the local device console via `InternalLogger`. By default, in iOS 14+, this implementation uses `OSLog`, and it flags all messages as `.private`.

For a developer testing an iOS app, reading OSLog messages requires `Console.app` or `idevicesyslog`, and messages are redacted due to their privacy setting:

```
MyApp(DatadogInternal)[123] <Fault>: <private>
```

 ### consolePrint can be overridden, but only in Swift

The SDK allows an application to override this default behavior, redirecting SDK output as desired. This is achieved by overwriting the global `consolePrint` variable with a different function, which `InternalLogger` will then use.

However, this override only works in Swift: global function-typed vars are not trivially exposed to Objective-C, and there's no existing setter function exposed in the Objective-C bindings.

 ## Changes in this PR

This PR adds a single function to the ObjC bindings for `InternalLogger`:

```
public static func setConsolePrint(_ block: @escaping (String, objc_CoreLoggerLevel) -> Void)
```

...where the provided `block` is wrapped and assigned to `DatadogInternal.consolePrint`.

This allows Objective-C client code to override `consolePrint` in the same way that Swift client code can.

 ## Testing

 ### Unit test coverage

The SDK's test suite has coverage for individual ObjC bindings, so I've added a simple test that verifies the expected behavior of `setConsolePrint`.

 ### Empirical test

In my test application, I can now provide a `consolePrint` callback that routes output to `NSLog`:

```objc
[DDDatadog setVerbosityLevel:DDCoreLoggerLevelDebug];
[DDInternalLogger setConsolePrint:^(NSString* message, DDCoreLoggerLevel level) {
    NSLog(@"[Datadog] %@", message);
}];
```

...and as a result, when I run my app with `devicectl device process launch --console`, I get unredacted output from the SDK:

```
MyApp[123:54321] [Datadog] 🔥 Datadog SDK usage error: `clientToken` cannot be empty.
```

## Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
