### PR TITLE
[PANA-8501] Report Session Replay experimental features in RUM

### DIFF
--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -722,6 +722,9 @@ public struct RUMActionEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -733,6 +736,7 @@ public struct RUMActionEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -742,16 +746,19 @@ public struct RUMActionEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -1734,6 +1741,9 @@ public struct RUMErrorEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -1745,6 +1755,7 @@ public struct RUMErrorEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -1754,16 +1765,19 @@ public struct RUMErrorEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -3175,6 +3189,9 @@ public struct RUMLongTaskEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -3186,6 +3203,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -3195,16 +3213,19 @@ public struct RUMLongTaskEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -4034,6 +4055,9 @@ public struct RUMResourceEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -4045,6 +4069,7 @@ public struct RUMResourceEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -4054,16 +4079,19 @@ public struct RUMResourceEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -5377,6 +5405,9 @@ public struct RUMTimeseriesCpuEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -5388,6 +5419,7 @@ public struct RUMTimeseriesCpuEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -5397,16 +5429,19 @@ public struct RUMTimeseriesCpuEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -5974,6 +6009,9 @@ public struct RUMTimeseriesMemoryEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -5985,6 +6023,7 @@ public struct RUMTimeseriesMemoryEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -5994,16 +6033,19 @@ public struct RUMTimeseriesMemoryEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -6731,6 +6773,9 @@ public struct RUMViewEvent: RUMDataModel {
             /// The id of the remote configuration applied to the SDK, if any
             public let remoteConfigurationId: String?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -6746,6 +6791,7 @@ public struct RUMViewEvent: RUMDataModel {
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
                 case remoteConfigurationId = "remote_configuration_id"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
@@ -6757,6 +6803,7 @@ public struct RUMViewEvent: RUMDataModel {
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
             ///   - remoteConfigurationId: The id of the remote configuration applied to the SDK, if any
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - startSessionReplayRecordingManually: Whether session replay recording configured to start manually
@@ -6764,6 +6811,7 @@ public struct RUMViewEvent: RUMDataModel {
             public init(
                 profilingSampleRate: Double? = nil,
                 remoteConfigurationId: String? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 startSessionReplayRecordingManually: Bool? = nil,
@@ -6771,6 +6819,7 @@ public struct RUMViewEvent: RUMDataModel {
             ) {
                 self.profilingSampleRate = profilingSampleRate
                 self.remoteConfigurationId = remoteConfigurationId
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.startSessionReplayRecordingManually = startSessionReplayRecordingManually
@@ -8898,6 +8947,9 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             /// The id of the remote configuration applied to the SDK, if any
             public let remoteConfigurationId: String?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -8913,6 +8965,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
                 case remoteConfigurationId = "remote_configuration_id"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case startSessionReplayRecordingManually = "start_session_replay_recording_manually"
@@ -8924,6 +8977,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
             ///   - remoteConfigurationId: The id of the remote configuration applied to the SDK, if any
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - startSessionReplayRecordingManually: Whether session replay recording configured to start manually
@@ -8931,6 +8985,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             public init(
                 profilingSampleRate: Double? = nil,
                 remoteConfigurationId: String? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 startSessionReplayRecordingManually: Bool? = nil,
@@ -8938,6 +8993,7 @@ public struct RUMViewUpdateEvent: RUMDataModel {
             ) {
                 self.profilingSampleRate = profilingSampleRate
                 self.remoteConfigurationId = remoteConfigurationId
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.startSessionReplayRecordingManually = startSessionReplayRecordingManually
@@ -11007,6 +11063,9 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -11018,6 +11077,7 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -11027,16 +11087,19 @@ public struct RUMVitalAppLaunchEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -11669,6 +11732,9 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -11680,6 +11746,7 @@ public struct RUMVitalDurationEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -11689,16 +11756,19 @@ public struct RUMVitalDurationEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -12291,6 +12361,9 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             /// The percentage of sessions profiled
             public let profilingSampleRate: Double?
 
+            /// Session Replay experimental features enabled in the SDK configuration
+            public let sessionReplayExperimentalFeatures: [String]?
+
             /// The percentage of sessions with RUM & Session Replay pricing tracked
             public let sessionReplaySampleRate: Double?
 
@@ -12302,6 +12375,7 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
 
             public enum CodingKeys: String, CodingKey {
                 case profilingSampleRate = "profiling_sample_rate"
+                case sessionReplayExperimentalFeatures = "session_replay_experimental_features"
                 case sessionReplaySampleRate = "session_replay_sample_rate"
                 case sessionSampleRate = "session_sample_rate"
                 case traceSampleRate = "trace_sample_rate"
@@ -12311,16 +12385,19 @@ public struct RUMVitalOperationStepEvent: RUMDataModel {
             ///
             /// - Parameters:
             ///   - profilingSampleRate: The percentage of sessions profiled
+            ///   - sessionReplayExperimentalFeatures: Session Replay experimental features enabled in the SDK configuration
             ///   - sessionReplaySampleRate: The percentage of sessions with RUM & Session Replay pricing tracked
             ///   - sessionSampleRate: The percentage of sessions tracked
             ///   - traceSampleRate: The percentage of sessions with traced resources
             public init(
                 profilingSampleRate: Double? = nil,
+                sessionReplayExperimentalFeatures: [String]? = nil,
                 sessionReplaySampleRate: Double? = nil,
                 sessionSampleRate: Double,
                 traceSampleRate: Double? = nil
             ) {
                 self.profilingSampleRate = profilingSampleRate
+                self.sessionReplayExperimentalFeatures = sessionReplayExperimentalFeatures
                 self.sessionReplaySampleRate = sessionReplaySampleRate
                 self.sessionSampleRate = sessionSampleRate
                 self.traceSampleRate = traceSampleRate
@@ -15493,4 +15570,4 @@ extension TelemetryUsageEvent.Telemetry {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/f3006920dbce58ebf21d6299016ffc5805164bbe
+// Generated from https://github.com/DataDog/rum-events-format/tree/00d5005015e04067bc591e618640de06ecbf7d23

--- a/DatadogInternal/Sources/Models/SessionReplay/SessionReplayCoreContext.swift
+++ b/DatadogInternal/Sources/Models/SessionReplay/SessionReplayCoreContext.swift
@@ -46,18 +46,23 @@ public enum SessionReplayCoreContext {
         public let sampleRate: SampleRate
         /// Whether session replay recording should be started manually.
         public let startRecordingManually: Bool
+        /// Session Replay experimental features enabled in the SDK configuration.
+        public let experimentalFeatures: [String]
 
         /// Creates a Session Replay configuration.
         ///
         /// - Parameters:
         ///   - sampleRate: The sample rate for session replay.
         ///   - startRecordingManually: Whether session replay recording should be started manually.
+        ///   - experimentalFeatures: Session Replay experimental features enabled in the SDK configuration.
         public init(
             sampleRate: SampleRate,
-            startRecordingManually: Bool
+            startRecordingManually: Bool,
+            experimentalFeatures: [String] = []
         ) {
             self.sampleRate = sampleRate
             self.startRecordingManually = startRecordingManually
+            self.experimentalFeatures = experimentalFeatures
         }
     }
 }

--- a/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels+objc.swift
@@ -282,6 +282,10 @@ public class objc_RUMActionEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -1462,6 +1466,10 @@ public class objc_RUMErrorEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -3389,6 +3397,10 @@ public class objc_RUMLongTaskEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -4698,6 +4710,10 @@ public class objc_RUMResourceEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -6354,6 +6370,10 @@ public class objc_RUMTimeseriesCpuEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -7273,6 +7293,10 @@ public class objc_RUMTimeseriesMemoryEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -8245,6 +8269,10 @@ public class objc_RUMViewEventDDConfiguration: NSObject {
 
     public var remoteConfigurationId: String? {
         root.swiftModel.dd.configuration!.remoteConfigurationId
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -10404,6 +10432,10 @@ public class objc_RUMViewUpdateEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.remoteConfigurationId
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -12522,6 +12554,10 @@ public class objc_RUMVitalAppLaunchEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -13678,6 +13714,10 @@ public class objc_RUMVitalDurationEventDDConfiguration: NSObject {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
     }
 
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
+    }
+
     public var sessionReplaySampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
@@ -14771,6 +14811,10 @@ public class objc_RUMVitalOperationStepEventDDConfiguration: NSObject {
 
     public var profilingSampleRate: NSNumber? {
         root.swiftModel.dd.configuration!.profilingSampleRate as NSNumber?
+    }
+
+    public var sessionReplayExperimentalFeatures: [String]? {
+        root.swiftModel.dd.configuration!.sessionReplayExperimentalFeatures
     }
 
     public var sessionReplaySampleRate: NSNumber? {
@@ -17450,4 +17494,4 @@ public class objc_TelemetryErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/f3006920dbce58ebf21d6299016ffc5805164bbe
+// Generated from https://github.com/DataDog/rum-events-format/tree/00d5005015e04067bc591e618640de06ecbf7d23

--- a/DatadogRUM/Sources/Integrations/SessionReplayDependency.swift
+++ b/DatadogRUM/Sources/Integrations/SessionReplayDependency.swift
@@ -10,6 +10,11 @@ import DatadogInternal
 // MARK: - Extracting SR context from `DatadogContext`
 
 extension DatadogContext {
+    /// The Session Replay configuration.
+    var sessionReplayConfiguration: SessionReplayCoreContext.Configuration? {
+        additionalContext(ofType: SessionReplayCoreContext.Configuration.self)
+    }
+
     /// The value indicating if replay is being performed by Session Replay.
     var hasReplay: Bool? {
         additionalContext(ofType: SessionReplayCoreContext.HasReplay.self)?.value

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -564,7 +564,7 @@ extension RUMViewScope {
         accessibilityState = currentAccessibilityState
 
         // Retrieve Session Replay config if any
-        let sessionReplayConfig = context.additionalContext(ofType: SessionReplayCoreContext.Configuration.self)
+        let sessionReplayConfig = context.sessionReplayConfiguration
         let profiling = context.additionalContext(ofType: ProfilingContext.self)?.ddProfiling
 
         let viewEvent = RUMViewEvent(
@@ -572,6 +572,7 @@ extension RUMViewScope {
                 browserSdkVersion: nil,
                 cls: nil,
                 configuration: .init(
+                    sessionReplayExperimentalFeatures: sessionReplayConfig?.experimentalFeatures,
                     sessionReplaySampleRate: sessionReplayConfig.map { Double($0.sampleRate) },
                     sessionSampleRate: Double(dependencies.samplingRate),
                     startSessionReplayRecordingManually: sessionReplayConfig?.startRecordingManually,

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -116,12 +116,14 @@ class RUMViewScopeTests: XCTestCase {
         let hasReplay: Bool = .mockRandom()
         let sessionReplaySampleRate: SampleRate = .mockRandom(min: 0, max: 100)
         let startRecordingManually: Bool = .random()
+        let sessionReplayExperimentalFeatures = ["composition_tree_recording", "swiftui"]
         var context = self.context
         context.set(additionalContext: SessionReplayCoreContext.HasReplay(value: hasReplay))
         context.set(additionalContext: SessionReplayCoreContext.RecordsCount(value: [scope.viewUUID.toRUMDataFormat: 1]))
         context.set(additionalContext: SessionReplayCoreContext.Configuration(
             sampleRate: sessionReplaySampleRate,
-            startRecordingManually: startRecordingManually
+            startRecordingManually: startRecordingManually,
+            experimentalFeatures: sessionReplayExperimentalFeatures
         ))
 
         _ = scope.process(
@@ -150,6 +152,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.dd.documentVersion, 1)
         XCTAssertEqual(event.dd.configuration?.traceSampleRate, Double(traceSampleRate))
         XCTAssertEqual(event.dd.configuration?.sessionReplaySampleRate, Double(sessionReplaySampleRate))
+        XCTAssertEqual(event.dd.configuration?.sessionReplayExperimentalFeatures, sessionReplayExperimentalFeatures)
         XCTAssertEqual(event.dd.configuration?.startSessionReplayRecordingManually, startRecordingManually)
         XCTAssertEqual(event.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
         XCTAssertEqual(event.source, .ios)
@@ -164,6 +167,38 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.os?.version, "os-version")
         XCTAssertEqual(event.os?.build, "os-build")
         XCTAssertEqual(event.dd.replayStats?.recordsCount, 1)
+    }
+
+    func testWhenSessionReplayHasNoExperimentalFeatures_itSendsEmptyExperimentalFeatures() throws {
+        let currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMViewScope(
+            isInitialView: true,
+            parent: parent,
+            dependencies: .mockAny(),
+            identity: .mockViewIdentifier(),
+            path: "UIViewController",
+            name: "ViewName",
+            customTimings: [:],
+            startTime: currentTime,
+            serverTimeOffset: .zero,
+            interactionToNextViewMetric: INVMetricMock(),
+            viewIndexInSession: .mockAny()
+        )
+
+        var context = self.context
+        context.set(additionalContext: SessionReplayCoreContext.Configuration(
+            sampleRate: .mockRandom(min: 0, max: 100),
+            startRecordingManually: .random()
+        ))
+
+        _ = scope.process(
+            command: RUMCommandMock(time: currentTime),
+            context: context,
+            writer: writer
+        )
+
+        let event = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).first)
+        XCTAssertEqual(event.dd.configuration?.sessionReplayExperimentalFeatures, [])
     }
 
     func testWhenInitialViewHasConfiguredSource_itSendsViewUpdateEventWithConfiguredSource() throws {

--- a/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
+++ b/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-06-29
-sdk_version: 3.13.0
-verified_against_commit: 48f0891ec
+last_updated: 2026-08-07
+sdk_version: 3.15.0
+verified_against_commit: 74689b369
 tracked_files:
   - DatadogSessionReplay/Sources/SessionReplay.swift
   - DatadogSessionReplay/Sources/SessionReplayConfiguration.swift

--- a/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
+++ b/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
@@ -18,7 +18,7 @@ internal struct RecordingComponents {
         resourcesWriter: any ResourcesWriting,
         srContextPublisher: SRContextPublisher
     ) throws {
-        if #available(iOS 13.0, tvOS 13.0, *), configuration.featureFlags[.layerTreeRecording] {
+        if #available(iOS 13.0, tvOS 13.0, *), configuration.featureFlags[.compositionTreeRecording] {
             // This is purely defensive, as `SessionReplay.enable()` initializes on the main thread
             self = try runOnMainThreadSync {
                 try .layerTreeRecordingComponents(

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -92,7 +92,8 @@ public enum SessionReplay {
         core.set(
             context: SessionReplayCoreContext.Configuration(
                 sampleRate: configuration.replaySampleRate,
-                startRecordingManually: !configuration.startRecordingImmediately
+                startRecordingManually: !configuration.startRecordingImmediately,
+                experimentalFeatures: configuration.featureFlags.stringValues
             )
         )
 

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -116,7 +116,7 @@ extension SessionReplay.Configuration {
 
         @_spi(Internal)
         @available(iOS 13.0, tvOS 13.0, *)
-        case layerTreeRecording
+        case compositionTreeRecording = "composition_tree_recording"
     }
 }
 
@@ -126,6 +126,13 @@ extension SessionReplay.Configuration.FeatureFlags {
         [
             .swiftui: false,
         ]
+    }
+
+    /// Enabled feature flag string values reported in RUM events.
+    internal var stringValues: [String] {
+        filter { $0.value }
+            .map { $0.key.rawValue }
+            .sorted()
     }
 
     /// Accesses a feature flag value.

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -31,12 +31,12 @@ class SessionReplayConfigurationTests: XCTestCase {
     }
 
     @available(iOS 13.0, tvOS 13.0, *)
-    func testDefaultConfigurationDisablesLayerTreeRecordingFeatureFlag() {
+    func testDefaultConfigurationDisablesCompositionTreeRecordingFeatureFlag() {
         // When
         let config = SessionReplay.Configuration()
 
         // Then
-        XCTAssertFalse(config.featureFlags[.layerTreeRecording])
+        XCTAssertFalse(config.featureFlags[.compositionTreeRecording])
     }
 
     func testDefaultConfigurationWithNewApi() {

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -142,6 +142,21 @@ class SessionReplayTests: XCTestCase {
         XCTAssertEqual(config.startRecordingManually, !startRecordingImmediately)
     }
 
+    @available(iOS 13.0, tvOS 13.0, *)
+    func testWhenEnabled_itUpdatesCoreContextWithEnabledFeatureFlags() throws {
+        let core = PassthroughCoreMock()
+        config.featureFlags[.swiftui] = true
+        config.featureFlags[.heatmaps] = true
+        config.featureFlags[.compositionTreeRecording] = true
+
+        // When
+        SessionReplay.enable(with: config, in: core)
+
+        // Then
+        let config = try XCTUnwrap(core.context.additionalContext(ofType: SessionReplayCoreContext.Configuration.self))
+        XCTAssertEqual(config.experimentalFeatures, ["composition_tree_recording", "heatmaps", "swiftui"])
+    }
+
     func testWhenEnabledWithCustomEndpoint() throws {
         let random: URL = .mockRandom()
         config.customEndpoint = random
@@ -182,9 +197,9 @@ class SessionReplayTests: XCTestCase {
     }
 
     @available(iOS 13.0, *)
-    func testWhenEnabledWithLayerTreeRecordingFeatureFlag_itUsesLayerTreeRecordingCoordinator() throws {
+    func testWhenEnabledWithCompositionTreeRecordingFeatureFlag_itUsesLayerTreeRecordingCoordinator() throws {
         // Given
-        config.featureFlags[.layerTreeRecording] = true
+        config.featureFlags[.compositionTreeRecording] = true
 
         // When
         SessionReplay.enable(with: config, in: core)

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
@@ -19,7 +19,7 @@ extension SessionReplay.Configuration.FeatureFlags {
         ]
 
         if #available(iOS 13.0, tvOS 13.0, *) {
-            flags[.layerTreeRecording] = true
+            flags[.compositionTreeRecording] = true
         }
 
         return flags

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -430,6 +430,7 @@ public class objc_RUMActionEventDDActionTarget: NSObject
     public var width: NSNumber?
 public class objc_RUMActionEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -663,6 +664,7 @@ public class objc_RUMErrorEventDD: NSObject
     public var traceId: String?
 public class objc_RUMErrorEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -1047,6 +1049,7 @@ public class objc_RUMLongTaskEventDD: NSObject
     public var session: objc_RUMLongTaskEventDDSession?
 public class objc_RUMLongTaskEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -1308,6 +1311,7 @@ public class objc_RUMResourceEventDD: NSObject
     public var traceId: String?
 public class objc_RUMResourceEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -1631,6 +1635,7 @@ public class objc_RUMTimeseriesCpuEventDD: NSObject
     public var session: objc_RUMTimeseriesCpuEventDDSession?
 public class objc_RUMTimeseriesCpuEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -1812,6 +1817,7 @@ public class objc_RUMTimeseriesMemoryEventDD: NSObject
     public var session: objc_RUMTimeseriesMemoryEventDDSession?
 public class objc_RUMTimeseriesMemoryEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -2004,6 +2010,7 @@ public class objc_RUMViewEventDDCLS: NSObject
 public class objc_RUMViewEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
     public var remoteConfigurationId: String?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var startSessionReplayRecordingManually: NSNumber?
@@ -2431,6 +2438,7 @@ public class objc_RUMViewUpdateEventDDCLS: NSObject
 public class objc_RUMViewUpdateEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
     public var remoteConfigurationId: String?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var startSessionReplayRecordingManually: NSNumber?
@@ -2850,6 +2858,7 @@ public class objc_RUMVitalAppLaunchEventDD: NSObject
     public var session: objc_RUMVitalAppLaunchEventDDSession?
 public class objc_RUMVitalAppLaunchEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -3080,6 +3089,7 @@ public class objc_RUMVitalDurationEventDD: NSObject
     public var session: objc_RUMVitalDurationEventDDSession?
 public class objc_RUMVitalDurationEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?
@@ -3299,6 +3309,7 @@ public class objc_RUMVitalOperationStepEventDD: NSObject
     public var session: objc_RUMVitalOperationStepEventDDSession?
 public class objc_RUMVitalOperationStepEventDDConfiguration: NSObject
     public var profilingSampleRate: NSNumber?
+    public var sessionReplayExperimentalFeatures: [String]?
     public var sessionReplaySampleRate: NSNumber?
     public var sessionSampleRate: NSNumber
     public var traceSampleRate: NSNumber?

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1524,7 +1524,7 @@ public enum SessionReplay
         case swiftui
         case heatmaps
         case screenChangeScheduling
-        case layerTreeRecording
+        case compositionTreeRecording = "composition_tree_recording"
 [?] extension SessionReplay.Configuration.FeatureFlags
     public static var defaults: Self
     public subscript(flag: Key) -> Bool


### PR DESCRIPTION
### What and why?

This PR reports enabled Session Replay experimental features in RUM view events under `_dd.configuration.session_replay_experimental_features`.

Related:
- https://github.com/DataDog/rum-events-format/pull/425

### How?

- Regenerates RUM models from `rum-events-format` with `session_replay_experimental_features`.
- Adds Session Replay experimental feature values to `SessionReplayCoreContext.Configuration`.
- Propagates those values from Session Replay configuration to RUM view events.
- Renames the internal preview flag to `compositionTreeRecording = "composition_tree_recording"`.
- Adds tests for both non-empty and empty experimental feature arrays.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
