### PR TITLE
fix(sr): snapshot the screen when a Session Replay slot ID changes

### DIFF
--- a/DatadogInternal/Sources/Models/SessionReplay/UIView+SessionReplaySlotID.swift
+++ b/DatadogInternal/Sources/Models/SessionReplay/UIView+SessionReplaySlotID.swift
@@ -17,27 +17,28 @@ public extension DatadogExtension where ExtendedType: UIView {
     ///
     /// The slot ID is supplied by the embedding SDK and is independent of the view's wireframe ID.
     var sessionReplaySlotID: String? {
-        get {
-            objc_getAssociatedObject(type, &sessionReplaySlotIDKey) as? String
-        }
-        nonmutating set {
-            guard newValue != sessionReplaySlotID else {
-                return
-            }
+        objc_getAssociatedObject(type, &sessionReplaySlotIDKey) as? String
+    }
 
-            objc_setAssociatedObject(
-                type,
-                &sessionReplaySlotIDKey,
-                newValue,
-                .OBJC_ASSOCIATION_COPY_NONATOMIC
-            )
-
-            // The view's contents are unchanged, but its representation in the wireframe tree is not.
-            // Marking it as needing layout makes Session Replay observe `CALayer.layoutSublayers` and
-            // record a new snapshot, so the slot is published without waiting for an unrelated
-            // screen change — the embedding host may not draw anything on its own.
-            runOnMainThreadSync { type.setNeedsLayout() }
+    /// Sets the Session Replay slot ID for this view.
+    ///
+    /// Changing the slot changes the recorded view hierarchy, so this triggers a new snapshot.
+    @available(iOS 13.0, tvOS 13.0, *)
+    @MainActor
+    func setSessionReplaySlotID(_ slotID: String?) {
+        guard slotID != sessionReplaySlotID else {
+            return
         }
+
+        objc_setAssociatedObject(
+            type,
+            &sessionReplaySlotIDKey,
+            slotID,
+            .OBJC_ASSOCIATION_COPY_NONATOMIC
+        )
+
+        // Changing the slot changes the recorded view hierarchy, so trigger a new snapshot.
+        type.setNeedsLayout()
     }
 }
 #endif

--- a/DatadogInternal/Sources/Models/SessionReplay/UIView+SessionReplaySlotID.swift
+++ b/DatadogInternal/Sources/Models/SessionReplay/UIView+SessionReplaySlotID.swift
@@ -21,12 +21,22 @@ public extension DatadogExtension where ExtendedType: UIView {
             objc_getAssociatedObject(type, &sessionReplaySlotIDKey) as? String
         }
         nonmutating set {
+            guard newValue != sessionReplaySlotID else {
+                return
+            }
+
             objc_setAssociatedObject(
                 type,
                 &sessionReplaySlotIDKey,
                 newValue,
                 .OBJC_ASSOCIATION_COPY_NONATOMIC
             )
+
+            // The view's contents are unchanged, but its representation in the wireframe tree is not.
+            // Marking it as needing layout makes Session Replay observe `CALayer.layoutSublayers` and
+            // record a new snapshot, so the slot is published without waiting for an unrelated
+            // screen change — the embedding host may not draw anything on its own.
+            runOnMainThreadSync { type.setNeedsLayout() }
         }
     }
 }

--- a/DatadogInternal/Tests/Models/UIViewSessionReplaySlotIDTests.swift
+++ b/DatadogInternal/Tests/Models/UIViewSessionReplaySlotIDTests.swift
@@ -36,7 +36,7 @@ struct UIViewSessionReplaySlotIDTests {
         let otherView = UIView()
 
         // when
-        view.dd.sessionReplaySlotID = "renderer-slot"
+        view.dd.setSessionReplaySlotID("renderer-slot")
 
         // then
         #expect(view.dd.sessionReplaySlotID == "renderer-slot")
@@ -48,10 +48,10 @@ struct UIViewSessionReplaySlotIDTests {
     func settingSlotIDToNilClearsIt() {
         // given
         let view = UIView()
-        view.dd.sessionReplaySlotID = "renderer-slot"
+        view.dd.setSessionReplaySlotID("renderer-slot")
 
         // when
-        view.dd.sessionReplaySlotID = nil
+        view.dd.setSessionReplaySlotID(nil)
 
         // then
         #expect(view.dd.sessionReplaySlotID == nil)
@@ -60,18 +60,32 @@ struct UIViewSessionReplaySlotIDTests {
     @available(iOS 13.0, *)
     @Test
     func changingSlotIDMarksTheViewAsNeedingLayout() {
-        // given — a view whose layout is up to date, as after a committed layout pass
+        // given
         let view = LayoutSpyView()
         view.layoutIfNeeded()
         view.setNeedsLayoutCount = 0
 
         // when
-        view.dd.sessionReplaySlotID = "renderer-slot"
+        view.dd.setSessionReplaySlotID("renderer-slot")
 
-        // then — Session Replay observes `CALayer.layoutSublayers`, so the slot is published
-        // on the next snapshot instead of waiting for an unrelated screen change
+        // then
         #expect(view.setNeedsLayoutCount == 1)
-        #expect(view.layer.needsLayout())
+    }
+
+    @available(iOS 13.0, *)
+    @Test
+    func settingSameSlotIDDoesNotMarkTheViewAsNeedingLayout() {
+        // given
+        let view = LayoutSpyView()
+        view.dd.setSessionReplaySlotID("renderer-slot")
+        view.layoutIfNeeded()
+        view.setNeedsLayoutCount = 0
+
+        // when
+        view.dd.setSessionReplaySlotID("renderer-slot")
+
+        // then
+        #expect(view.setNeedsLayoutCount == 0)
     }
 
     @available(iOS 13.0, *)
@@ -79,14 +93,14 @@ struct UIViewSessionReplaySlotIDTests {
     func clearingSlotIDMarksTheViewAsNeedingLayout() {
         // given
         let view = LayoutSpyView()
-        view.dd.sessionReplaySlotID = "renderer-slot"
+        view.dd.setSessionReplaySlotID("renderer-slot")
         view.layoutIfNeeded()
         view.setNeedsLayoutCount = 0
 
         // when
-        view.dd.sessionReplaySlotID = nil
+        view.dd.setSessionReplaySlotID(nil)
 
-        // then — the slot disappearing changes the wireframe tree just as much as it appearing
+        // then
         #expect(view.setNeedsLayoutCount == 1)
     }
 }

--- a/DatadogInternal/Tests/Models/UIViewSessionReplaySlotIDTests.swift
+++ b/DatadogInternal/Tests/Models/UIViewSessionReplaySlotIDTests.swift
@@ -56,5 +56,47 @@ struct UIViewSessionReplaySlotIDTests {
         // then
         #expect(view.dd.sessionReplaySlotID == nil)
     }
+
+    @available(iOS 13.0, *)
+    @Test
+    func changingSlotIDMarksTheViewAsNeedingLayout() {
+        // given — a view whose layout is up to date, as after a committed layout pass
+        let view = LayoutSpyView()
+        view.layoutIfNeeded()
+        view.setNeedsLayoutCount = 0
+
+        // when
+        view.dd.sessionReplaySlotID = "renderer-slot"
+
+        // then — Session Replay observes `CALayer.layoutSublayers`, so the slot is published
+        // on the next snapshot instead of waiting for an unrelated screen change
+        #expect(view.setNeedsLayoutCount == 1)
+        #expect(view.layer.needsLayout())
+    }
+
+    @available(iOS 13.0, *)
+    @Test
+    func clearingSlotIDMarksTheViewAsNeedingLayout() {
+        // given
+        let view = LayoutSpyView()
+        view.dd.sessionReplaySlotID = "renderer-slot"
+        view.layoutIfNeeded()
+        view.setNeedsLayoutCount = 0
+
+        // when
+        view.dd.sessionReplaySlotID = nil
+
+        // then — the slot disappearing changes the wireframe tree just as much as it appearing
+        #expect(view.setNeedsLayoutCount == 1)
+    }
+}
+
+private final class LayoutSpyView: UIView {
+    var setNeedsLayoutCount = 0
+
+    override func setNeedsLayout() {
+        setNeedsLayoutCount += 1
+        super.setNeedsLayout()
+    }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/ScreenChangeMonitorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/ScreenChangeMonitorTests.swift
@@ -6,7 +6,11 @@
 
 #if os(iOS)
 import QuartzCore
+import UIKit
 import XCTest
+
+@_spi(Internal)
+import DatadogInternal
 
 @testable import DatadogSessionReplay
 
@@ -16,6 +20,7 @@ final class ScreenChangeMonitorTests: XCTestCase {
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var screenChangeMonitor: ScreenChangeMonitor!
     private var changesets: [CALayerChangeset] = []
+    private var window: UIWindow?
 
     override func setUp() async throws {
         try await super.setUp()
@@ -29,6 +34,10 @@ final class ScreenChangeMonitorTests: XCTestCase {
     }
 
     override func tearDown() {
+        screenChangeMonitor?.stop()
+        screenChangeMonitor = nil
+        window?.isHidden = true
+        window = nil
         changesets.removeAll()
         super.tearDown()
     }
@@ -69,5 +78,70 @@ final class ScreenChangeMonitorTests: XCTestCase {
         // then
         XCTAssertEqual(changesets.count, 0, "Should ignore layer changes after calling stop()")
     }
+
+    // MARK: - Session Replay slot IDs
+    //
+    // The embedding host renders through a `CAMetalLayer`, which never triggers `display` or
+    // `draw(in:)` on its own. Without a change reported when the slot is assigned, the embedded
+    // content could stay unrecorded until something unrelated changed on screen.
+
+    @available(iOS 13.0, *)
+    func testWhenSlotIDIsAssignedToMetalBackedViewInWindow_itReportsLayoutChange() {
+        // given — a Metal-backed view on screen with its layout settled, as after the host
+        // presented the embedded content
+        let view = MetalBackedView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        let window = makeKeyWindow(with: view)
+        CATransaction.flush()
+
+        screenChangeMonitor.start()
+        testTimerScheduler.advance(to: 1.00)
+        changesets.removeAll()
+
+        // when — the embedding SDK registers the slot. Nothing else on screen changes.
+        view.dd.sessionReplaySlotID = "renderer-slot"
+        CATransaction.flush()
+
+        // then — the swizzled `CALayer.layoutSublayers` fired, even though the layer draws
+        // none of its contents through Core Animation
+        testTimerScheduler.advance(to: 1.20)
+        XCTAssertTrue(view.layer is CAMetalLayer)
+        XCTAssertEqual(changesets.count, 1)
+        XCTAssertEqual(changesets.first?.aspects(for: .init(view.layer)), .layout)
+        withExtendedLifetime(window) {}
+    }
+
+    @available(iOS 13.0, *)
+    func testWhenSlotIDIsAssignedBeforeTheViewIsOnScreen_itReportsLayoutChangeOnAttachment() {
+        // given — the slot is minted eagerly, before the host presents the view. A detached
+        // layer is not in the render tree, so no layout pass runs for it yet.
+        let view = MetalBackedView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        screenChangeMonitor.start()
+        testTimerScheduler.advance(to: 1.00)
+        view.dd.sessionReplaySlotID = "renderer-slot"
+
+        // when — the host presents it
+        let window = makeKeyWindow(with: view)
+        CATransaction.flush()
+
+        // then — the pending layout is flushed on attachment, so the slot is still recorded
+        testTimerScheduler.advance(to: 1.20)
+        let aspects = changesets.map { $0.aspects(for: .init(view.layer)) }
+        XCTAssertTrue(aspects.contains { $0?.contains(.layout) == true }, "got \(aspects)")
+        withExtendedLifetime(window) {}
+    }
+
+    private func makeKeyWindow(with view: UIView) -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        window.addSubview(view)
+        window.makeKeyAndVisible()
+        self.window = window
+        return window
+    }
+}
+
+/// Mimics `FlutterView`, which renders through Metal rather than Core Animation.
+@available(iOS 13.0, *)
+private final class MetalBackedView: UIView {
+    override class var layerClass: AnyClass { CAMetalLayer.self }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/ScreenChangeMonitorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/ScreenChangeMonitorTests.swift
@@ -6,11 +6,7 @@
 
 #if os(iOS)
 import QuartzCore
-import UIKit
 import XCTest
-
-@_spi(Internal)
-import DatadogInternal
 
 @testable import DatadogSessionReplay
 
@@ -20,7 +16,6 @@ final class ScreenChangeMonitorTests: XCTestCase {
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var screenChangeMonitor: ScreenChangeMonitor!
     private var changesets: [CALayerChangeset] = []
-    private var window: UIWindow?
 
     override func setUp() async throws {
         try await super.setUp()
@@ -36,8 +31,6 @@ final class ScreenChangeMonitorTests: XCTestCase {
     override func tearDown() {
         screenChangeMonitor?.stop()
         screenChangeMonitor = nil
-        window?.isHidden = true
-        window = nil
         changesets.removeAll()
         super.tearDown()
     }
@@ -78,70 +71,5 @@ final class ScreenChangeMonitorTests: XCTestCase {
         // then
         XCTAssertEqual(changesets.count, 0, "Should ignore layer changes after calling stop()")
     }
-
-    // MARK: - Session Replay slot IDs
-    //
-    // The embedding host renders through a `CAMetalLayer`, which never triggers `display` or
-    // `draw(in:)` on its own. Without a change reported when the slot is assigned, the embedded
-    // content could stay unrecorded until something unrelated changed on screen.
-
-    @available(iOS 13.0, *)
-    func testWhenSlotIDIsAssignedToMetalBackedViewInWindow_itReportsLayoutChange() {
-        // given — a Metal-backed view on screen with its layout settled, as after the host
-        // presented the embedded content
-        let view = MetalBackedView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
-        let window = makeKeyWindow(with: view)
-        CATransaction.flush()
-
-        screenChangeMonitor.start()
-        testTimerScheduler.advance(to: 1.00)
-        changesets.removeAll()
-
-        // when — the embedding SDK registers the slot. Nothing else on screen changes.
-        view.dd.sessionReplaySlotID = "renderer-slot"
-        CATransaction.flush()
-
-        // then — the swizzled `CALayer.layoutSublayers` fired, even though the layer draws
-        // none of its contents through Core Animation
-        testTimerScheduler.advance(to: 1.20)
-        XCTAssertTrue(view.layer is CAMetalLayer)
-        XCTAssertEqual(changesets.count, 1)
-        XCTAssertEqual(changesets.first?.aspects(for: .init(view.layer)), .layout)
-        withExtendedLifetime(window) {}
-    }
-
-    @available(iOS 13.0, *)
-    func testWhenSlotIDIsAssignedBeforeTheViewIsOnScreen_itReportsLayoutChangeOnAttachment() {
-        // given — the slot is minted eagerly, before the host presents the view. A detached
-        // layer is not in the render tree, so no layout pass runs for it yet.
-        let view = MetalBackedView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
-        screenChangeMonitor.start()
-        testTimerScheduler.advance(to: 1.00)
-        view.dd.sessionReplaySlotID = "renderer-slot"
-
-        // when — the host presents it
-        let window = makeKeyWindow(with: view)
-        CATransaction.flush()
-
-        // then — the pending layout is flushed on attachment, so the slot is still recorded
-        testTimerScheduler.advance(to: 1.20)
-        let aspects = changesets.map { $0.aspects(for: .init(view.layer)) }
-        XCTAssertTrue(aspects.contains { $0?.contains(.layout) == true }, "got \(aspects)")
-        withExtendedLifetime(window) {}
-    }
-
-    private func makeKeyWindow(with view: UIView) -> UIWindow {
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
-        window.addSubview(view)
-        window.makeKeyAndVisible()
-        self.window = window
-        return window
-    }
-}
-
-/// Mimics `FlutterView`, which renders through Metal rather than Core Animation.
-@available(iOS 13.0, *)
-private final class MetalBackedView: UIView {
-    override class var layerClass: AnyClass { CAMetalLayer.self }
 }
 #endif

--- a/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/ScreenChangeMonitorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/ScreenChangeMonitorTests.swift
@@ -29,8 +29,6 @@ final class ScreenChangeMonitorTests: XCTestCase {
     }
 
     override func tearDown() {
-        screenChangeMonitor?.stop()
-        screenChangeMonitor = nil
         changesets.removeAll()
         super.tearDown()
     }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/EmbeddedContentViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/EmbeddedContentViewRecorderTests.swift
@@ -45,7 +45,7 @@ struct EmbeddedContentViewRecorderTests {
         let recorder = EmbeddedContentViewRecorder(identifier: UUID())
         let context = ViewTreeRecordingContext.mockWith()
         let embeddedContentView = UIView()
-        embeddedContentView.dd.sessionReplaySlotID = "opaque-slot"
+        embeddedContentView.dd.setSessionReplaySlotID("opaque-slot")
 
         // When
         let semantics = try #require(
@@ -94,7 +94,7 @@ struct EmbeddedContentViewRecorderTests {
             )
         })
         let embeddedContentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        embeddedContentView.dd.sessionReplaySlotID = "opaque-slot"
+        embeddedContentView.dd.setSessionReplaySlotID("opaque-slot")
         embeddedContentView.addSubview(UIView(frame: embeddedContentView.bounds))
         let context = ViewTreeRecordingContext.mockWith(coordinateSpace: embeddedContentView)
         let viewTreeRecorder = ViewTreeRecorder(nodeRecorders: [recorder, fallbackRecorder])
@@ -113,7 +113,7 @@ struct EmbeddedContentViewRecorderTests {
         // Given
         let embeddedContentRecorder = EmbeddedContentViewRecorder(identifier: UUID())
         let embeddedContentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        embeddedContentView.dd.sessionReplaySlotID = "opaque-slot"
+        embeddedContentView.dd.setSessionReplaySlotID("opaque-slot")
         let context = ViewTreeRecordingContext.mockWith(coordinateSpace: embeddedContentView)
         _ = embeddedContentRecorder.semantics(
             of: embeddedContentView,
@@ -155,7 +155,7 @@ struct EmbeddedContentViewRecorderTests {
         let recorder = EmbeddedContentViewRecorder(identifier: UUID())
         let context = ViewTreeRecordingContext.mockWith()
         let embeddedContentView = UIView()
-        embeddedContentView.dd.sessionReplaySlotID = "opaque-slot"
+        embeddedContentView.dd.setSessionReplaySlotID("opaque-slot")
 
         // When
         let semantics = try #require(
@@ -187,9 +187,9 @@ struct EmbeddedContentViewRecorderTests {
         let recorder = EmbeddedContentViewRecorder(identifier: UUID())
         let context = ViewTreeRecordingContext.mockWith()
         let firstEmbeddedContentView = UIView()
-        firstEmbeddedContentView.dd.sessionReplaySlotID = "first-slot"
+        firstEmbeddedContentView.dd.setSessionReplaySlotID("first-slot")
         let secondEmbeddedContentView = UIView()
-        secondEmbeddedContentView.dd.sessionReplaySlotID = "second-slot"
+        secondEmbeddedContentView.dd.setSessionReplaySlotID("second-slot")
 
         // When
         let firstSemantics = try #require(

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -13,6 +13,7 @@ import DatadogInternal
 @_spi(Internal)
 @testable import DatadogSessionReplay
 
+@MainActor
 class ViewTreeSnapshotBuilderTests: XCTestCase {
     func testWhenQueryingNodeRecorders_itPassesAppropriateContext() throws {
         // Given
@@ -160,13 +161,14 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         XCTAssertTrue(registry.identifiers.isEmpty)
     }
 
+    @available(iOS 13.0, *)
     func testSnapshotIncludesEveryEmbeddedContentSlot() {
         // Given
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
         let firstEmbeddedContentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        firstEmbeddedContentView.dd.sessionReplaySlotID = "first-slot"
+        firstEmbeddedContentView.dd.setSessionReplaySlotID("first-slot")
         let secondEmbeddedContentView = UIView(frame: CGRect(x: 100, y: 0, width: 100, height: 100))
-        secondEmbeddedContentView.dd.sessionReplaySlotID = "second-slot"
+        secondEmbeddedContentView.dd.setSessionReplaySlotID("second-slot")
         rootView.addSubview(firstEmbeddedContentView)
         rootView.addSubview(secondEmbeddedContentView)
         let builder = ViewTreeSnapshotBuilder(
@@ -183,12 +185,13 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         XCTAssertEqual(snapshot.embeddedContentSlots.count, 2)
     }
 
+    @available(iOS 13.0, *)
     func testWhenUIKitViewHasSessionReplaySlotID_itIsRecordedAsEmbeddedContent() {
         // Given
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
         let embeddedContentLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         embeddedContentLabel.text = "Native label"
-        embeddedContentLabel.dd.sessionReplaySlotID = "embedded-slot"
+        embeddedContentLabel.dd.setSessionReplaySlotID("embedded-slot")
         rootView.addSubview(embeddedContentLabel)
         let builder = ViewTreeSnapshotBuilder(
             additionalNodeRecorders: [],
@@ -205,11 +208,12 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         XCTAssertFalse(snapshot.nodes.contains { $0.wireframesBuilder is UILabelWireframesBuilder })
     }
 
+    @available(iOS 13.0, *)
     func testDetachedEmbeddedContentViewRemainsCachedWhileAlive() {
         // Given
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
         let embeddedContentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        embeddedContentView.dd.sessionReplaySlotID = "retained-slot"
+        embeddedContentView.dd.setSessionReplaySlotID("retained-slot")
         rootView.addSubview(embeddedContentView)
         let builder = ViewTreeSnapshotBuilder(
             additionalNodeRecorders: [],
@@ -227,6 +231,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         withExtendedLifetime(embeddedContentView) {}
     }
 
+    @available(iOS 13.0, *)
     func testSnapshotExcludesDeallocatedEmbeddedContentViews() {
         // Given
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
@@ -239,7 +244,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         var initialSlots: [WireframeID: String] = [:]
         autoreleasepool {
             let embeddedContentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-            embeddedContentView.dd.sessionReplaySlotID = "released-slot"
+            embeddedContentView.dd.setSessionReplaySlotID("released-slot")
             weakEmbeddedContentView = embeddedContentView
             rootView.addSubview(embeddedContentView)
             initialSlots = builder.createSnapshot(of: rootView, with: .mockAny()).embeddedContentSlots


### PR DESCRIPTION
### What and why?

Session Replay only snapshots on a swizzled CALayer callback, so a slot assigned by an embedding host stayed unpublished until something unrelated redrew the screen — in an add-to-app host embedding Flutter, possibly never.

### How?

Mark the view as needing layout on assignment so `layoutSublayers` fires and the next snapshot carries the placeholder. `setNeedsLayout`, not `setNeedsDisplay`: the contents didn't change, only the wireframe tree.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
