### PR TITLE
[PANA-8536] Add composition tree recording benchmarks

### DIFF
--- a/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplaySwiftUI/SessionReplaySwiftUIScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplaySwiftUI/SessionReplaySwiftUIScenario.swift
@@ -15,6 +15,12 @@ import DatadogSessionReplay
 import CatalogSwiftUI
 
 struct SessionReplaySwiftUIScenario: Scenario {
+    private let recordingPipeline: SessionReplayRecordingPipeline
+
+    init(recordingPipeline: SessionReplayRecordingPipeline) {
+        self.recordingPipeline = recordingPipeline
+    }
+
     var initialViewController: UIViewController {
         UIHostingController(
             rootView: CatalogSwiftUI.ContentView()
@@ -40,11 +46,29 @@ struct SessionReplaySwiftUIScenario: Scenario {
                 textAndInputPrivacyLevel: .maskSensitiveInputs,
                 imagePrivacyLevel: .maskNone,
                 touchPrivacyLevel: .show,
-                featureFlags: [.swiftui: true, .heatmaps: true]
+                featureFlags: featureFlags
             )
         )
 
-        RUMMonitor.shared().addAttribute(forKey: "scenario", value: "SessionReplaySwiftUI")
+        RUMMonitor.shared().addAttribute(forKey: "scenario", value: rumScenarioName)
+    }
+
+    private var featureFlags: SessionReplay.Configuration.FeatureFlags {
+        switch recordingPipeline {
+        case .viewTree:
+            return [.swiftui: true, .heatmaps: true]
+        case .compositionTree:
+            return [.compositionTreeRecording: true]
+        }
+    }
+
+    private var rumScenarioName: String {
+        switch recordingPipeline {
+        case .viewTree:
+            return "SessionReplaySwiftUI"
+        case .compositionTree:
+            return "SessionReplaySwiftUICompositionTree"
+        }
     }
 }
 

--- a/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplayUIKit/SessionReplayScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SessionReplay/SessionReplayUIKit/SessionReplayScenario.swift
@@ -14,6 +14,12 @@ import DatadogSessionReplay
 import CatalogUIKit
 
 struct SessionReplayScenario: Scenario {
+    private let recordingPipeline: SessionReplayRecordingPipeline
+
+    init(recordingPipeline: SessionReplayRecordingPipeline) {
+        self.recordingPipeline = recordingPipeline
+    }
+
     var initialViewController: UIViewController {
         let storyboard = UIStoryboard(name: "Main", bundle: CatalogUIKit.bundle)
         return storyboard.instantiateInitialViewController()!
@@ -39,10 +45,28 @@ struct SessionReplayScenario: Scenario {
                 textAndInputPrivacyLevel: .maskSensitiveInputs,
                 imagePrivacyLevel: .maskNone,
                 touchPrivacyLevel: .show,
-                featureFlags: [.heatmaps: true]
+                featureFlags: featureFlags
             )
         )
 
-        RUMMonitor.shared().addAttribute(forKey: "scenario", value: "SessionReplay")
+        RUMMonitor.shared().addAttribute(forKey: "scenario", value: rumScenarioName)
+    }
+
+    private var featureFlags: SessionReplay.Configuration.FeatureFlags {
+        switch recordingPipeline {
+        case .viewTree:
+            return [.heatmaps: true]
+        case .compositionTree:
+            return [.compositionTreeRecording: true]
+        }
+    }
+
+    private var rumScenarioName: String {
+        switch recordingPipeline {
+        case .viewTree:
+            return "SessionReplay"
+        case .compositionTree:
+            return "SessionReplayCompositionTree"
+        }
     }
 }

--- a/BenchmarkTests/Runner/Scenarios/SyntheticScenario.swift
+++ b/BenchmarkTests/Runner/Scenarios/SyntheticScenario.swift
@@ -7,13 +7,21 @@
 import Foundation
 import UIKit
 
+/// The Session Replay recording pipeline exercised by a benchmark scenario.
+internal enum SessionReplayRecordingPipeline {
+    case viewTree
+    case compositionTree
+}
+
 /// The Synthetics Scenario reads the `BENCHMARK_SCENARIO` environment
 /// variable to instantiate a `Scenario` compliant object.
 internal struct SyntheticScenario: Scenario {
     /// The Synthetics benchmark scenario value.
     internal enum Name: String, CaseIterable {
         case sessionReplay
+        case sessionReplayCompositionTree
         case sessionReplaySwiftUI
+        case sessionReplaySwiftUICompositionTree
         case logsCustom
         case logsHeavyTraffic
         case trace
@@ -69,9 +77,13 @@ internal struct SyntheticScenario: Scenario {
     init(name: Name) {
         switch name {
         case .sessionReplay:
-            _scenario = SessionReplayScenario()
+            _scenario = SessionReplayScenario(recordingPipeline: .viewTree)
+        case .sessionReplayCompositionTree:
+            _scenario = SessionReplayScenario(recordingPipeline: .compositionTree)
         case .sessionReplaySwiftUI:
-            _scenario = SessionReplaySwiftUIScenario()
+            _scenario = SessionReplaySwiftUIScenario(recordingPipeline: .viewTree)
+        case .sessionReplaySwiftUICompositionTree:
+            _scenario = SessionReplaySwiftUIScenario(recordingPipeline: .compositionTree)
         case .logsCustom:
             _scenario = LogsCustomScenario()
         case .logsHeavyTraffic:


### PR DESCRIPTION
### What and why?

Adds UIKit and SwiftUI benchmark scenarios for the Session Replay composition-tree recording pipeline. This lets Synthetics measure its performance separately while preserving the existing view-tree benchmarks for comparison.

Synthetics tests and monitors will be configured separately.

### How?

- Adds `sessionReplayCompositionTree` and `sessionReplaySwiftUICompositionTree`.
- Reuses the existing UIKit and SwiftUI workloads by making their recording pipeline configurable.
- Enables only `.compositionTreeRecording` for the new scenarios.
- Uses distinct RUM scenario names while leaving the existing scenarios unchanged.

The new scenarios only enable `.compositionTreeRecording` because `heatmaps` are not supported yet and will work automatically when support is added.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs