### PR TITLE
Expose composition tree recording feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FEATURE] Add an experimental Core Animation recording pipeline for Session Replay, available through the `compositionTreeRecording` feature flag. See [#3127][]
 - [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
 
 # 3.15.0 / 05-08-2026
@@ -1221,6 +1222,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3106]: https://github.com/DataDog/dd-sdk-ios/pull/3106
 [#3109]: https://github.com/DataDog/dd-sdk-ios/pull/3109
 [#3074]: https://github.com/DataDog/dd-sdk-ios/pull/3074
+[#3127]: https://github.com/DataDog/dd-sdk-ios/pull/3127
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
+++ b/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-07
+last_updated: 2026-08-10
 sdk_version: 3.15.0
-verified_against_commit: df6ccc593
+verified_against_commit: 857787064
 tracked_files:
   - DatadogSessionReplay/Sources/SessionReplay.swift
   - DatadogSessionReplay/Sources/SessionReplayConfiguration.swift

--- a/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
+++ b/DatadogSessionReplay/SESSION_REPLAY_FEATURE.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-08-07
 sdk_version: 3.15.0
-verified_against_commit: 74689b369
+verified_against_commit: df6ccc593
 tracked_files:
   - DatadogSessionReplay/Sources/SessionReplay.swift
   - DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -94,6 +94,7 @@ SessionReplay.enable(
         //   .swiftui                - Enable SwiftUI recording (experimental)
         //   .heatmaps               - Enable heatmap identifier computation (experimental)
         //   .screenChangeScheduling - DEPRECATED: now default and always enabled; setting it has no effect
+        //   .compositionTreeRecording - Enable the Core Animation recording pipeline (experimental, iOS 13+)
         featureFlags: [
             .swiftui: true,   // Enable SwiftUI recording (experimental)
             .heatmaps: false  // Enable heatmap identifier computation (experimental)
@@ -233,6 +234,7 @@ SessionReplayPrivacyView(
 - `.swiftui` — Enable SwiftUI recording (experimental, default: `false`)
 - `.heatmaps` — Enable heatmap identifier computation (experimental, default: `false`)
 - `.screenChangeScheduling` — **Deprecated.** Screen change scheduling is now the default and always enabled; setting this flag has no effect. Kept on the public API for backward compatibility.
+- `.compositionTreeRecording` — Enable the Core Animation recording pipeline (experimental, iOS 13+, default: `false`)
 
 ## Feature Interactions
 

--- a/DatadogSessionReplay/Sources/SessionReplay+objc.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay+objc.swift
@@ -129,6 +129,7 @@ public final class objc_SessionReplayConfiguration: NSObject {
     /// Available flags:
     /// - `swiftui`: `false` by default.
     /// - `heatmaps`: `false` by default.
+    /// - `composition_tree_recording`: `false` by default (iOS 13+).
     @objc public var featureFlags: [String: Bool] {
         set { _swift.featureFlags = newValue.dd.featureFlags }
         get { _swift.featureFlags.dd.featureFlags }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -114,7 +114,12 @@ extension SessionReplay.Configuration {
         @available(*, deprecated, message: "Screen change scheduling is now the default and always enabled. This flag has no effect.")
         case screenChangeScheduling
 
-        @_spi(Internal)
+        /// Enables the experimental Core Animation recording pipeline.
+        ///
+        /// The default recorder builds replay wireframes from semantic information
+        /// extracted from UIKit and SwiftUI properties. This pipeline uses the rendered
+        /// layer tree as its primary source, preserving its structure and rendering
+        /// effects to improve replay fidelity in UIKit, SwiftUI, and React Native apps.
         @available(iOS 13.0, tvOS 13.0, *)
         case compositionTreeRecording = "composition_tree_recording"
     }

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
@@ -160,7 +160,7 @@ struct LayerTreeSnapshotBuilderTests {
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
         let embeddedContentView = UILabel(frame: CGRect(x: 10, y: 20, width: 100, height: 80))
         embeddedContentView.text = "Native label"
-        embeddedContentView.dd.sessionReplaySlotID = "embedded-slot"
+        embeddedContentView.dd.setSessionReplaySlotID("embedded-slot")
         embeddedContentView.addSubview(UIView(frame: embeddedContentView.bounds))
         rootView.addSubview(embeddedContentView)
 


### PR DESCRIPTION
### What and why?

Expose `SessionReplay.Configuration.FeatureFlag.compositionTreeRecording` as public API so customers can opt into the experimental Core Animation recording pipeline during preview.

Depends on:
- #3123

### How?

Remove `@_spi(Internal)` from `compositionTreeRecording` and add public documentation explaining how the experimental pipeline differs from the default recorder.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
