### PR TITLE
RUM-18007 Sanitize vital and fatal-error RUM events before writing

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		3C3EF2B02C1AEBAB009E9E57 /* LaunchReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */; };
 		3C41693C29FBF4D50042B9D2 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
 		3C43A3882C188974000BFB21 /* WatchdogTerminationMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */; };
+		B21F9B173E636896FBBF638B /* WatchdogTerminationReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A0F1FDC6F852757B99EF56 /* WatchdogTerminationReporterTests.swift */; };
 		3C4CF9922C47BE07006DE1C0 /* MemoryWarningMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5CD8C12C3EBA1700B12303 /* MemoryWarningMonitor.swift */; };
 		3C4CF9982C47CC91006DE1C0 /* MemoryWarningMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4CF9972C47CC8C006DE1C0 /* MemoryWarningMonitorTests.swift */; };
 		3C4CF99B2C47DAA5006DE1C0 /* MemoryWarningMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4CF99A2C47DAA5006DE1C0 /* MemoryWarningMocks.swift */; };
@@ -2113,6 +2114,7 @@
 		3C3C9E2E2C64F470003AF22F /* Data+CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+CryptoTests.swift"; sourceTree = "<group>"; };
 		3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReport.swift; sourceTree = "<group>"; };
 		3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationMonitorTests.swift; sourceTree = "<group>"; };
+		11A0F1FDC6F852757B99EF56 /* WatchdogTerminationReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationReporterTests.swift; sourceTree = "<group>"; };
 		3C4CF9972C47CC8C006DE1C0 /* MemoryWarningMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWarningMonitorTests.swift; sourceTree = "<group>"; };
 		3C4CF99A2C47DAA5006DE1C0 /* MemoryWarningMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWarningMocks.swift; sourceTree = "<group>"; };
 		3C5CD8C12C3EBA1700B12303 /* MemoryWarningMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWarningMonitor.swift; sourceTree = "<group>"; };
@@ -3957,6 +3959,7 @@
 				3CFF4FA32C0E0FE5006F191D /* WatchdogTerminationCheckerTests.swift */,
 				3CEC57752C16FDD30042B5F2 /* AppStateManagerTests.swift */,
 				3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */,
+				11A0F1FDC6F852757B99EF56 /* WatchdogTerminationReporterTests.swift */,
 			);
 			path = WatchdogTerminations;
 			sourceTree = "<group>";
@@ -9463,6 +9466,7 @@
 				3C4CF99B2C47DAA5006DE1C0 /* MemoryWarningMocks.swift in Sources */,
 				5B1D02942E8ED6C000AB2391 /* FlagEvaluationReceiverTests.swift in Sources */,
 				3C43A3882C188974000BFB21 /* WatchdogTerminationMonitorTests.swift in Sources */,
+				B21F9B173E636896FBBF638B /* WatchdogTerminationReporterTests.swift in Sources */,
 				D29A9F9D29DDB483005C54A4 /* ValuePublisherTests.swift in Sources */,
 				6174D61A2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */,
 				9654971D2D774060006428EE /* SwiftUIViewNameExtractorTests.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -154,6 +154,90 @@ class CrashReportReceiverTests: XCTestCase {
         XCTAssertEqual(featureScope.eventsWritten(ofType: RUMErrorEvent.self).count, 1)
     }
 
+    func testGivenCrashDuringRUMSessionWithActiveViewCollectedLessThan4HoursAgoAndTooManyAttributes_whenSending_itSanitizesRUMErrorContext() throws {
+        let secondsIn4Hours: TimeInterval = 4 * 60 * 60
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 0..<secondsIn4Hours))
+        let activeRUMView: RUMViewEvent = .mockRandomWith(crashCount: 0)
+        let lastRUMAttributes = RUMEventAttributes(
+            contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+        )
+
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            trackingConsent: .granted,
+            lastRUMViewEvent: activeRUMView,
+            lastRUMAttributes: lastRUMAttributes
+        )
+
+        let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            sessionSampler: .mockKeepAll(),
+            trackBackgroundEvents: .mockRandom()
+        )
+
+        // When
+        XCTAssertTrue(
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
+            ), from: NOPDatadogCore())
+        )
+
+        // Then
+        let sentRUMError = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).first)
+        let usrInfoCount = sentRUMError.usr?.usrInfo.count ?? 0
+        let accountInfoCount = sentRUMError.account?.accountInfo.count ?? 0
+        let contextInfoCount = sentRUMError.context?.contextInfo.count ?? 0
+        XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+        XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
+    }
+
+    func testGivenCrashDuringRUMSessionWithActiveViewCollectedMoreThan4HoursAgoAndTooManyAttributes_whenSending_itSanitizesRUMErrorContext() throws {
+        let secondsIn4Hours: TimeInterval = 4 * 60 * 60
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: secondsIn4Hours..<TimeInterval.greatestFiniteMagnitude))
+        let activeRUMView: RUMViewEvent = .mockRandomWith(crashCount: 0)
+        let lastRUMAttributes = RUMEventAttributes(
+            contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+        )
+
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            trackingConsent: .granted,
+            lastRUMViewEvent: activeRUMView,
+            lastRUMAttributes: lastRUMAttributes
+        )
+
+        let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            sessionSampler: .mockKeepAll(),
+            trackBackgroundEvents: .mockRandom()
+        )
+
+        // When
+        XCTAssertTrue(
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
+            ), from: NOPDatadogCore())
+        )
+
+        // Then
+        let sentRUMError = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).first)
+        let usrInfoCount = sentRUMError.usr?.usrInfo.count ?? 0
+        let accountInfoCount = sentRUMError.account?.accountInfo.count ?? 0
+        let contextInfoCount = sentRUMError.context?.contextInfo.count ?? 0
+        XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+        XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
+    }
+
     func testGivenCrashDuringBackgroundRUMSessionWithNoActiveView_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -280,6 +280,49 @@ class CrashReportReceiverTests: XCTestCase {
         XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
     }
 
+    func testGivenCrashDuringRUMSessionWithActiveViewAndViewEventMapperReintroducingTooManyAttributes_whenSending_itSanitizesTheMappedRUMViewContext() throws {
+        let secondsIn4Hours: TimeInterval = 4 * 60 * 60
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 0..<secondsIn4Hours))
+        let activeRUMView: RUMViewEvent = .mockRandomWith(crashCount: 0)
+
+        let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            sessionSampler: .mockKeepAll(),
+            trackBackgroundEvents: .mockRandom(),
+            eventsMapper: .mockWith(
+                viewEventMapper: { viewEvent in
+                    var mappedView = viewEvent
+                    mappedView.context = RUMEventAttributes(
+                        contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+                    )
+                    return mappedView
+                }
+            )
+        )
+
+        // When
+        XCTAssertTrue(
+            receiver.receive(message: .payload(
+                Crash(report: .mockWith(date: crashDate), context: .mockWith(
+                    trackingConsent: .granted,
+                    lastRUMViewEvent: activeRUMView
+                ))
+            ), from: NOPDatadogCore())
+        )
+
+        // Then
+        let sentRUMView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).first)
+        let usrInfoCount = sentRUMView.usr?.usrInfo.count ?? 0
+        let accountInfoCount = sentRUMView.account?.accountInfo.count ?? 0
+        let contextInfoCount = sentRUMView.context?.contextInfo.count ?? 0
+        XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes, "the view returned by `viewEventMapper` must be sanitized before writing")
+    }
+
     func testGivenCrashDuringBackgroundRUMSessionWithNoActiveView_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -323,6 +323,50 @@ class CrashReportReceiverTests: XCTestCase {
         XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes, "the view returned by `viewEventMapper` must be sanitized before writing")
     }
 
+    func testGivenCrashDuringRUMSessionWithActiveView_whenSending_itMapsTheRawRUMViewContextBeforeSanitizing() throws {
+        let secondsIn4Hours: TimeInterval = 4 * 60 * 60
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 0..<secondsIn4Hours))
+        var activeRUMView: RUMViewEvent = .mockRandomWith(crashCount: 0)
+        activeRUMView.context = RUMEventAttributes(
+            contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+        )
+
+        var contextInfoCountSeenByMapper: Int?
+        let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            sessionSampler: .mockKeepAll(),
+            trackBackgroundEvents: .mockRandom(),
+            eventsMapper: .mockWith(
+                viewEventMapper: { viewEvent in
+                    contextInfoCountSeenByMapper = viewEvent.context?.contextInfo.count
+                    return viewEvent
+                }
+            )
+        )
+
+        // When
+        XCTAssertTrue(
+            receiver.receive(message: .payload(
+                Crash(report: .mockWith(date: crashDate), context: .mockWith(
+                    trackingConsent: .granted,
+                    lastRUMViewEvent: activeRUMView
+                ))
+            ), from: NOPDatadogCore())
+        )
+
+        // Then
+        XCTAssertEqual(
+            contextInfoCountSeenByMapper,
+            numberOfAttributes,
+            "`viewEventMapper` must receive the raw view, before sanitization removes attributes"
+        )
+    }
+
     func testGivenCrashDuringBackgroundRUMSessionWithNoActiveView_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -238,6 +238,48 @@ class CrashReportReceiverTests: XCTestCase {
         XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
     }
 
+    func testGivenCrashDuringRUMSessionWithActiveViewCollectedLessThan4HoursAgoAndTooManyAttributes_whenSending_itSanitizesRUMViewContext() throws {
+        let secondsIn4Hours: TimeInterval = 4 * 60 * 60
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 0..<secondsIn4Hours))
+        let activeRUMView: RUMViewEvent = .mockRandomWith(crashCount: 0)
+        let lastRUMAttributes = RUMEventAttributes(
+            contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+        )
+
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            trackingConsent: .granted,
+            lastRUMViewEvent: activeRUMView,
+            lastRUMAttributes: lastRUMAttributes
+        )
+
+        let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            sessionSampler: .mockKeepAll(),
+            trackBackgroundEvents: .mockRandom()
+        )
+
+        // When
+        XCTAssertTrue(
+            receiver.receive(message: .payload(
+                Crash(report: crashReport, context: crashContext)
+            ), from: NOPDatadogCore())
+        )
+
+        // Then
+        let sentRUMView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).first)
+        let usrInfoCount = sentRUMView.usr?.usrInfo.count ?? 0
+        let accountInfoCount = sentRUMView.account?.accountInfo.count ?? 0
+        let contextInfoCount = sentRUMView.context?.contextInfo.count ?? 0
+        XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+        XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
+    }
+
     func testGivenCrashDuringBackgroundRUMSessionWithNoActiveView_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/FatalAppHangsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/FatalAppHangsHandler.swift
@@ -17,6 +17,7 @@ internal final class FatalAppHangsHandler {
     /// Device date provider.
     private let dateProvider: DateProvider
     private let uuidGenerator: RUMUUIDGenerator
+    private let sanitizer = RUMEventSanitizer()
 
     init(
         featureScope: FeatureScope,
@@ -117,8 +118,8 @@ internal final class FatalAppHangsHandler {
                 additionalAttributes: nil,
                 timeSinceAppStart: timeSinceAppStart
             )
-            let error = builder.createRUMError(with: fatalHang.lastRUMView)
-            let view = builder.updateRUMViewWithError(fatalHang.lastRUMView)
+            let error = self.sanitizer.sanitize(event: builder.createRUMError(with: fatalHang.lastRUMView))
+            let view = self.sanitizer.sanitize(event: builder.updateRUMViewWithError(fatalHang.lastRUMView))
 
             if realDateNow.timeIntervalSince(realErrorDate) < FatalErrorBuilder.Constants.viewEventAvailabilityThreshold {
                 DD.logger.debug("Sending fatal App hang as RUM error with issuing RUM view update")

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationReporter.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationReporter.swift
@@ -29,6 +29,7 @@ internal final class WatchdogTerminationReporter: WatchdogTerminationReporting {
 
     private let dateProvider: DateProvider
     private let uuidGenerator: RUMUUIDGenerator
+    private let sanitizer = RUMEventSanitizer()
 
     init(
         featureScope: FeatureScope,
@@ -67,7 +68,7 @@ internal final class WatchdogTerminationReporter: WatchdogTerminationReporting {
                 errorMeta: nil,
                 additionalAttributes: nil
             )
-            let error = builder.createRUMError(with: viewEvent)
+            let error = self.sanitizer.sanitize(event: builder.createRUMError(with: viewEvent))
             let view = builder.updateRUMViewWithError(viewEvent)
 
             if realDateNow.timeIntervalSince(errorDate) < FatalErrorBuilder.Constants.viewEventAvailabilityThreshold {

--- a/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationReporter.swift
+++ b/DatadogRUM/Sources/Instrumentation/WatchdogTerminations/WatchdogTerminationReporter.swift
@@ -69,7 +69,7 @@ internal final class WatchdogTerminationReporter: WatchdogTerminationReporting {
                 additionalAttributes: nil
             )
             let error = self.sanitizer.sanitize(event: builder.createRUMError(with: viewEvent))
-            let view = builder.updateRUMViewWithError(viewEvent)
+            let view = self.sanitizer.sanitize(event: builder.updateRUMViewWithError(viewEvent))
 
             if realDateNow.timeIntervalSince(errorDate) < FatalErrorBuilder.Constants.viewEventAvailabilityThreshold {
                 DD.logger.debug("Sending Watchdog Termination as RUM error with issuing RUM view update")

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -282,7 +282,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 writer.write(value: self.sanitizer.sanitize(event: rumError))
             }
             if let mappedView = self.eventsMapper.map(event: sanitizedRUMView) {
-                writer.write(value: self.eventsMapper.map(event: mappedView))
+                writer.write(value: self.sanitizer.sanitize(event: mappedView))
             }
         }
     }

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -32,6 +32,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
     /// Integration with Synthetics tests. It contains the Synthetics test context when active.
     let syntheticsTest: RUMSyntheticsTest?
     let eventsMapper: RUMEventsMapper
+    private let sanitizer = RUMEventSanitizer()
 
     // MARK: - Initialization
 
@@ -132,10 +133,10 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 let rumError = builder.createRUMError(with: lastRUMViewEvent)
 
                 if let mappedError = self.eventsMapper.map(event: rumError) {
-                    writer.write(value: mappedError)
+                    writer.write(value: self.sanitizer.sanitize(event: mappedError))
                 } else {
                     DD.logger.warn("errorEventMapper returned 'nil' for a crash. Discarding crashes is not supported. The unmodified event will be sent.")
-                    writer.write(value: rumError)
+                    writer.write(value: self.sanitizer.sanitize(event: rumError))
                 }
             }
         }
@@ -274,10 +275,10 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             let rumError = builder.createRUMError(with: updatedRUMView)
 
             if let mappedError = self.eventsMapper.map(event: rumError) {
-                writer.write(value: mappedError)
+                writer.write(value: self.sanitizer.sanitize(event: mappedError))
             } else {
                 DD.logger.warn("errorEventMapper returned 'nil' for a crash. Discarding crashes is not supported. The unmodified event will be sent.")
-                writer.write(value: rumError)
+                writer.write(value: self.sanitizer.sanitize(event: rumError))
             }
             if let mappedView = self.eventsMapper.map(event: updatedRUMView) {
                 writer.write(value: self.eventsMapper.map(event: mappedView))

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -272,6 +272,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         featureScope.eventWriteContext(bypassConsent: true) { context, writer in
             let builder = createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
             let updatedRUMView = builder.updateRUMViewWithError(rumView)
+            let sanitizedRUMView = self.sanitizer.sanitize(event: updatedRUMView)
             let rumError = builder.createRUMError(with: updatedRUMView)
 
             if let mappedError = self.eventsMapper.map(event: rumError) {
@@ -280,7 +281,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 DD.logger.warn("errorEventMapper returned 'nil' for a crash. Discarding crashes is not supported. The unmodified event will be sent.")
                 writer.write(value: self.sanitizer.sanitize(event: rumError))
             }
-            if let mappedView = self.eventsMapper.map(event: updatedRUMView) {
+            if let mappedView = self.eventsMapper.map(event: sanitizedRUMView) {
                 writer.write(value: self.eventsMapper.map(event: mappedView))
             }
         }

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -272,7 +272,6 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         featureScope.eventWriteContext(bypassConsent: true) { context, writer in
             let builder = createFatalErrorBuilder(context: context, crash: crashReport, crashDate: crashTimings.realCrashDate, timeSinceAppStart: crashTimings.timeSinceAppStart)
             let updatedRUMView = builder.updateRUMViewWithError(rumView)
-            let sanitizedRUMView = self.sanitizer.sanitize(event: updatedRUMView)
             let rumError = builder.createRUMError(with: updatedRUMView)
 
             if let mappedError = self.eventsMapper.map(event: rumError) {
@@ -281,7 +280,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 DD.logger.warn("errorEventMapper returned 'nil' for a crash. Discarding crashes is not supported. The unmodified event will be sent.")
                 writer.write(value: self.sanitizer.sanitize(event: rumError))
             }
-            if let mappedView = self.eventsMapper.map(event: sanitizedRUMView) {
+            if let mappedView = self.eventsMapper.map(event: updatedRUMView) {
                 writer.write(value: self.sanitizer.sanitize(event: mappedView))
             }
         }

--- a/DatadogRUM/Sources/RUMEvent/RUMEventSanitizer.swift
+++ b/DatadogRUM/Sources/RUMEvent/RUMEventSanitizer.swift
@@ -91,3 +91,7 @@ extension RUMResourceEvent: RUMSanitizableEvent {}
 extension RUMErrorEvent: RUMSanitizableEvent {}
 
 extension RUMLongTaskEvent: RUMSanitizableEvent {}
+
+extension RUMVitalAppLaunchEvent: RUMSanitizableEvent {}
+
+extension RUMVitalOperationStepEvent: RUMSanitizableEvent {}

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMAppLaunchManager.swift
@@ -19,6 +19,7 @@ internal class RUMAppLaunchManager {
     private unowned let parent: RUMContextProvider
     private let dependencies: RUMScopeDependencies
     private let telemetryController: AppLaunchMetricController
+    private let sanitizer = RUMEventSanitizer()
 
     private var timeToInitialDisplay: Double?
     private var timeToFullDisplay: (
@@ -237,8 +238,9 @@ private extension RUMAppLaunchManager {
             vital: vital
         )
 
-        writer.write(value: vitalEvent)
-        telemetryController.track(ttidEvent: vitalEvent, context: context)
+        let sanitizedVitalEvent = sanitizer.sanitize(event: vitalEvent)
+        writer.write(value: sanitizedVitalEvent)
+        telemetryController.track(ttidEvent: sanitizedVitalEvent, context: context)
     }
 
     func sendTTIDMessageToProfiler(vital: Vital) {

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMFeatureOperationManager.swift
@@ -36,6 +36,7 @@ internal class RUMFeatureOperationManager {
     private unowned let parent: RUMContextProvider
     private let dependencies: RUMScopeDependencies
     private let sessionSampler: DeterministicSampler
+    private let sanitizer = RUMEventSanitizer()
 
     // MARK: - Initialization
 
@@ -142,7 +143,7 @@ internal class RUMFeatureOperationManager {
             vital: vital
         )
 
-        writer.write(value: vitalEvent)
+        writer.write(value: sanitizer.sanitize(event: vitalEvent))
     }
 
     private func shouldSendOperationMessage(for command: RUMOperationStepVitalCommand) -> Bool {

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
@@ -282,6 +282,80 @@ class AppHangsMonitorTests: XCTestCase {
         XCTAssertNil(featureScope.dataStoreMock.value(forKey: RUMDataStore.Key.fatalAppHangKey.rawValue))
     }
 
+    func testGivenPendingHangWithTooManyAttributes_whenStartedInAnotherProcess_itSanitizesRUMErrorContextBeforeWriting() throws {
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let hangDate: Date = currentDate.secondsAgo(.random(in: 0...4.hours))
+        var view: RUMViewEvent = .mockRandom()
+        view.context = RUMEventAttributes(
+            contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+        )
+        let hang: AppHang = .mockWith(startDate: hangDate)
+
+        // Given
+        featureScope.contextMock.trackingConsent = .granted
+        monitor.start()
+        fatalErrorContext.view = view
+        watchdogThread.delegate?.hangStarted(hang)
+        monitor.stop()
+
+        // When
+        let monitor = AppHangsMonitor(
+            featureScope: featureScope,
+            watchdogThread: watchdogThread,
+            fatalErrorContext: fatalErrorContext,
+            processID: UUID(), // different process
+            dateProvider: DateProviderMock(now: currentDate),
+            uuidGenerator: RUMUUIDGeneratorMock()
+        )
+        monitor.start()
+        defer { monitor.stop() }
+
+        // Then
+        let sentRUMError = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).first)
+        let usrInfoCount = sentRUMError.usr?.usrInfo.count ?? 0
+        let accountInfoCount = sentRUMError.account?.accountInfo.count ?? 0
+        let contextInfoCount = sentRUMError.context?.contextInfo.count ?? 0
+        XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+    }
+
+    func testGivenPendingHangWithTooManyAttributes_whenStartedInAnotherProcess_itSanitizesRUMViewContextBeforeWriting() throws {
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let hangDate: Date = currentDate.secondsAgo(.random(in: 0...4.hours))
+        var view: RUMViewEvent = .mockRandom()
+        view.context = RUMEventAttributes(
+            contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+        )
+        let hang: AppHang = .mockWith(startDate: hangDate)
+
+        // Given
+        featureScope.contextMock.trackingConsent = .granted
+        monitor.start()
+        fatalErrorContext.view = view
+        watchdogThread.delegate?.hangStarted(hang)
+        monitor.stop()
+
+        // When
+        let monitor = AppHangsMonitor(
+            featureScope: featureScope,
+            watchdogThread: watchdogThread,
+            fatalErrorContext: fatalErrorContext,
+            processID: UUID(), // different process
+            dateProvider: DateProviderMock(now: currentDate),
+            uuidGenerator: RUMUUIDGeneratorMock()
+        )
+        monitor.start()
+        defer { monitor.stop() }
+
+        // Then
+        let sentRUMView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).first)
+        let usrInfoCount = sentRUMView.usr?.usrInfo.count ?? 0
+        let accountInfoCount = sentRUMView.account?.accountInfo.count ?? 0
+        let contextInfoCount = sentRUMView.context?.contextInfo.count ?? 0
+        XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+    }
+
     // MARK: - Fatal App Hangs - Testing Uploaded Data
 
     func testWhenSendingRUMViewEvent_itIsLinkedToPreviousRUMSessionAndIncludesErrorInformation() throws {

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationReporterTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationReporterTests.swift
@@ -42,4 +42,35 @@ final class WatchdogTerminationReporterTests: XCTestCase {
         XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
         XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
     }
+
+    func testSend_sanitizesRUMViewContextBeforeWriting() throws {
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        // Given
+        var viewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
+        viewEvent.context = RUMEventAttributes(
+            contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+        )
+
+        let reporter = WatchdogTerminationReporter(
+            featureScope: featureScope,
+            dateProvider: DateProviderMock(),
+            uuidGenerator: RUMUUIDGeneratorMock()
+        )
+
+        // When
+        reporter.send(
+            date: Date(timeIntervalSinceReferenceDate: TimeInterval(viewEvent.date)),
+            state: .mockWith(trackingConsent: .granted),
+            viewEvent: viewEvent
+        )
+
+        // Then
+        let sentRUMView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).first)
+        let usrInfoCount = sentRUMView.usr?.usrInfo.count ?? 0
+        let accountInfoCount = sentRUMView.account?.accountInfo.count ?? 0
+        let contextInfoCount = sentRUMView.context?.contextInfo.count ?? 0
+        XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+        XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
+    }
 }

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationReporterTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationReporterTests.swift
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import DatadogRUM
+import TestUtilities
+
+final class WatchdogTerminationReporterTests: XCTestCase {
+    let featureScope = FeatureScopeMock()
+
+    func testSend_sanitizesRUMErrorContextBeforeWriting() throws {
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        // Given
+        var viewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
+        viewEvent.context = RUMEventAttributes(
+            contextInfo: Dictionary(uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny() as Encodable) })
+        )
+
+        let reporter = WatchdogTerminationReporter(
+            featureScope: featureScope,
+            dateProvider: DateProviderMock(),
+            uuidGenerator: RUMUUIDGeneratorMock()
+        )
+
+        // When
+        reporter.send(
+            date: Date(timeIntervalSinceReferenceDate: TimeInterval(viewEvent.date)),
+            state: .mockWith(trackingConsent: .granted),
+            viewEvent: viewEvent
+        )
+
+        // Then
+        let sentRUMError = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).first)
+        let usrInfoCount = sentRUMError.usr?.usrInfo.count ?? 0
+        let accountInfoCount = sentRUMError.account?.accountInfo.count ?? 0
+        let contextInfoCount = sentRUMError.context?.contextInfo.count ?? 0
+        XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+        XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
+    }
+}

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationReporterTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationReporterTests.swift
@@ -14,6 +14,7 @@ final class WatchdogTerminationReporterTests: XCTestCase {
 
     func testSend_sanitizesRUMErrorContextBeforeWriting() throws {
         let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
         var viewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
@@ -23,13 +24,13 @@ final class WatchdogTerminationReporterTests: XCTestCase {
 
         let reporter = WatchdogTerminationReporter(
             featureScope: featureScope,
-            dateProvider: DateProviderMock(),
+            dateProvider: RelativeDateProvider(using: currentDate),
             uuidGenerator: RUMUUIDGeneratorMock()
         )
 
         // When
         reporter.send(
-            date: Date(timeIntervalSinceReferenceDate: TimeInterval(viewEvent.date)),
+            date: currentDate,
             state: .mockWith(trackingConsent: .granted),
             viewEvent: viewEvent
         )
@@ -45,6 +46,7 @@ final class WatchdogTerminationReporterTests: XCTestCase {
 
     func testSend_sanitizesRUMViewContextBeforeWriting() throws {
         let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
         var viewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
@@ -54,13 +56,13 @@ final class WatchdogTerminationReporterTests: XCTestCase {
 
         let reporter = WatchdogTerminationReporter(
             featureScope: featureScope,
-            dateProvider: DateProviderMock(),
+            dateProvider: RelativeDateProvider(using: currentDate),
             uuidGenerator: RUMUUIDGeneratorMock()
         )
 
         // When
         reporter.send(
-            date: Date(timeIntervalSinceReferenceDate: TimeInterval(viewEvent.date)),
+            date: currentDate,
             state: .mockWith(trackingConsent: .granted),
             viewEvent: viewEvent
         )

--- a/DatadogRUM/Tests/RUMEvent/RUMEventSanitizerTests.swift
+++ b/DatadogRUM/Tests/RUMEvent/RUMEventSanitizerTests.swift
@@ -14,6 +14,8 @@ class RUMEventSanitizerTests: XCTestCase {
     private let actionEvent: RUMActionEvent = .mockAny()
     private let errorEvent: RUMErrorEvent = .mockRandom()
     private let longTaskEvent: RUMLongTaskEvent = .mockRandom()
+    private let vitalAppLaunchEvent: RUMVitalAppLaunchEvent = .mockRandom()
+    private let vitalOperationStepEvent: RUMVitalOperationStepEvent = .mockRandom()
 
     func testWhenAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
         func test<Event>(event: Event) where Event: RUMSanitizableEvent {
@@ -84,6 +86,8 @@ class RUMEventSanitizerTests: XCTestCase {
         test(event: actionEvent)
         test(event: errorEvent)
         test(event: longTaskEvent)
+        test(event: vitalAppLaunchEvent)
+        test(event: vitalOperationStepEvent)
     }
 
     func testWhenNumberOfAttributesExceedsLimit_itDropsExtraOnes() {
@@ -125,6 +129,8 @@ class RUMEventSanitizerTests: XCTestCase {
         test(event: actionEvent)
         test(event: errorEvent)
         test(event: longTaskEvent)
+        test(event: vitalAppLaunchEvent)
+        test(event: vitalOperationStepEvent)
     }
 
     // MARK: - Private

--- a/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
@@ -98,6 +98,22 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         XCTAssertEqual(event.dd.profiling?.quotaReason, quotaReason)
     }
 
+    func testFeatureOperationCommand_sanitizesContextAttributesBeforeWriting() throws {
+        // Given
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+        let attributes = Dictionary(
+            uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny()) }
+        )
+        let command: RUMOperationStepVitalCommand = .mockWith(attributes: attributes)
+
+        // When
+        manager.process(command, context: mockContext, writer: mockWriter, activeView: .mockAny())
+
+        // Then
+        let event = try XCTUnwrap(mockWriter.events(ofType: RUMVitalOperationStepEvent.self).first)
+        XCTAssertEqual(event.context?.contextInfo.count, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+    }
+
     func testFeatureOperationCommand_sendsOperationMessageWithServerTimeOffset() throws {
         // Given
         let featureScope = FeatureScopeMock()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
@@ -101,6 +101,25 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertEqual(event.dd.profiling?.quotaReason, quotaReason)
     }
 
+    func testTTIDCommand_sanitizesContextAttributesBeforeWriting() throws {
+        // Given
+        let numberOfAttributes = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+        let attributes = Dictionary(
+            uniqueKeysWithValues: (0..<numberOfAttributes).map { ("attribute-\($0)", String.mockAny()) }
+        )
+        let command: RUMTimeToInitialDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(1),
+            attributes: attributes
+        )
+
+        // When
+        manager.process(command, context: mockContext, writer: mockWriter)
+
+        // Then
+        let event = try XCTUnwrap(mockWriter.events(ofType: RUMVitalAppLaunchEvent.self).first)
+        XCTAssertEqual(event.context?.contextInfo.count, AttributesSanitizer.Constraints.maxNumberOfAttributes)
+    }
+
     func testTTIDCommand_appliesServerTimeOffsetToAppLaunchEventAndProfilerMessage() throws {
         // Given
         let featureScope = FeatureScopeMock()

--- a/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogInternal/RUMDataModelMocks.swift
@@ -760,9 +760,12 @@ extension RUMVitalOperationStepEvent: RandomMockable {
     public static func mockRandom() -> RUMVitalOperationStepEvent {
         return RUMVitalOperationStepEvent(
             dd: .init(),
+            account: .mockRandom(),
             application: .init(id: .mockRandom()),
+            context: .mockRandom(),
             date: .mockRandom(),
             session: .init(id: .mockRandom(), type: .user),
+            usr: .mockRandom(),
             view: .init(id: .mockRandom(), url: .mockRandom()),
             vital: .mockRandom()
         )
@@ -786,9 +789,12 @@ extension RUMVitalAppLaunchEvent: RandomMockable, AnyMockable {
     public static func mockRandom() -> Self {
         return RUMVitalAppLaunchEvent(
             dd: .init(),
+            account: .mockRandom(),
             application: .init(id: .mockRandom()),
+            context: .mockRandom(),
             date: .mockRandom(),
             session: .init(id: .mockRandom(), type: .user),
+            usr: .mockRandom(),
             view: .init(id: .mockRandom(), url: .mockRandom()),
             vital: .mockRandom()
         )
@@ -798,17 +804,23 @@ extension RUMVitalAppLaunchEvent: RandomMockable, AnyMockable {
 
     public static func mockWith(
         dd: DD = .init(),
+        account: RUMAccount? = .mockRandom(),
         application: Application = .init(id: .mockAny()),
+        context: RUMEventAttributes? = .mockRandom(),
         date: Int64 = .mockAny(),
         session: Session = .init(id: .mockAny(), type: .user),
+        usr: RUMUser? = .mockRandom(),
         view: View = .init(id: .mockAny(), url: .mockAny()),
         vital: Vital = .mockAny()
     ) -> Self {
         .init(
             dd: dd,
+            account: account,
             application: application,
+            context: context,
             date: date,
             session: session,
+            usr: usr,
             view: view,
             vital: vital
         )


### PR DESCRIPTION
### What and why?

A few RUM event types were not going through `RUMEventSanitizer` before being written :

- `RUMVitalAppLaunchEvent` (TTID app-launch vital)
- `RUMVitalOperationStepEvent` (feature-operation vital steps)
- `RUMErrorEvent` from crash reports (`CrashReportReceiver`)
- `RUMErrorEvent` from watchdog terminations (`WatchdogTerminationReporter`)