### PR TITLE
RUM-17998: Fix crash in the attribute encoder when an attribute throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [FEATURE] Add an experimental Core Animation recording pipeline for Session Replay, available through the `compositionTreeRecording` feature flag. See [#3127][]
 - [FEATURE] Add `disallowList` to `RUM.Configuration.URLSessionTracking` to exclude URLs from automatic RUM resource tracking, with `*` wildcard support. [#3097][]
 - [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
+- [FIX] Fix `EXC_BREAKPOINT` crash when a log or RUM attribute's `encode(to:)` throws after partially encoding a value. [#3134][]
 
 # 3.15.0 / 05-08-2026
 
@@ -1225,6 +1226,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3074]: https://github.com/DataDog/dd-sdk-ios/pull/3074
 [#3127]: https://github.com/DataDog/dd-sdk-ios/pull/3127
 [#3097]: https://github.com/DataDog/dd-sdk-ios/pull/3097
+[#3134]: https://github.com/DataDog/dd-sdk-ios/pull/3134
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
@@ -1264,3 +1266,4 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [@blimmer]: https://github.com/blimmer
 [@thedavidharris]: https://github.com/thedavidharris
 [@noremac]: https://github.com/noremac
+[@saladdays831]: https://github.com/saladdays831

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -193,6 +193,8 @@
 		1182FA712DA2F827007FE71A /* RUMSessionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9CB2DA2F827007FE71A /* RUMSessionMatcher.swift */; };
 		1182FA722DA2F827007FE71A /* BacktraceReportMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9D12DA2F827007FE71A /* BacktraceReportMocks.swift */; };
 		1182FA732DA2F827007FE71A /* DatadogRemoteFeatureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1182F9E12DA2F827007FE71A /* DatadogRemoteFeatureMock.swift */; };
+		1183151F302CA92A006C664A /* LogEventEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1183151E302CA92A006C664A /* LogEventEncodingTests.swift */; };
+		11831521302CB93D006C664A /* AttributeEncodingRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11831520302CB93D006C664A /* AttributeEncodingRecovery.swift */; };
 		1188485A2F6C50EC008D2919 /* ProfilingHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118848592F6C50EC008D2919 /* ProfilingHandler.swift */; };
 		118848602F6C5122008D2919 /* ProfilingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1188485E2F6C5122008D2919 /* ProfilingOperation.swift */; };
 		1188486C2F717DDE008D2919 /* DatadogProfiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1188486A2F717DD8008D2919 /* DatadogProfiler.swift */; };
@@ -2031,6 +2033,8 @@
 		1182FA1A2DA2F827007FE71A /* DatadogCoreProxy+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DatadogCoreProxy+Utils.swift"; sourceTree = "<group>"; };
 		1182FA1B2DA2F827007FE71A /* ServerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerMock.swift; sourceTree = "<group>"; };
 		1182FA1D2DA2F827007FE71A /* PrintFunctionSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFunctionSpy.swift; sourceTree = "<group>"; };
+		1183151E302CA92A006C664A /* LogEventEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventEncodingTests.swift; sourceTree = "<group>"; };
+		11831520302CB93D006C664A /* AttributeEncodingRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributeEncodingRecovery.swift; sourceTree = "<group>"; };
 		118848522F6C4E0C008D2919 /* OperationMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMessage.swift; sourceTree = "<group>"; };
 		118848592F6C50EC008D2919 /* ProfilingHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingHandler.swift; sourceTree = "<group>"; };
 		1188485E2F6C5122008D2919 /* ProfilingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingOperation.swift; sourceTree = "<group>"; };
@@ -4994,6 +4998,7 @@
 				61133C3C2423990D00786299 /* LogSanitizerTests.swift */,
 				615D52BD2C88A98300F8B8FC /* SynchronizedTagsTests.swift */,
 				615D52C02C88AB1E00F8B8FC /* SynchronizedAttributesTests.swift */,
+				1183151E302CA92A006C664A /* LogEventEncodingTests.swift */,
 			);
 			path = Log;
 			sourceTree = "<group>";
@@ -6523,6 +6528,7 @@
 				D23039CB298D5235001A1FA3 /* Attributes.swift */,
 				D23039CC298D5235001A1FA3 /* AttributesSanitizer.swift */,
 				96E746A62F30E317006B3419 /* AttributeEncoding.swift */,
+				11831520302CB93D006C664A /* AttributeEncodingRecovery.swift */,
 			);
 			path = Attributes;
 			sourceTree = "<group>";
@@ -8895,6 +8901,7 @@
 				D2A783E829A53468003B03BB /* ConsoleLoggerTests.swift in Sources */,
 				D2A783EB29A53468003B03BB /* LogSanitizerTests.swift in Sources */,
 				615D52BE2C88A98300F8B8FC /* SynchronizedTagsTests.swift in Sources */,
+				1183151F302CA92A006C664A /* LogEventEncodingTests.swift in Sources */,
 				D2D30E602A40CD310020C553 /* LogsTests.swift in Sources */,
 				D2A783E729A53468003B03BB /* LogEventBuilderTests.swift in Sources */,
 				D242C2A12A14D747004B4980 /* RemoteLoggerTests.swift in Sources */,
@@ -8953,6 +8960,7 @@
 				D263BCAF29DAFFEB00FA0E21 /* PerformancePresetOverride.swift in Sources */,
 				D23039E7298D5236001A1FA3 /* NetworkConnectionInfo.swift in Sources */,
 				D23039E9298D5236001A1FA3 /* TrackingConsent.swift in Sources */,
+				11831521302CB93D006C664A /* AttributeEncodingRecovery.swift in Sources */,
 				D2EBEE2629BA160F00B15732 /* B3HTTPHeaders.swift in Sources */,
 				D23354FC2A42E32000AFCAE2 /* InternalExtended.swift in Sources */,
 				D2D7483A2DC2306100C61353 /* TraceID.swift in Sources */,

--- a/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
+++ b/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
@@ -20,6 +20,8 @@ internal struct FeatureStorage {
     let unauthorizedFilesOrchestrator: FilesOrchestratorType
     /// Encryption algorithm applied to persisted data.
     let encryption: DataEncryption?
+    /// JSON encoder reused by writers executing on this storage queue.
+    private let jsonEncoder: JSONEncoder = .dd.default()
     /// Telemetry interface.
     let telemetry: Telemetry
 
@@ -30,7 +32,8 @@ internal struct FeatureStorage {
                 execute: FileWriter(
                     orchestrator: authorizedFilesOrchestrator,
                     encryption: encryption,
-                    telemetry: telemetry
+                    telemetry: telemetry,
+                    jsonEncoder: jsonEncoder
                 ),
                 on: queue
             )
@@ -41,7 +44,8 @@ internal struct FeatureStorage {
                 execute: FileWriter(
                     orchestrator: unauthorizedFilesOrchestrator,
                     encryption: encryption,
-                    telemetry: telemetry
+                    telemetry: telemetry,
+                    jsonEncoder: jsonEncoder
                 ),
                 on: queue
             )

--- a/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
@@ -5,10 +5,8 @@
  */
 
 import Foundation
+@_spi(Internal)
 import DatadogInternal
-
-/// JSON encoder used to encode data.
-private let jsonEncoder: JSONEncoder = .dd.default()
 
 /// Writes data to files.
 internal struct FileWriter: Writer {
@@ -16,16 +14,20 @@ internal struct FileWriter: Writer {
     let orchestrator: FilesOrchestratorType
     /// Algorithm to encrypt written data.
     let encryption: DataEncryption?
+    /// JSON encoder used to encode data.
+    private let jsonEncoder: JSONEncoder
     /// Telemetry interface.
     let telemetry: Telemetry
 
     init(
         orchestrator: FilesOrchestratorType,
         encryption: DataEncryption?,
-        telemetry: Telemetry
+        telemetry: Telemetry,
+        jsonEncoder: JSONEncoder = .dd.default()
     ) {
         self.orchestrator = orchestrator
         self.encryption = encryption
+        self.jsonEncoder = jsonEncoder
         self.telemetry = telemetry
     }
 
@@ -98,7 +100,7 @@ internal struct FileWriter: Writer {
     /// - Parameter event: The value to encode.
     /// - Returns: Data representation of the value.
     private func encode<T: Encodable>(value: T, blockType: BatchBlockType) throws -> Data {
-        let data = try jsonEncoder.encode(value)
+        let data = try jsonEncoder.dd.encodeWithAttributeRecovery(value)
         return try BatchDataBlock(
             type: blockType,
             data: encrypt(data: data)

--- a/DatadogCrashReporting/Sources/CrashReportingFeature.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingFeature.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+@_spi(Internal)
 import DatadogInternal
 
 internal final class CrashReportingFeature: DatadogFeature {
@@ -97,7 +98,7 @@ internal final class CrashReportingFeature: DatadogFeature {
     /// Note: this `JSONEncoder` must have the same configuration as the `JSONEncoder` used later for writing payloads to uploadable files.
     /// Otherwise the format of data read and uploaded from crash report context will be different than the format of data retrieved from the user
     /// and written directly to uploadable file.
-    internal static let crashContextEncoder: JSONEncoder = .dd.default()
+    internal static var crashContextEncoder: JSONEncoder { .dd.default() }
     /// JSON decoder used for reading `CrashContext` from JSON `Data` injected to crash report.
     /// Note: it must follow a configuration that enables reading data encoded with `crashContextEncoder`.
     internal static let crashContextDecoder: JSONDecoder = {
@@ -115,7 +116,7 @@ internal final class CrashReportingFeature: DatadogFeature {
 
     private func encode(crashContext: CrashContext) -> Data? {
         do {
-            return try CrashReportingFeature.crashContextEncoder.encode(crashContext)
+            return try CrashReportingFeature.crashContextEncoder.dd.encodeWithAttributeRecovery(crashContext)
         } catch {
             DD.logger.error(
                 """

--- a/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
@@ -44,6 +44,43 @@ class CrashReportingFeatureTests: XCTestCase {
         XCTAssertEqual(decodedContext.env, "test-env")
     }
 
+    func testItRecoversMalformedAttributesWhenInjectingCrashContext() throws {
+        struct AlwaysFailingAttribute: Encodable {
+            func encode(to encoder: Encoder) throws {
+                throw EncodingError.invalidValue(
+                    self,
+                    .init(codingPath: encoder.codingPath, debugDescription: "failure")
+                )
+            }
+        }
+
+        let plugin = CrashReportingPluginMock()
+        let crashContext: CrashContext = .mockWith(
+            userInfo: UserInfo(
+                id: "user-id",
+                extraInfo: [
+                    "valid": "preserved",
+                    "invalid": AlwaysFailingAttribute(),
+                ]
+            )
+        )
+        let feature = CrashReportingFeature.mockWith(
+            integration: CrashReportSenderMock(),
+            crashReportingPlugin: plugin,
+            crashContextProvider: CrashContextProviderMock(initialCrashContext: crashContext)
+        )
+
+        feature.flush()
+
+        let data = try XCTUnwrap(plugin.injectedContextData)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let user = try XCTUnwrap(json["userInfo"] as? [String: Any])
+
+        XCTAssertEqual(user["id"] as? String, "user-id")
+        XCTAssertEqual(user["valid"] as? String, "preserved")
+        XCTAssertTrue(user["invalid"] is NSNull)
+    }
+
     // MARK: - Crash Report Reading Tests
 
     func testItSendsLaunchReportWhenNoPendingCrash() {

--- a/DatadogInternal/Sources/Attributes/AttributeEncoding.swift
+++ b/DatadogInternal/Sources/Attributes/AttributeEncoding.swift
@@ -30,30 +30,3 @@ public enum AttributeEncodingContext {
         }
     }
 }
-
-public extension KeyedEncodingContainer {
-    /// Encodes an attribute, catching and logging any encoding failures.
-    /// If encoding fails, the attribute is skipped and an error is logged, but execution continues.
-    /// This prevents a single malformed attribute from causing the entire event to be dropped.
-    ///
-    /// - Parameters:
-    ///   - value: The encodable value to encode
-    ///   - key: The coding key for this attribute
-    ///   - attributeName: The name of the attribute as known by the customer (for error reporting)
-    ///   - context: The context of this attribute (custom, userInfo, accountInfo, or internal)
-    mutating func encodeAttribute<T: Encodable>(
-        _ value: T,
-        forKey key: Key,
-        attributeName: String,
-        context: AttributeEncodingContext = .custom
-    ) {
-        do {
-            try encode(value, forKey: key)
-        } catch {
-            let contextPrefix = context.errorMessagePrefix
-            DD.logger.error(
-                "Failed to encode \(contextPrefix)attribute '\(attributeName)': \(error). This attribute will be dropped from the event."
-            )
-        }
-    }
-}

--- a/DatadogInternal/Sources/Attributes/AttributeEncodingRecovery.swift
+++ b/DatadogInternal/Sources/Attributes/AttributeEncodingRecovery.swift
@@ -1,0 +1,115 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+private extension CodingUserInfoKey {
+    static let shouldRecoverAttributeFailures = CodingUserInfoKey(
+        rawValue: "com.datadoghq.should-recover-attribute-failures"
+    )
+}
+
+private struct RecoverableAttributeEncodingError: Error {}
+
+public extension Encoder {
+    /// Whether attribute failures should be isolated from the enclosing value.
+    @_spi(Internal)
+    var shouldRecoverAttributeFailures: Bool {
+        guard let key = CodingUserInfoKey.shouldRecoverAttributeFailures else {
+            return false
+        }
+        return userInfo[key] as? Bool ?? false
+    }
+}
+
+public extension DatadogExtension where ExtendedType == JSONEncoder {
+    /// Encodes directly, then retries once with individual attributes isolated if one fails.
+    /// Values reached during the first attempt can execute their `encode(to:)` implementation twice.
+    @_spi(Internal)
+    func encodeWithAttributeRecovery<T: Encodable>(_ value: T) throws -> Data {
+        guard let recoveryKey = CodingUserInfoKey.shouldRecoverAttributeFailures else {
+            return try type.encode(value)
+        }
+
+        let previousValue = type.userInfo[recoveryKey]
+        type.userInfo[recoveryKey] = nil
+        defer { type.userInfo[recoveryKey] = previousValue }
+
+        do {
+            return try type.encode(value)
+        } catch is RecoverableAttributeEncodingError {
+            type.userInfo[recoveryKey] = true
+            return try type.encode(value)
+        }
+    }
+}
+
+public extension KeyedEncodingContainer {
+    /// Encodes an attribute, catching and logging any encoding failures.
+    /// If encoding fails, the attribute is replaced with `null` and an error is logged.
+    /// This prevents a single malformed attribute from causing the entire event to be dropped.
+    ///
+    /// - Parameters:
+    ///   - value: The encodable value to encode
+    ///   - key: The coding key for this attribute
+    ///   - attributeName: The name of the attribute as known by the customer (for error reporting)
+    ///   - context: The context of this attribute (custom, userInfo, accountInfo, or internal)
+    mutating func encodeAttribute<T: Encodable>(
+        _ value: T,
+        forKey key: Key,
+        attributeName: String,
+        context: AttributeEncodingContext = .custom
+    ) {
+        do {
+            // A referencing encoder confines partial writes to this key while preserving the
+            // event encoder's coding path, strategies, and user info.
+            let attributeEncoder = superEncoder(forKey: key)
+            try encodeAttributeValue(value, to: attributeEncoder)
+        } catch {
+            // `superEncoder(forKey:)` reserves the key, so replace any partial value with null.
+            try? encodeNil(forKey: key)
+            DD.logger.error(
+                "Failed to encode \(context.errorMessagePrefix)attribute '\(attributeName)'. "
+                    + "This attribute will be encoded as null.",
+                error: error
+            )
+        }
+    }
+
+    /// Encodes directly during the initial pass and isolates attribute failures during recovery.
+    @_spi(Internal)
+    mutating func encodeAttribute<T: Encodable>(
+        _ value: T,
+        forKey key: Key,
+        attributeName: String,
+        context: AttributeEncodingContext,
+        shouldRecover: Bool
+    ) throws {
+        if shouldRecover {
+            encodeAttribute(
+                value,
+                forKey: key,
+                attributeName: attributeName,
+                context: context
+            )
+            return
+        }
+
+        do {
+            try encode(value, forKey: key)
+        } catch {
+            throw RecoverableAttributeEncodingError()
+        }
+    }
+}
+
+private extension KeyedEncodingContainer {
+    /// Encodes through the encoder's container to preserve its strategies and specialized handling.
+    func encodeAttributeValue<T: Encodable>(_ value: T, to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}

--- a/DatadogInternal/Sources/Context/AccountInfo.swift
+++ b/DatadogInternal/Sources/Context/AccountInfo.swift
@@ -37,8 +37,19 @@ public struct AccountInfo: Codable {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        extraInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .accountInfo)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try extraInfo.forEach { name, value in
+            if shouldRecover, CodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .accountInfo,
+                shouldRecover: shouldRecover
+            )
         }
     }
 

--- a/DatadogInternal/Sources/Context/UserInfo.swift
+++ b/DatadogInternal/Sources/Context/UserInfo.swift
@@ -49,8 +49,19 @@ public struct UserInfo: Codable {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        extraInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .userInfo)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try extraInfo.forEach { name, value in
+            if shouldRecover, CodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .userInfo,
+                shouldRecover: shouldRecover
+            )
         }
     }
 

--- a/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMDataModels.swift
@@ -341,8 +341,19 @@ extension RUMAccount {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        accountInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .accountInfo)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try accountInfo.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .accountInfo,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -2706,8 +2717,15 @@ extension RUMErrorEvent.FeatureFlags {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        featureFlagsInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try featureFlagsInfo.forEach { name, value in
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -2741,8 +2759,15 @@ extension RUMEventAttributes {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        contextInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try contextInfo.forEach { name, value in
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -4964,8 +4989,15 @@ extension RUMResourceEvent.Resource.Request.Headers {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        headersInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try headersInfo.forEach { name, value in
+            try dynamicContainer.encodeAttribute(
+                value,
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -4984,8 +5016,15 @@ extension RUMResourceEvent.Resource.Response.Headers {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        headersInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try headersInfo.forEach { name, value in
+            try dynamicContainer.encodeAttribute(
+                value,
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -5067,8 +5106,19 @@ extension RUMSyntheticsTest {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        syntheticsInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try syntheticsInfo.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .internal,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -6451,8 +6501,19 @@ extension RUMUser {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        usrInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .userInfo)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try usrInfo.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .userInfo,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -8613,8 +8674,15 @@ extension RUMViewEvent.FeatureFlags {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        featureFlagsInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try featureFlagsInfo.forEach { name, value in
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -8633,8 +8701,15 @@ extension RUMViewEvent.View.CustomTimings {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        customTimingsInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try customTimingsInfo.forEach { name, value in
+            try dynamicContainer.encodeAttribute(
+                value,
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -10787,8 +10862,15 @@ extension RUMViewUpdateEvent.FeatureFlags {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        featureFlagsInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try featureFlagsInfo.forEach { name, value in
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -10807,8 +10889,15 @@ extension RUMViewUpdateEvent.View.CustomTimings {
     public func encode(to encoder: Encoder) throws {
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        customTimingsInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(value, forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try customTimingsInfo.forEach { name, value in
+            try dynamicContainer.encodeAttribute(
+                value,
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -13902,8 +13991,19 @@ extension TelemetryConfigurationEvent.Telemetry {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        telemetryInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try telemetryInfo.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .internal,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -13933,8 +14033,19 @@ extension TelemetryConfigurationEvent.Telemetry.Configuration.Plugins {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        pluginsInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try pluginsInfo.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .custom,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -14221,8 +14332,19 @@ extension TelemetryDebugEvent.Telemetry {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        telemetryInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try telemetryInfo.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .internal,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -14546,8 +14668,19 @@ extension TelemetryErrorEvent.Telemetry {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        telemetryInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try telemetryInfo.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .internal,
+                shouldRecover: shouldRecover
+            )
         }
     }
 
@@ -15547,8 +15680,19 @@ extension TelemetryUsageEvent.Telemetry {
 
         // Encode dynamic properties:
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        telemetryInfo.forEach { name, value in
-            dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .internal)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
+        try telemetryInfo.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try dynamicContainer.encodeAttribute(
+                AnyEncodable(value),
+                forKey: DynamicCodingKey(name),
+                attributeName: name,
+                context: .internal,
+                shouldRecover: shouldRecover
+            )
         }
     }
 

--- a/DatadogInternal/Tests/AttributeEncodingTests.swift
+++ b/DatadogInternal/Tests/AttributeEncodingTests.swift
@@ -6,10 +6,20 @@
 
 import XCTest
 import TestUtilities
+@_spi(Internal)
 @testable import DatadogInternal
 
 class AttributeEncodingTests: XCTestCase {
     private let encoder = JSONEncoder()
+
+    private struct AlwaysFailingAttribute: Encodable {
+        func encode(to encoder: Encoder) throws {
+            throw EncodingError.invalidValue(
+                self,
+                .init(codingPath: encoder.codingPath, debugDescription: "failure")
+            )
+        }
+    }
 
     // MARK: - AttributeEncodingContext Tests
 
@@ -46,7 +56,7 @@ class AttributeEncodingTests: XCTestCase {
         XCTAssertEqual(jsonObject["intAttr"] as? Int, 42)
     }
 
-    func testEncodeAttributeWithInvalidValueSkipsAttributeAndLogsError() throws {
+    func testEncodeAttributeWithInvalidValueEncodesNullAndLogsError() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -72,14 +82,17 @@ class AttributeEncodingTests: XCTestCase {
         let encodedData = try encoder.encode(TestEvent(nonEncodableValue: NonEncodableObject()))
         let jsonObject = try JSONSerialization.jsonObject(with: encodedData) as! [String: Any]
 
-        // Then - valid attribute is present, invalid is skipped
+        // Then - valid attribute is present, invalid is null
         XCTAssertEqual(jsonObject["validAttr"] as? String, "valid")
-        XCTAssertNil(jsonObject["invalidAttr"])
+        XCTAssertTrue(jsonObject["invalidAttr"] is NSNull)
 
         // And error is logged
         let errorLog = try XCTUnwrap(dd.logger.errorLog)
         XCTAssertTrue(
             errorLog.message.contains("Failed to encode attribute 'invalidAttr'")
+        )
+        XCTAssertTrue(
+            errorLog.message.contains("This attribute will be encoded as null")
         )
     }
 
@@ -222,31 +235,490 @@ class AttributeEncodingTests: XCTestCase {
         )
     }
 
-    func testEncodeAttributeErrorMessageIncludesDroppedNotice() throws {
+    func testEncodeAttributeThrowingAfterPartialEncodeDoesNotAffectSubsequentAttributes() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        class NonEncodableObject {}
+        struct ThrowingAfterPartialEncode: Encodable {
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(["partial value"])
+                throw EncodingError.invalidValue(
+                    0,
+                    .init(codingPath: encoder.codingPath, debugDescription: "thrown after encoding a value")
+                )
+            }
+        }
 
         struct TestEvent: Encodable {
             enum CodingKeys: String, CodingKey {
-                case attr
+                case before
+                case poison
+                case after
             }
 
             func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
-                container.encodeAttribute(AnyEncodable(NonEncodableObject()), forKey: .attr, attributeName: CodingKeys.attr.rawValue)
+                container.encodeAttribute(AnyEncodable("before"), forKey: .before, attributeName: CodingKeys.before.rawValue)
+                container.encodeAttribute(ThrowingAfterPartialEncode(), forKey: .poison, attributeName: CodingKeys.poison.rawValue)
+                container.encodeAttribute(AnyEncodable("after"), forKey: .after, attributeName: CodingKeys.after.rawValue)
             }
         }
 
         // When
-        _ = try encoder.encode(TestEvent())
+        let encodedData = try encoder.encode(TestEvent())
+        let jsonObject = try JSONSerialization.jsonObject(with: encodedData) as! [String: Any]
 
         // Then
+        XCTAssertEqual(jsonObject["before"] as? String, "before")
+        XCTAssertTrue(jsonObject["poison"] is NSNull)
+        XCTAssertEqual(jsonObject["after"] as? String, "after")
+
         let errorLog = try XCTUnwrap(dd.logger.errorLog)
         XCTAssertTrue(
-            errorLog.message.contains("This attribute will be dropped from the event")
+            errorLog.message.contains("Failed to encode attribute 'poison'")
         )
+    }
+
+    func testEncodeAttributeWithCustomScalarEncodesSuccessfully() throws {
+        struct CustomScalar: Encodable {
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode("custom")
+            }
+        }
+
+        struct TestEvent: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case attribute
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                container.encodeAttribute(
+                    CustomScalar(),
+                    forKey: .attribute,
+                    attributeName: CodingKeys.attribute.rawValue
+                )
+            }
+        }
+
+        let encodedData = try encoder.encode(TestEvent())
+        let jsonObject = try JSONSerialization.jsonObject(with: encodedData) as! [String: Any]
+
+        XCTAssertEqual(jsonObject["attribute"] as? String, "custom")
+    }
+
+    // MARK: - Context attribute recovery
+
+    func testAccountInfoRecoveryPreservesStaticPropertiesWhenExtraInfoKeysCollide() throws {
+        let accountInfo = AccountInfo(
+            id: "account-id",
+            name: "account-name",
+            extraInfo: [
+                "id": AlwaysFailingAttribute(),
+                "name": AlwaysFailingAttribute(),
+            ]
+        )
+
+        let data = try encoder.dd.encodeWithAttributeRecovery(accountInfo)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["id"] as? String, "account-id")
+        XCTAssertEqual(json["name"] as? String, "account-name")
+    }
+
+    func testUserInfoRecoveryPreservesStaticPropertiesWhenExtraInfoKeysCollide() throws {
+        let userInfo = UserInfo(
+            anonymousId: "anonymous-id",
+            id: "user-id",
+            name: "user-name",
+            email: "user@example.com",
+            extraInfo: [
+                "anonymousId": AlwaysFailingAttribute(),
+                "id": AlwaysFailingAttribute(),
+                "name": AlwaysFailingAttribute(),
+                "email": AlwaysFailingAttribute(),
+            ]
+        )
+
+        let data = try encoder.dd.encodeWithAttributeRecovery(userInfo)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["anonymousId"] as? String, "anonymous-id")
+        XCTAssertEqual(json["id"] as? String, "user-id")
+        XCTAssertEqual(json["name"] as? String, "user-name")
+        XCTAssertEqual(json["email"] as? String, "user@example.com")
+    }
+
+    // MARK: - Attribute recovery
+
+    func testAttributeRecoveryIsDisabledByDefault() throws {
+        struct TestEvent: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case shouldRecover
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(encoder.shouldRecoverAttributeFailures, forKey: .shouldRecover)
+            }
+        }
+
+        let data = try JSONEncoder().encode(TestEvent())
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["shouldRecover"] as? Bool, false)
+    }
+
+    func testDirectEncodingDoesNotRecoverAttributeFailure() {
+        struct TestEvent: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case invalid
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeAttribute(
+                    AlwaysFailingAttribute(),
+                    forKey: .invalid,
+                    attributeName: CodingKeys.invalid.rawValue,
+                    context: .custom,
+                    shouldRecover: encoder.shouldRecoverAttributeFailures
+                )
+            }
+        }
+
+        XCTAssertThrowsError(try JSONEncoder().encode(TestEvent()))
+    }
+
+    func testEncodeWithAttributeRecoveryDoesNotRetrySuccessfulEvent() throws {
+        final class CountingValue: Encodable {
+            private(set) var encodeCount = 0
+            private(set) var userInfoCounts: [Int] = []
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                userInfoCounts.append(encoder.userInfo.count)
+                var container = encoder.singleValueContainer()
+                try container.encode("value")
+            }
+        }
+
+        struct TestEvent: Encodable {
+            let value: CountingValue
+
+            enum CodingKeys: String, CodingKey {
+                case value
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeAttribute(
+                    value,
+                    forKey: .value,
+                    attributeName: CodingKeys.value.rawValue,
+                    context: .custom,
+                    shouldRecover: encoder.shouldRecoverAttributeFailures
+                )
+            }
+        }
+
+        let value = CountingValue()
+        let encodedData = try JSONEncoder().dd.encodeWithAttributeRecovery(TestEvent(value: value))
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedData) as? [String: Any])
+
+        XCTAssertEqual(value.encodeCount, 1)
+        XCTAssertEqual(value.userInfoCounts, [0])
+        XCTAssertEqual(jsonObject["value"] as? String, "value")
+    }
+
+    func testEncodeWithAttributeRecoveryPreservesEncoderStrategies() throws {
+        struct TestEvent: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case date
+                case data
+                case url
+                case decimal
+                case dictionary
+                case infinity
+                case invalid
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                let shouldRecover = encoder.shouldRecoverAttributeFailures
+                try container.encodeAttribute(
+                    Date(timeIntervalSince1970: 0),
+                    forKey: .date,
+                    attributeName: CodingKeys.date.rawValue,
+                    context: .custom,
+                    shouldRecover: shouldRecover
+                )
+                try container.encodeAttribute(
+                    Data([1, 2, 3]),
+                    forKey: .data,
+                    attributeName: CodingKeys.data.rawValue,
+                    context: .custom,
+                    shouldRecover: shouldRecover
+                )
+                try container.encodeAttribute(
+                    URL(string: "https://example.com/path?q=1")!,
+                    forKey: .url,
+                    attributeName: CodingKeys.url.rawValue,
+                    context: .custom,
+                    shouldRecover: shouldRecover
+                )
+                try container.encodeAttribute(
+                    Decimal(string: "123.45")!,
+                    forKey: .decimal,
+                    attributeName: CodingKeys.decimal.rawValue,
+                    context: .custom,
+                    shouldRecover: shouldRecover
+                )
+                try container.encodeAttribute(
+                    ["camelCaseKey": 1],
+                    forKey: .dictionary,
+                    attributeName: CodingKeys.dictionary.rawValue,
+                    context: .custom,
+                    shouldRecover: shouldRecover
+                )
+                try container.encodeAttribute(
+                    Double.infinity,
+                    forKey: .infinity,
+                    attributeName: CodingKeys.infinity.rawValue,
+                    context: .custom,
+                    shouldRecover: shouldRecover
+                )
+                try container.encodeAttribute(
+                    AlwaysFailingAttribute(),
+                    forKey: .invalid,
+                    attributeName: CodingKeys.invalid.rawValue,
+                    context: .custom,
+                    shouldRecover: shouldRecover
+                )
+            }
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.dataEncodingStrategy = .custom { _, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode("custom-data")
+        }
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.nonConformingFloatEncodingStrategy = .convertToString(
+            positiveInfinity: "positive-infinity",
+            negativeInfinity: "negative-infinity",
+            nan: "nan"
+        )
+
+        let encodedData = try encoder.dd.encodeWithAttributeRecovery(TestEvent())
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedData) as? [String: Any])
+
+        XCTAssertEqual(json["date"] as? String, "1970-01-01T00:00:00Z")
+        XCTAssertEqual(json["data"] as? String, "custom-data")
+        XCTAssertEqual(json["url"] as? String, "https://example.com/path?q=1")
+        XCTAssertEqual((json["decimal"] as? NSNumber)?.doubleValue, 123.45)
+        let dictionary = try XCTUnwrap(json["dictionary"] as? [String: Any])
+        XCTAssertEqual(dictionary["camelCaseKey"] as? Int, 1)
+        XCTAssertNil(dictionary["camel_case_key"])
+        XCTAssertEqual(json["infinity"] as? String, "positive-infinity")
+        XCTAssertTrue(json["invalid"] is NSNull)
+    }
+
+    func testEncodeWithAttributeRecoveryRetriesOnceAndContainsAllFailures() throws {
+        final class CountingValue: Encodable {
+            private(set) var encodeCount = 0
+            private(set) var userInfoCounts: [Int] = []
+            private(set) var recoveryStates: [Bool] = []
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                userInfoCounts.append(encoder.userInfo.count)
+                recoveryStates.append(encoder.shouldRecoverAttributeFailures)
+                var container = encoder.singleValueContainer()
+                try container.encode("call-\(encodeCount)")
+            }
+        }
+
+        final class ThrowingValue: Encodable {
+            private(set) var encodeCount = 0
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                var container = encoder.singleValueContainer()
+                try container.encode("partial")
+                throw EncodingError.invalidValue(
+                    encodeCount,
+                    .init(codingPath: encoder.codingPath, debugDescription: "failure")
+                )
+            }
+        }
+
+        struct TestEvent: Encodable {
+            let before: CountingValue
+            let firstFailure: ThrowingValue
+            let secondFailure: ThrowingValue
+            let after: CountingValue
+
+            enum CodingKeys: String, CodingKey {
+                case before
+                case firstFailure
+                case secondFailure
+                case after
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                let shouldRecover = encoder.shouldRecoverAttributeFailures
+                try container.encodeAttribute(before, forKey: .before, attributeName: "before", context: .custom, shouldRecover: shouldRecover)
+                try container.encodeAttribute(firstFailure, forKey: .firstFailure, attributeName: "firstFailure", context: .custom, shouldRecover: shouldRecover)
+                try container.encodeAttribute(secondFailure, forKey: .secondFailure, attributeName: "secondFailure", context: .custom, shouldRecover: shouldRecover)
+                try container.encodeAttribute(after, forKey: .after, attributeName: "after", context: .custom, shouldRecover: shouldRecover)
+            }
+        }
+
+        let before = CountingValue()
+        let firstFailure = ThrowingValue()
+        let secondFailure = ThrowingValue()
+        let after = CountingValue()
+        let event = TestEvent(
+            before: before,
+            firstFailure: firstFailure,
+            secondFailure: secondFailure,
+            after: after
+        )
+
+        let encodedData = try JSONEncoder().dd.encodeWithAttributeRecovery(event)
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedData) as? [String: Any])
+
+        XCTAssertEqual(before.encodeCount, 2)
+        XCTAssertEqual(before.userInfoCounts, [0, 1])
+        XCTAssertEqual(before.recoveryStates, [false, true])
+        XCTAssertEqual(firstFailure.encodeCount, 2)
+        XCTAssertEqual(secondFailure.encodeCount, 1)
+        XCTAssertEqual(after.encodeCount, 1)
+        XCTAssertEqual(jsonObject["before"] as? String, "call-2")
+        XCTAssertTrue(jsonObject["firstFailure"] is NSNull)
+        XCTAssertTrue(jsonObject["secondFailure"] is NSNull)
+        XCTAssertEqual(jsonObject["after"] as? String, "call-1")
+    }
+
+    func testEncodeWithAttributeRecoveryContainsAStatefulValueThatThrowsOnlyOnRetry() throws {
+        final class SucceedsOnceThenThrows: Encodable {
+            private(set) var encodeCount = 0
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                var container = encoder.singleValueContainer()
+                try container.encode("partial")
+                if encodeCount > 1 {
+                    throw EncodingError.invalidValue(
+                        encodeCount,
+                        .init(codingPath: encoder.codingPath, debugDescription: "failure on retry")
+                    )
+                }
+            }
+        }
+
+        struct AlwaysThrows: Encodable {
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode("partial")
+                throw EncodingError.invalidValue(
+                    0,
+                    .init(codingPath: encoder.codingPath, debugDescription: "trigger recovery")
+                )
+            }
+        }
+
+        struct TestEvent: Encodable {
+            let stateful: SucceedsOnceThenThrows
+
+            enum CodingKeys: String, CodingKey {
+                case stateful
+                case trigger
+                case after
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                let shouldRecover = encoder.shouldRecoverAttributeFailures
+                try container.encodeAttribute(stateful, forKey: .stateful, attributeName: "stateful", context: .custom, shouldRecover: shouldRecover)
+                try container.encodeAttribute(AlwaysThrows(), forKey: .trigger, attributeName: "trigger", context: .custom, shouldRecover: shouldRecover)
+                try container.encodeAttribute("after", forKey: .after, attributeName: "after", context: .custom, shouldRecover: shouldRecover)
+            }
+        }
+
+        let stateful = SucceedsOnceThenThrows()
+        let encodedData = try JSONEncoder().dd.encodeWithAttributeRecovery(TestEvent(stateful: stateful))
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedData) as? [String: Any])
+
+        XCTAssertEqual(stateful.encodeCount, 2)
+        XCTAssertTrue(jsonObject["stateful"] is NSNull)
+        XCTAssertTrue(jsonObject["trigger"] is NSNull)
+        XCTAssertEqual(jsonObject["after"] as? String, "after")
+    }
+
+    func testEncodeWithAttributeRecoveryPreservesPrecisionAndEncoderContext() throws {
+        final class ContextAwareValue: Encodable {
+            private(set) var encodeCount = 0
+
+            enum CodingKeys: String, CodingKey {
+                case decimal
+                case codingPath
+                case userInfo
+            }
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(Decimal(string: "12345678901234567890.123456789")!, forKey: .decimal)
+                try container.encode(encoder.codingPath.map(\.stringValue).joined(separator: "."), forKey: .codingPath)
+                let key = CodingUserInfoKey(rawValue: "attribute-recovery-test")!
+                try container.encode(encoder.userInfo[key] as? String, forKey: .userInfo)
+            }
+        }
+
+        struct AlwaysThrows: Encodable {
+            func encode(to encoder: Encoder) throws {
+                throw EncodingError.invalidValue(
+                    0,
+                    .init(codingPath: encoder.codingPath, debugDescription: "trigger recovery")
+                )
+            }
+        }
+
+        struct TestEvent: Encodable {
+            let value: ContextAwareValue
+
+            enum CodingKeys: String, CodingKey {
+                case value
+                case trigger
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                let shouldRecover = encoder.shouldRecoverAttributeFailures
+                try container.encodeAttribute(value, forKey: .value, attributeName: "value", context: .custom, shouldRecover: shouldRecover)
+                try container.encodeAttribute(AlwaysThrows(), forKey: .trigger, attributeName: "trigger", context: .custom, shouldRecover: shouldRecover)
+            }
+        }
+
+        let value = ContextAwareValue()
+        let encoder = JSONEncoder()
+        encoder.userInfo[CodingUserInfoKey(rawValue: "attribute-recovery-test")!] = "preserved"
+        let encodedData = try encoder.dd.encodeWithAttributeRecovery(TestEvent(value: value))
+        let jsonString = try XCTUnwrap(String(data: encodedData, encoding: .utf8))
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedData) as? [String: Any])
+        let encodedValue = try XCTUnwrap(jsonObject["value"] as? [String: Any])
+
+        XCTAssertEqual(value.encodeCount, 2)
+        XCTAssertTrue(jsonString.contains("12345678901234567890.123456789"))
+        XCTAssertEqual(encodedValue["codingPath"] as? String, "value")
+        XCTAssertEqual(encodedValue["userInfo"] as? String, "preserved")
+        XCTAssertTrue(jsonObject["trigger"] is NSNull)
     }
 }

--- a/DatadogLogs/Sources/Log/LogEventEncoder.swift
+++ b/DatadogLogs/Sources/Log/LogEventEncoder.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+@_spi(Internal)
 import DatadogInternal
 
 /// `Encodable` representation of log. It gets sanitized before encoding.
@@ -323,51 +324,71 @@ internal struct LogEventEncoder {
         }
 
         // Encode attributes...
-        // Individual attribute encoding failures are caught and logged, allowing the event to be sent
-        // with all successfully encoded attributes. This prevents a single malformed attribute from
-        // causing the entire event to be dropped.
+        // The first attempt encodes attributes directly. If one fails, a fresh attempt isolates all
+        // attribute failures so malformed values cannot corrupt the event encoder.
         var attributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        let shouldRecover = encoder.shouldRecoverAttributeFailures
 
         // 1. user info attributes
-        log.userInfo.extraInfo.forEach { name, value in
+        try log.userInfo.extraInfo.forEach { name, value in
             let key = DynamicCodingKey("usr.\(name)")
-            attributesContainer.encodeAttribute(
+            if shouldRecover, StaticCodingKeys(stringValue: key.stringValue) != nil {
+                return
+            }
+
+            try attributesContainer.encodeAttribute(
                 AnyEncodable(value),
                 forKey: key,
                 attributeName: name,
-                context: .userInfo
+                context: .userInfo,
+                shouldRecover: shouldRecover
             )
         }
 
         // 2. account info attributes
-        log.accountInfo?.extraInfo.forEach { name, value in
+        try log.accountInfo?.extraInfo.forEach { name, value in
             let key = DynamicCodingKey("account.\(name)")
-            attributesContainer.encodeAttribute(
+            if shouldRecover, StaticCodingKeys(stringValue: key.stringValue) != nil {
+                return
+            }
+
+            try attributesContainer.encodeAttribute(
                 AnyEncodable(value),
                 forKey: key,
                 attributeName: name,
-                context: .accountInfo
+                context: .accountInfo,
+                shouldRecover: shouldRecover
             )
         }
 
         // 3. user attributes
-        log.attributes.userAttributes.forEach { name, value in
-            attributesContainer.encodeAttribute(
+        try log.attributes.userAttributes.forEach { name, value in
+            if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                return
+            }
+
+            try attributesContainer.encodeAttribute(
                 AnyEncodable(value),
                 forKey: DynamicCodingKey(name),
                 attributeName: name,
-                context: .custom
+                context: .custom,
+                shouldRecover: shouldRecover
             )
         }
 
         // 4. internal attributes
         if let internalAttributes = log.attributes.internalAttributes {
-            internalAttributes.forEach { name, value in
-                attributesContainer.encodeAttribute(
+            try internalAttributes.forEach { name, value in
+                if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                    return
+                }
+
+                try attributesContainer.encodeAttribute(
                     AnyEncodable(value),
                     forKey: DynamicCodingKey(name),
                     attributeName: name,
-                    context: .internal
+                    context: .internal,
+                    shouldRecover: shouldRecover
                 )
             }
         }

--- a/DatadogLogs/Tests/Log/LogEventEncodingTests.swift
+++ b/DatadogLogs/Tests/Log/LogEventEncodingTests.swift
@@ -1,0 +1,203 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@_spi(Internal)
+import DatadogInternal
+@testable import DatadogLogs
+
+final class LogEventEncodingTests: XCTestCase {
+    private struct AlwaysFailingAttribute: Encodable {
+        func encode(to encoder: Encoder) throws {
+            throw EncodingError.invalidValue(
+                self,
+                .init(codingPath: encoder.codingPath, debugDescription: "failure")
+            )
+        }
+    }
+
+    func testAttributeEncodingDoesNotRetrySuccessfulEvent() throws {
+        final class CountingValue: Encodable {
+            private(set) var encodeCount = 0
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                var container = encoder.singleValueContainer()
+                try container.encode("value")
+            }
+        }
+
+        let value = CountingValue()
+        let event = LogEvent.mockWith(
+            userInfo: .empty,
+            accountInfo: AccountInfo(id: "account", name: nil, extraInfo: [:]),
+            networkConnectionInfo: .mockWith(),
+            mobileCarrierInfo: nil,
+            attributes: .mockWith(userAttributes: ["value": value], internalAttributes: nil)
+        )
+
+        let data = try JSONEncoder.dd.default().dd.encodeWithAttributeRecovery(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(value.encodeCount, 1)
+        XCTAssertEqual(json["value"] as? String, "value")
+    }
+
+    func testAttributeEncodingReplacesAValueThatThrowsAfterWritingWithNull() throws {
+        final class CountingValue: Encodable {
+            private(set) var encodeCount = 0
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                var container = encoder.singleValueContainer()
+                try container.encode("call-\(encodeCount)")
+            }
+        }
+
+        final class ThrowingAfterPartialEncode: Encodable {
+            private(set) var encodeCount = 0
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                var container = encoder.singleValueContainer()
+                try container.encode(["partial value"])
+                throw EncodingError.invalidValue(
+                    0,
+                    .init(codingPath: encoder.codingPath, debugDescription: "thrown after encoding a value")
+                )
+            }
+        }
+
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        let countingValue = CountingValue()
+        let poison = ThrowingAfterPartialEncode()
+        let event = LogEvent.mockWith(
+            userInfo: UserInfo(extraInfo: ["counted": countingValue]),
+            accountInfo: AccountInfo(id: "account", name: nil, extraInfo: [:]),
+            networkConnectionInfo: .mockWith(),
+            mobileCarrierInfo: nil,
+            attributes: .mockWith(
+                userAttributes: [
+                    "before": "before",
+                    "poison": poison,
+                    "after": "after",
+                ],
+                internalAttributes: nil
+            )
+        )
+
+        let encoder: JSONEncoder = .dd.default()
+        let data = try encoder.dd.encodeWithAttributeRecovery(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["before"] as? String, "before")
+        XCTAssertTrue(json["poison"] is NSNull)
+        XCTAssertEqual(json["after"] as? String, "after")
+        XCTAssertEqual(countingValue.encodeCount, 2)
+        XCTAssertEqual(json["usr.counted"] as? String, "call-2")
+        XCTAssertEqual(poison.encodeCount, 2)
+        XCTAssertTrue(try XCTUnwrap(dd.logger.errorLog).message.contains("attribute 'poison'"))
+    }
+
+    func testAttributeRecoveryPreservesStaticFieldsWhenAttributeKeysCollide() throws {
+        let event = LogEvent.mockWith(
+            userInfo: UserInfo(
+                anonymousId: "anonymous-id",
+                id: "user-id",
+                name: "user-name",
+                email: "user@example.com",
+                extraInfo: [
+                    "anonymous_id": AlwaysFailingAttribute(),
+                    "id": AlwaysFailingAttribute(),
+                    "name": AlwaysFailingAttribute(),
+                    "email": AlwaysFailingAttribute(),
+                ]
+            ),
+            accountInfo: AccountInfo(
+                id: "account-id",
+                name: "account-name",
+                extraInfo: [
+                    "id": AlwaysFailingAttribute(),
+                    "name": AlwaysFailingAttribute(),
+                ]
+            ),
+            networkConnectionInfo: .mockWith(),
+            mobileCarrierInfo: nil,
+            attributes: .mockWith(
+                userAttributes: ["date": AlwaysFailingAttribute()],
+                internalAttributes: ["service": AlwaysFailingAttribute()]
+            )
+        )
+
+        let data = try JSONEncoder.dd.default().dd.encodeWithAttributeRecovery(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["usr.anonymous_id"] as? String, "anonymous-id")
+        XCTAssertEqual(json["usr.id"] as? String, "user-id")
+        XCTAssertEqual(json["usr.name"] as? String, "user-name")
+        XCTAssertEqual(json["usr.email"] as? String, "user@example.com")
+        XCTAssertEqual(json["account.id"] as? String, "account-id")
+        XCTAssertEqual(json["account.name"] as? String, "account-name")
+        XCTAssertFalse(json["date"] is NSNull)
+        XCTAssertEqual(json["service"] as? String, event.serviceName)
+    }
+
+    func testAttributeEncodingPreservesPrecisionAndCodingPath() throws {
+        final class ContextAwareValue: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case decimal
+                case codingPath
+            }
+
+            private(set) var encodeCount = 0
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(
+                    Decimal(string: "12345678901234567890.123456789")!,
+                    forKey: .decimal
+                )
+                try container.encode(
+                    encoder.codingPath.map(\.stringValue).joined(separator: "."),
+                    forKey: .codingPath
+                )
+            }
+        }
+
+        struct ThrowingValue: Encodable {
+            func encode(to encoder: Encoder) throws {
+                throw EncodingError.invalidValue(
+                    0,
+                    .init(codingPath: encoder.codingPath, debugDescription: "failure")
+                )
+            }
+        }
+
+        let value = ContextAwareValue()
+        let event = LogEvent.mockWith(
+            userInfo: UserInfo(extraInfo: ["structured": value]),
+            accountInfo: AccountInfo(id: "account", name: nil, extraInfo: [:]),
+            networkConnectionInfo: .mockWith(),
+            mobileCarrierInfo: nil,
+            attributes: .mockWith(userAttributes: ["poison": ThrowingValue()], internalAttributes: nil)
+        )
+
+        let encoder: JSONEncoder = .dd.default()
+        let data = try encoder.dd.encodeWithAttributeRecovery(event)
+        let jsonString = try XCTUnwrap(String(data: data, encoding: .utf8))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let structured = try XCTUnwrap(json["usr.structured"] as? [String: Any])
+
+        XCTAssertEqual(value.encodeCount, 2)
+        XCTAssertTrue(jsonString.contains("12345678901234567890.123456789"))
+        XCTAssertEqual(structured["codingPath"] as? String, "usr.structured")
+        XCTAssertTrue(json["poison"] is NSNull)
+    }
+}

--- a/DatadogLogs/Tests/RemoteLoggerTests.swift
+++ b/DatadogLogs/Tests/RemoteLoggerTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import TestUtilities
+@_spi(Internal)
 import DatadogInternal
 @testable import DatadogLogs
 
@@ -653,7 +654,7 @@ class RemoteLoggerTests: XCTestCase {
     /// - **Swift APIs with manual wrapping**: Swift API requires `Encodable`, but customers can explicitly wrap non-encodable
     ///   types using `AnyEncodable(value)` to bypass compile-time checks.
 
-    func testWhenMultipleAttributesFailToEncode_itSkipsAllMalformedAttributes() throws {
+    func testWhenMultipleAttributesFailToEncode_itReplacesAllMalformedAttributesWithNull() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -684,62 +685,19 @@ class RemoteLoggerTests: XCTestCase {
         let log = try XCTUnwrap(logs.first)
 
         // Encode to JSON
-        let jsonData = try JSONEncoder().encode(log)
+        let jsonData = try JSONEncoder().dd.encodeWithAttributeRecovery(log)
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
 
-        // Event sent with only valid attribute
+        // Event sent with its valid attribute and malformed attributes replaced by null.
         XCTAssertEqual(jsonObject["valid"] as? String, "test")
-        XCTAssertNil(jsonObject["onComplete"])
-        XCTAssertNil(jsonObject["callback"])
-        XCTAssertNil(jsonObject["custom_object"])
+        XCTAssertTrue(jsonObject["onComplete"] is NSNull)
+        XCTAssertTrue(jsonObject["callback"] is NSNull)
+        XCTAssertTrue(jsonObject["custom_object"] is NSNull)
 
         // And all errors logged
         XCTAssertEqual(
             dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
             3
-        )
-    }
-
-    func testWhenOnlyMalformedAttributesAdded_itSendsEventWithoutCustomAttributes() throws {
-        // Given
-        let dd = DD.mockWith(logger: CoreLoggerMock())
-        defer { dd.reset() }
-
-        let logger = RemoteLogger(
-            featureScope: featureScope,
-            globalAttributes: .mockAny(),
-            configuration: .mockAny(),
-            dateProvider: RelativeDateProvider(),
-            rumContextIntegration: false,
-            activeSpanIntegration: false,
-            backtraceReporter: BacktraceReporterMock()
-        )
-
-        // When
-        logger.addAttribute(forKey: "invalid1", value: AnyEncodable(NSObject()))
-        logger.addAttribute(forKey: "invalid2", value: AnyEncodable(NSObject()))
-        logger.info("Test message")
-
-        // Then - encode to trigger error handling
-        let logs = featureScope.eventsWritten(ofType: LogEvent.self)
-        XCTAssertEqual(logs.count, 1)
-
-        let log = try XCTUnwrap(logs.first)
-        XCTAssertEqual(log.message, "Test message")
-
-        // Encode to JSON
-        let jsonData = try JSONEncoder().encode(log)
-        let jsonObject = try JSONSerialization.jsonObject(with: jsonData) as! [String: Any]
-
-        // Event still sent, just without custom attributes (all were malformed)
-        XCTAssertEqual(jsonObject["message"] as? String, "Test message")
-        XCTAssertNil(jsonObject["invalid1"])
-        XCTAssertNil(jsonObject["invalid2"])
-
-        // And errors logged
-        XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
-            2
         )
     }
 }

--- a/DatadogRUM/Sources/Feature/RUMDataStore.swift
+++ b/DatadogRUM/Sources/Feature/RUMDataStore.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+@_spi(Internal)
 import DatadogInternal
 
 internal extension FeatureScope {
@@ -35,8 +36,6 @@ internal struct RUMDataStore {
         case anonymousId = "rum-anonymous-id"
     }
 
-    /// Encodes values in RUM data store.
-    private static let encoder = JSONEncoder()
     /// Decodes values in RUM data store.
     private static let decoder = JSONDecoder()
 
@@ -45,7 +44,7 @@ internal struct RUMDataStore {
 
     func setValue<V: Codable>(_ value: V, forKey key: Key, version: DataStoreKeyVersion = dataStoreDefaultKeyVersion) {
         do {
-            let data = try RUMDataStore.encoder.encode(value)
+            let data = try JSONEncoder().dd.encodeWithAttributeRecovery(value)
             featureScope.dataStore.setValue(data, forKey: key.rawValue, version: version)
         } catch let error {
             DD.logger.error("Failed to encode \(type(of: value)) in RUM Data Store", error: error)

--- a/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Monitor+AttributeEncodingTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+@_spi(Internal)
 import DatadogInternal
 @testable import DatadogRUM
 @testable import TestUtilities
@@ -19,6 +20,15 @@ class Monitor_AttributeEncodingTests: XCTestCase {
     private let featureScope = FeatureScopeMock()
     private var monitor: Monitor! // swiftlint:disable:this implicitly_unwrapped_optional
 
+    private struct AlwaysFailingAttribute: Encodable {
+        func encode(to encoder: Encoder) throws {
+            throw EncodingError.invalidValue(
+                self,
+                .init(codingPath: encoder.codingPath, debugDescription: "failure")
+            )
+        }
+    }
+
     override func setUp() {
         monitor = Monitor(
             dependencies: .mockWith(featureScope: featureScope),
@@ -32,7 +42,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
 
     // MARK: - Custom attributes (context.*)
 
-    func testWhenCustomAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+    func testWhenCustomAttributeFailsToEncode_itIsNullAndEventIsSent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -44,51 +54,59 @@ class Monitor_AttributeEncodingTests: XCTestCase {
 
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
-        let jsonData = try JSONEncoder().encode(viewEvent)
+        let jsonData = try encodeForStorage(viewEvent)
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
         let context = json["context"] as? [String: Any]
 
         XCTAssertEqual(context?["valid"] as? String, "test", "Valid attribute should be present in the event")
-        XCTAssertNil(context?["invalid"], "Non-encodable attribute should be dropped")
+        XCTAssertTrue(context?["invalid"] is NSNull, "Non-encodable attribute should be null")
 
         XCTAssertEqual(
             dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute 'invalid'") }.count,
             1,
-            "One error should be logged for the dropped attribute"
+            "One error should be logged for the null attribute"
         )
     }
 
-    func testWhenOnlyMalformedCustomAttributesAdded_itSendsEventWithoutCustomAttributes() throws {
-        // Given
+    func testWhenCustomAttributeThrowsAfterPartialEncoding_itIsNullAndEventIsSent() throws {
+        final class ThrowingAfterPartialEncode: Encodable {
+            private(set) var encodeCount = 0
+
+            func encode(to encoder: Encoder) throws {
+                encodeCount += 1
+                var container = encoder.singleValueContainer()
+                try container.encode(["partial value"])
+                throw EncodingError.invalidValue(
+                    0,
+                    .init(codingPath: encoder.codingPath, debugDescription: "thrown after encoding a value")
+                )
+            }
+        }
+
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        // When
-        monitor.addAttribute(forKey: "invalid1", value: AnyEncodable(NSObject()))
-        let closure: (NSArray) -> Void = { _ in }
-        monitor.addAttribute(forKey: "invalid2", value: AnyEncodable(closure))
+        let poison = ThrowingAfterPartialEncode()
+        monitor.addAttribute(forKey: "before", value: "before")
+        monitor.addAttribute(forKey: "poison", value: poison)
+        monitor.addAttribute(forKey: "after", value: "after")
         monitor.notifySDKInit()
 
-        // Then - event is sent even though all custom attributes are malformed
-        let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
-        XCTAssertEqual(viewEvents.count, 1)
+        let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let jsonData = try encodeForStorage(viewEvent)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let context = try XCTUnwrap(json["context"] as? [String: Any])
 
-        let viewEvent = try XCTUnwrap(viewEvents.first)
-        let jsonData = try JSONEncoder().encode(viewEvent)
-        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
-
-        XCTAssertNil((json["context"] as? [String: Any])?["invalid1"])
-        XCTAssertNil((json["context"] as? [String: Any])?["invalid2"])
-
-        XCTAssertEqual(
-            dd.logger.errorLogs.filter { $0.message.contains("Failed to encode attribute") }.count,
-            2
-        )
+        XCTAssertEqual(context["before"] as? String, "before")
+        XCTAssertTrue(context["poison"] is NSNull)
+        XCTAssertEqual(context["after"] as? String, "after")
+        XCTAssertEqual(poison.encodeCount, 2)
+        XCTAssertTrue(try XCTUnwrap(dd.logger.errorLog).message.contains("attribute 'poison'"))
     }
 
     // MARK: - User info extra attributes (usr.*)
 
-    func testWhenUserInfoExtraAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+    func testWhenUserInfoExtraAttributeFailsToEncode_itIsNullAndEventIsSent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -106,12 +124,12 @@ class Monitor_AttributeEncodingTests: XCTestCase {
 
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
-        let jsonData = try JSONEncoder().encode(viewEvent)
+        let jsonData = try encodeForStorage(viewEvent)
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
         let usr = json["usr"] as? [String: Any]
 
         XCTAssertEqual(usr?["valid_info"] as? String, "test", "Valid user info attribute should be present")
-        XCTAssertNil(usr?["invalid_info"], "Non-encodable user info attribute should be dropped")
+        XCTAssertTrue(usr?["invalid_info"] is NSNull, "Non-encodable user info attribute should be null")
 
         XCTAssertEqual(
             dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_info") }.count,
@@ -121,7 +139,7 @@ class Monitor_AttributeEncodingTests: XCTestCase {
 
     // MARK: - Account info extra attributes (account.*)
 
-    func testWhenAccountInfoExtraAttributeFailsToEncode_itIsDroppedAndEventIsSent() throws {
+    func testWhenAccountInfoExtraAttributeFailsToEncode_itIsNullAndEventIsSent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -139,12 +157,12 @@ class Monitor_AttributeEncodingTests: XCTestCase {
 
         // Then
         let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
-        let jsonData = try JSONEncoder().encode(viewEvent)
+        let jsonData = try encodeForStorage(viewEvent)
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
         let account = json["account"] as? [String: Any]
 
         XCTAssertEqual(account?["valid_plan"] as? String, "enterprise", "Valid account info attribute should be present")
-        XCTAssertNil(account?["invalid_plan"], "Non-encodable account info attribute should be dropped")
+        XCTAssertTrue(account?["invalid_plan"] is NSNull, "Non-encodable account info attribute should be null")
 
         XCTAssertEqual(
             dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_plan") }.count,
@@ -152,9 +170,33 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         )
     }
 
+    func testWhenRecoveryAccountAndUserAttributesCollide_itPreservesStaticProperties() throws {
+        featureScope.contextMock = .mockWith(
+            userInfo: UserInfo(
+                id: "user-id",
+                extraInfo: ["id": AlwaysFailingAttribute()]
+            ),
+            accountInfo: AccountInfo(
+                id: "account-id",
+                extraInfo: ["id": AlwaysFailingAttribute()]
+            )
+        )
+
+        monitor.notifySDKInit()
+
+        let viewEvent = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).last)
+        let jsonData = try encodeForStorage(viewEvent)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: jsonData) as? [String: Any])
+        let user = try XCTUnwrap(json["usr"] as? [String: Any])
+        let account = try XCTUnwrap(json["account"] as? [String: Any])
+
+        XCTAssertEqual(user["id"] as? String, "user-id")
+        XCTAssertEqual(account["id"] as? String, "account-id")
+    }
+
     // MARK: - Feature flag values (feature_flags.*)
 
-    func testWhenFeatureFlagValueFailsToEncode_itIsDroppedAndEventIsSent() throws {
+    func testWhenFeatureFlagValueFailsToEncode_itIsNullAndEventIsSent() throws {
         // Given
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
@@ -168,16 +210,42 @@ class Monitor_AttributeEncodingTests: XCTestCase {
         // Then
         let viewEvents = featureScope.eventsWritten(ofType: RUMViewEvent.self)
         let viewWithFlags = try XCTUnwrap(viewEvents.last(where: { $0.view.name == "TestView" }))
-        let jsonData = try JSONEncoder().encode(viewWithFlags)
+        let jsonData = try encodeForStorage(viewWithFlags)
         let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: jsonData) as? [String: Any], "Expected encoded RUM view event JSON to be a dictionary")
         let featureFlags = json["feature_flags"] as? [String: Any]
 
         XCTAssertEqual(featureFlags?["valid_flag"] as? String, "enabled", "Valid feature flag should be present")
-        XCTAssertNil(featureFlags?["invalid_flag"], "Non-encodable feature flag should be dropped")
+        XCTAssertTrue(featureFlags?["invalid_flag"] is NSNull, "Non-encodable feature flag should be null")
 
         XCTAssertEqual(
             dd.logger.errorLogs.filter { $0.message.contains("Failed to encode") && $0.message.contains("invalid_flag") }.count,
             1
         )
+    }
+
+    // MARK: - RUM data store
+
+    func testRUMDataStoreRecoversMalformedAttributes() throws {
+        let value = RUMEventAttributes(
+            contextInfo: [
+                "valid": "preserved",
+                "invalid": AlwaysFailingAttribute(),
+            ]
+        )
+
+        featureScope.rumDataStore.setValue(value, forKey: .watchdogRUMViewEvent)
+
+        let storedValue = try XCTUnwrap(
+            featureScope.dataStoreMock.value(forKey: RUMDataStore.Key.watchdogRUMViewEvent.rawValue)
+        )
+        let data = try XCTUnwrap(storedValue.data())
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["valid"] as? String, "preserved")
+        XCTAssertTrue(json["invalid"] is NSNull)
+    }
+
+    private func encodeForStorage<T: Encodable>(_ value: T) throws -> Data {
+        try JSONEncoder.dd.default().dd.encodeWithAttributeRecovery(value)
     }
 }

--- a/tools/rum-models-generator/Sources/CodeGeneration/Print/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/CodeGeneration/Print/SwiftPrinter.swift
@@ -257,9 +257,26 @@ public class SwiftPrinter: BasePrinter, CodePrinter {
                 default:            context = ".custom"
                 }
                 let encodedValue = value.replacingOccurrences(of: "$1", with: "value")
-                writeLine("\(dynamicProperty.backtickName).forEach { name, value in") // dynamic properties are dictionaries
+                writeLine("let shouldRecover = encoder.shouldRecoverAttributeFailures")
+                writeLine("try \(dynamicProperty.backtickName).forEach { name, value in") // dynamic properties are dictionaries
                 indentRight()
-                    writeLine("dynamicContainer.encodeAttribute(\(encodedValue), forKey: DynamicCodingKey(name), attributeName: name, context: \(context))")
+                    if !staticallyEncodedProperties.isEmpty {
+                        writeLine("if shouldRecover, StaticCodingKeys(stringValue: name) != nil {")
+                        indentRight()
+                            writeLine("return")
+                        indentLeft()
+                        writeLine("}")
+                        writeEmptyLine()
+                    }
+                    writeLine("try dynamicContainer.encodeAttribute(")
+                    indentRight()
+                        writeLine("\(encodedValue),")
+                        writeLine("forKey: DynamicCodingKey(name),")
+                        writeLine("attributeName: name,")
+                        writeLine("context: \(context),")
+                        writeLine("shouldRecover: shouldRecover")
+                    indentLeft()
+                    writeLine(")")
                 indentLeft()
                 writeLine("}")
             }

--- a/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift
@@ -355,8 +355,15 @@ final class SwiftPrinterTests: XCTestCase {
             public func encode(to encoder: Encoder) throws {
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-                context.forEach { name, value in
-                    dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+                let shouldRecover = encoder.shouldRecoverAttributeFailures
+                try context.forEach { name, value in
+                    try dynamicContainer.encodeAttribute(
+                        AnyEncodable(value),
+                        forKey: DynamicCodingKey(name),
+                        attributeName: name,
+                        context: .custom,
+                        shouldRecover: shouldRecover
+                    )
                 }
             }
 
@@ -469,8 +476,19 @@ final class SwiftPrinterTests: XCTestCase {
 
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-                context.forEach { name, value in
-                    dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+                let shouldRecover = encoder.shouldRecoverAttributeFailures
+                try context.forEach { name, value in
+                    if shouldRecover, StaticCodingKeys(stringValue: name) != nil {
+                        return
+                    }
+
+                    try dynamicContainer.encodeAttribute(
+                        AnyEncodable(value),
+                        forKey: DynamicCodingKey(name),
+                        attributeName: name,
+                        context: .custom,
+                        shouldRecover: shouldRecover
+                    )
                 }
             }
 
@@ -790,8 +808,15 @@ final class SwiftPrinterTests: XCTestCase {
             public func encode(to encoder: Encoder) throws {
                 // Encode dynamic properties:
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-                context.forEach { name, value in
-                    dynamicContainer.encodeAttribute(AnyEncodable(value), forKey: DynamicCodingKey(name), attributeName: name, context: .custom)
+                let shouldRecover = encoder.shouldRecoverAttributeFailures
+                try context.forEach { name, value in
+                    try dynamicContainer.encodeAttribute(
+                        AnyEncodable(value),
+                        forKey: DynamicCodingKey(name),
+                        attributeName: name,
+                        context: .custom,
+                        shouldRecover: shouldRecover
+                    )
                 }
             }
 


### PR DESCRIPTION
### What and why?

Encoding an event can crash when one of its custom attributes throws after partially writing a value. The failed write leaves the underlying encoder in an invalid state, and encoding a subsequent attribute can trigger an `EXC_BREAKPOINT`.

This change prevents a malformed attribute from crashing the SDK or causing the entire event to be discarded. The malformed attribute is encoded as null, while valid attributes and static event fields are preserved.

Fixes #3130
Supersedes #3131

Credit @SaladDays831 for identifying the issue and contributing the initial fix.

### How?

Previously, attribute encoding errors were caught individually and encoding continued using the same event encoder. This works when an attribute throws before writing anything, but it is unsafe when the attribute writes a partial value first because the encoder may no longer accept subsequent values.

The initial solution in #3131 avoids reusing a corrupted encoder by validating non-scalar attributes separately before adding them to the event. While this safely handles malformed attributes, it adds extra encoding and decoding work to valid attributes which is the common path.

This PR keeps the existing direct encoding path for events whose attributes are valid. If an attribute fails, the incomplete attempt is discarded and the event is encoded one more time with each attribute isolated. Any malformed attributes are then replaced with null, without affecting the remaining event.

The retry happens at most once. Values reached before the initial failure may therefore have their `encode(to:)` implementation called twice.

**Performance trade-off**

Release benchmarks encoded events containing 26 attributes, including one custom structured or throwing `Encodable`. Each result is the mean of 10 measurements with 2,000 event encodes per measurement.


Implementation | Valid attributes | Throwing attribute
-- | -- | --
develop | 65.47 µs/event | Crashes
This PR | 65.37 µs/event | 195.95 µs/event
#3131 | 151.03 µs/event | 134.54 µs/event

This PR has no measurable overhead compared with develop on the normal path and is approximately 2.3x faster than #3131 when attributes encode successfully. Recovery is slower than #3131, but that additional work is limited to events containing a throwing attribute, which is not a common case. 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
