### PR TITLE
RUM-17922: Report client side stats to configuration telemetry

### DIFF
--- a/DatadogInternal/Sources/Telemetry/Telemetry.swift
+++ b/DatadogInternal/Sources/Telemetry/Telemetry.swift
@@ -58,6 +58,7 @@ public struct ConfigurationTelemetry: Equatable {
     public let mauiVersion: String?
     public let useAllowedTracingUrls: Bool?
     public let useBeforeSend: Bool?
+    public let useClientSideStats: Bool?
     public let useExcludedActivityUrls: Bool?
     public let useFirstPartyHosts: Bool?
     public let useLocalEncryption: Bool?
@@ -440,6 +441,7 @@ extension Telemetry {
         mauiVersion: String? = nil,
         useAllowedTracingUrls: Bool? = nil,
         useBeforeSend: Bool? = nil,
+        useClientSideStats: Bool? = nil,
         useExcludedActivityUrls: Bool? = nil,
         useFirstPartyHosts: Bool? = nil,
         useLocalEncryption: Bool? = nil,
@@ -499,6 +501,7 @@ extension Telemetry {
             mauiVersion: mauiVersion,
             useAllowedTracingUrls: useAllowedTracingUrls,
             useBeforeSend: useBeforeSend,
+            useClientSideStats: useClientSideStats,
             useExcludedActivityUrls: useExcludedActivityUrls,
             useFirstPartyHosts: useFirstPartyHosts,
             useLocalEncryption: useLocalEncryption,
@@ -643,6 +646,7 @@ extension ConfigurationTelemetry {
             mauiVersion: other.mauiVersion ?? mauiVersion,
             useAllowedTracingUrls: other.useAllowedTracingUrls ?? useAllowedTracingUrls,
             useBeforeSend: other.useBeforeSend ?? useBeforeSend,
+            useClientSideStats: other.useClientSideStats ?? useClientSideStats,
             useExcludedActivityUrls: other.useExcludedActivityUrls ?? useExcludedActivityUrls,
             useFirstPartyHosts: other.useFirstPartyHosts ?? useFirstPartyHosts,
             useLocalEncryption: other.useLocalEncryption ?? useLocalEncryption,

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -467,6 +467,7 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             useAllowedTracingOrigins: nil,
             useAllowedTracingUrls: nil,
             useBeforeSend: nil,
+            useClientSideStats: configuration.useClientSideStats,
             useCrossSiteSessionCookie: nil,
             useExcludedActivityUrls: nil,
             useFirstPartyHosts: configuration.useFirstPartyHosts,

--- a/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift
@@ -355,6 +355,7 @@ class TelemetryReceiverTests: XCTestCase {
         let trackViewsManually: Bool? = .mockRandom()
         let unityVersion: String? = .mockRandom()
         let mauiVersion: String? = .mockRandom()
+        let useClientSideStats: Bool? = .mockRandom()
         let useFirstPartyHosts: Bool? = .mockRandom()
         let useLocalEncryption: Bool? = .mockRandom()
         let useProxy: Bool? = .mockRandom()
@@ -386,6 +387,7 @@ class TelemetryReceiverTests: XCTestCase {
             trackViewsManually: trackViewsManually,
             unityVersion: unityVersion,
             mauiVersion: mauiVersion,
+            useClientSideStats: useClientSideStats,
             useFirstPartyHosts: useFirstPartyHosts,
             useLocalEncryption: useLocalEncryption,
             useProxy: useProxy,
@@ -423,6 +425,7 @@ class TelemetryReceiverTests: XCTestCase {
         XCTAssertEqual(event?.telemetry.configuration.trackViewsManually, trackViewsManually)
         XCTAssertEqual(event?.telemetry.configuration.unityVersion, unityVersion)
         XCTAssertEqual(event?.telemetry.configuration.mauiVersion, mauiVersion)
+        XCTAssertEqual(event?.telemetry.configuration.useClientSideStats, useClientSideStats)
         XCTAssertEqual(event?.telemetry.configuration.useFirstPartyHosts, useFirstPartyHosts)
         XCTAssertEqual(event?.telemetry.configuration.useLocalEncryption, useLocalEncryption)
         XCTAssertEqual(event?.telemetry.configuration.useProxy, useProxy)

--- a/DatadogTrace/Sources/Feature/TraceFeature.swift
+++ b/DatadogTrace/Sources/Feature/TraceFeature.swift
@@ -58,6 +58,6 @@ internal final class TraceFeature: DatadogRemoteFeature {
         self.performanceOverride = nil
 
         // Send configuration telemetry:
-        core.telemetry.configuration(useTracing: true)
+        core.telemetry.configuration(useClientSideStats: configuration.statsComputationEnabled, useTracing: true)
     }
 }

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -715,6 +715,7 @@ extension TelemetryConfigurationEvent: RandomMockable {
                     useAllowedTracingOrigins: .mockRandom(),
                     useAllowedTracingUrls: nil,
                     useBeforeSend: nil,
+                    useClientSideStats: .mockRandom(),
                     useCrossSiteSessionCookie: nil,
                     useExcludedActivityUrls: nil,
                     useFirstPartyHosts: .mockRandom(),


### PR DESCRIPTION
### What and why?
Wire the Trace configuration `statsComputationEnabled` into `use_client_side_stats` telemetry

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
