### PR TITLE
fix: Crash in the attribute encoder when an attribute throws mid-encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FEATURE] Add an experimental Core Animation recording pipeline for Session Replay, available through the `compositionTreeRecording` feature flag. See [#3127][]
 - [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
+- [FIX] Fix `EXC_BREAKPOINT` crash when a log or RUM attribute's `encode(to:)` throws after partially encoding a value. [#3131][]
 
 # 3.15.0 / 05-08-2026
 

--- a/DatadogInternal/Sources/Attributes/AttributeEncoding.swift
+++ b/DatadogInternal/Sources/Attributes/AttributeEncoding.swift
@@ -48,6 +48,9 @@ public extension KeyedEncodingContainer {
         context: AttributeEncodingContext = .custom
     ) {
         do {
+            // Values that throw mid-encode corrupt the encoder;
+            // Probe on a throwaway encoder before the real one.
+            _ = try JSONEncoder.dd.default().encode([value])
             try encode(value, forKey: key)
         } catch {
             let contextPrefix = context.errorMessagePrefix

--- a/DatadogInternal/Sources/Attributes/AttributeEncoding.swift
+++ b/DatadogInternal/Sources/Attributes/AttributeEncoding.swift
@@ -48,16 +48,34 @@ public extension KeyedEncodingContainer {
         context: AttributeEncodingContext = .custom
     ) {
         do {
-            // Values that throw mid-encode corrupt the encoder;
-            // Encode on an isolated encoder, decode the safe result, re-encode
-            let data = try JSONEncoder.dd.default().encode([value])
-            let safe = try JSONDecoder().decode([AnyCodable].self, from: data)
-            try encode(safe[0], forKey: key)
+            if isPartialEncodeSafe(value) {
+                try encode(value, forKey: key)
+            } else {
+                // Values that throw mid-encode corrupt the encoder;
+                // Encode on an isolated encoder, decode the safe result, re-encode
+                let data = try JSONEncoder.dd.default().encode([value])
+                let safe = try JSONDecoder().decode([AnyCodable].self, from: data)
+                try encode(safe[0], forKey: key)
+            }
         } catch {
             let contextPrefix = context.errorMessagePrefix
             DD.logger.error(
                 "Failed to encode \(contextPrefix)attribute '\(attributeName)': \(error). This attribute will be dropped from the event."
             )
         }
+    }
+}
+
+private func isPartialEncodeSafe(_ value: Any) -> Bool {
+    let value = (value as? _AnyEncodable)?.value ?? value
+    switch value {
+    case is String, is Bool,
+         is Int, is Int8, is Int16, is Int32, is Int64,
+         is UInt, is UInt8, is UInt16, is UInt32, is UInt64,
+         is Float, is Double,
+         is NSNumber, is NSNull, is Date, is URL, is Void:
+        return true
+    default:
+        return false
     }
 }

--- a/DatadogInternal/Sources/Attributes/AttributeEncoding.swift
+++ b/DatadogInternal/Sources/Attributes/AttributeEncoding.swift
@@ -49,9 +49,10 @@ public extension KeyedEncodingContainer {
     ) {
         do {
             // Values that throw mid-encode corrupt the encoder;
-            // Probe on a throwaway encoder before the real one.
-            _ = try JSONEncoder.dd.default().encode([value])
-            try encode(value, forKey: key)
+            // Encode on an isolated encoder, decode the safe result, re-encode
+            let data = try JSONEncoder.dd.default().encode([value])
+            let safe = try JSONDecoder().decode([AnyCodable].self, from: data)
+            try encode(safe[0], forKey: key)
         } catch {
             let contextPrefix = context.errorMessagePrefix
             DD.logger.error(

--- a/DatadogInternal/Tests/AttributeEncodingTests.swift
+++ b/DatadogInternal/Tests/AttributeEncodingTests.swift
@@ -268,6 +268,54 @@ class AttributeEncodingTests: XCTestCase {
         )
     }
 
+    func testEncodeAttributeWithEncoderDependentValueDoesNotAffectSubsequentAttributes() throws {
+        // Given
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        // Encodes only the first time; on any later call it writes a value and throws.
+        final class SucceedsOnceThenWritesAndThrows: Encodable {
+            private var encodeCalls = 0
+
+            func encode(to encoder: Encoder) throws {
+                encodeCalls += 1
+                var container = encoder.singleValueContainer()
+                if encodeCalls == 1 {
+                    try container.encode("ok")
+                } else {
+                    try container.encode(["partial value"])
+                    throw EncodingError.invalidValue(
+                        0,
+                        .init(codingPath: encoder.codingPath, debugDescription: "thrown after encoding a value")
+                    )
+                }
+            }
+        }
+
+        struct TestEvent: Encodable {
+            let poison: SucceedsOnceThenWritesAndThrows
+
+            enum CodingKeys: String, CodingKey {
+                case poison
+                case after
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                container.encodeAttribute(poison, forKey: .poison, attributeName: CodingKeys.poison.rawValue)
+                container.encodeAttribute(AnyEncodable("after"), forKey: .after, attributeName: CodingKeys.after.rawValue)
+            }
+        }
+
+        // When
+        let encodedData = try encoder.encode(TestEvent(poison: SucceedsOnceThenWritesAndThrows()))
+        let jsonObject = try JSONSerialization.jsonObject(with: encodedData) as! [String: Any]
+
+        // Then
+        XCTAssertEqual(jsonObject["poison"] as? String, "ok")
+        XCTAssertEqual(jsonObject["after"] as? String, "after")
+    }
+
     func testEncodeAttributeErrorMessageIncludesDroppedNotice() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())

--- a/DatadogInternal/Tests/AttributeEncodingTests.swift
+++ b/DatadogInternal/Tests/AttributeEncodingTests.swift
@@ -222,6 +222,52 @@ class AttributeEncodingTests: XCTestCase {
         )
     }
 
+    func testEncodeAttributeThrowingAfterPartialEncodeDoesNotAffectSubsequentAttributes() throws {
+        // Given
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        struct ThrowingAfterPartialEncode: Encodable {
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(["partial value"])
+                throw EncodingError.invalidValue(
+                    0,
+                    .init(codingPath: encoder.codingPath, debugDescription: "thrown after encoding a value")
+                )
+            }
+        }
+
+        struct TestEvent: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case before
+                case poison
+                case after
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                container.encodeAttribute(AnyEncodable("before"), forKey: .before, attributeName: CodingKeys.before.rawValue)
+                container.encodeAttribute(ThrowingAfterPartialEncode(), forKey: .poison, attributeName: CodingKeys.poison.rawValue)
+                container.encodeAttribute(AnyEncodable("after"), forKey: .after, attributeName: CodingKeys.after.rawValue)
+            }
+        }
+
+        // When
+        let encodedData = try encoder.encode(TestEvent())
+        let jsonObject = try JSONSerialization.jsonObject(with: encodedData) as! [String: Any]
+
+        // Then
+        XCTAssertEqual(jsonObject["before"] as? String, "before")
+        XCTAssertNil(jsonObject["poison"])
+        XCTAssertEqual(jsonObject["after"] as? String, "after")
+
+        let errorLog = try XCTUnwrap(dd.logger.errorLog)
+        XCTAssertTrue(
+            errorLog.message.contains("Failed to encode attribute 'poison'")
+        )
+    }
+
     func testEncodeAttributeErrorMessageIncludesDroppedNotice() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())


### PR DESCRIPTION
### What and why?

Fixes #3130.
Throwing mid-encode is ok per the Encodable contract.

### How?

`encodeAttribute` encodes safe values directly. Everything else:
1. encodes on an isolated `JSONEncoder`, this can throw mid-encode and corrupt only the discarded encoder.
2. decodes into `[AnyCodable]`
3. re-encodes the safe result into the real container

`SpanEventBuilder.castValuesToString` already does a similar thing with isolated encoding
Regression test added for each case.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
