### PR TITLE
RUMS-6218: Prevent attribute sanitizer key collision crash

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		115792E62F4504F700AEE829 /* binary_image_resolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 115792E42F4504F700AEE829 /* binary_image_resolver.h */; };
 		115792EC2F4608A200AEE829 /* BinaryImageResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115792EB2F4608A200AEE829 /* BinaryImageResolverTests.swift */; };
 		1157930A2F51F05100AEE829 /* binary_image_resolver_testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 115793092F51F05100AEE829 /* binary_image_resolver_testing.h */; };
+		11582D80302DF335003E3106 /* AttributesSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11582D7F302DF335003E3106 /* AttributesSanitizerTests.swift */; };
 		115F480C2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */; };
 		116232382F866ACF00F20ABC /* OperationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118848522F6C4E0C008D2919 /* OperationMessage.swift */; };
 		1162323A2F866B4000F20ABC /* MockThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E2182E40E34A00BA4113 /* MockThread.swift */; };
@@ -1932,6 +1933,7 @@
 		115792E42F4504F700AEE829 /* binary_image_resolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = binary_image_resolver.h; sourceTree = "<group>"; };
 		115792EB2F4608A200AEE829 /* BinaryImageResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryImageResolverTests.swift; sourceTree = "<group>"; };
 		115793092F51F05100AEE829 /* binary_image_resolver_testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = binary_image_resolver_testing.h; sourceTree = "<group>"; };
+		11582D7F302DF335003E3106 /* AttributesSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesSanitizerTests.swift; sourceTree = "<group>"; };
 		115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicSamplerTests.swift; sourceTree = "<group>"; };
 		1162323D2F87D8F600F20ABC /* ProfilingContextMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingContextMessageReceiver.swift; sourceTree = "<group>"; };
 		1162323F2F87FA5D00F20ABC /* ProfilingSamplerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingSamplerProvider.swift; sourceTree = "<group>"; };
@@ -7014,6 +7016,7 @@
 				D2F44FBA299AA2310074B0D9 /* Upload */,
 				D2A783D629A530B4003B03BB /* Utils */,
 				B1EB089E0D4DAF6EF03C6AA0 /* Heatmaps */,
+				11582D7F302DF335003E3106 /* AttributesSanitizerTests.swift */,
 			);
 			name = DatadogInternalTests;
 			path = ../DatadogInternal/Tests;
@@ -9550,6 +9553,7 @@
 				D2181A8E2B051B7900A518C0 /* URLSessionSwizzlerTests.swift in Sources */,
 				D2A783DA29A530EF003B03BB /* SwiftExtensionsTests.swift in Sources */,
 				96E746AA2F30E535006B3419 /* AttributeEncodingTests.swift in Sources */,
+				11582D80302DF335003E3106 /* AttributesSanitizerTests.swift in Sources */,
 				D2D36DCB2AC6DCCA0021F28A /* DatadogCoreProtocolTests.swift in Sources */,
 				D2160CD429C0DF6700FAA9A5 /* NetworkInstrumentationFeatureTests.swift in Sources */,
 				D263BCB629DB014900FA0E21 /* TimeInterval+ConvenienceTests.swift in Sources */,

--- a/DatadogInternal/Sources/Attributes/AttributesSanitizer.swift
+++ b/DatadogInternal/Sources/Attributes/AttributesSanitizer.swift
@@ -35,7 +35,8 @@ public struct AttributesSanitizer {
     ///     one.two.three.four.five.six.seven.eight_nine_ten_eleven
     ///
     public func sanitizeKeys<Value>(for attributes: [String: Value], prefixLevels: Int = 0) -> [String: Value] {
-        let sanitizedAttributes: [(String, Value)] = attributes.map { key, value in
+        var sanitizedAttributes = attributes
+        attributes.forEach { key, value in
             let sanitizedName = sanitize(attributeKey: key, prefixLevels: prefixLevels)
             if sanitizedName != key {
                 DD.logger.warn(
@@ -43,12 +44,13 @@ public struct AttributesSanitizer {
                     \(featureName) attribute '\(key)' was modified to '\(sanitizedName)' to match Datadog constraints.
                     """
                 )
-                return (sanitizedName, value)
-            } else {
-                return (key, value)
+                sanitizedAttributes.removeValue(forKey: key)
+                if attributes[sanitizedName] == nil {
+                    sanitizedAttributes[sanitizedName] = value
+                }
             }
         }
-        return Dictionary(uniqueKeysWithValues: sanitizedAttributes)
+        return sanitizedAttributes
     }
 
     private func sanitize(attributeKey: String, prefixLevels: Int = 0) -> String {

--- a/DatadogInternal/Tests/AttributesSanitizerTests.swift
+++ b/DatadogInternal/Tests/AttributesSanitizerTests.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogInternal
+
+final class AttributesSanitizerTests: XCTestCase {
+    func testSanitizeKeysWhenSanitizedKeyCollidesWithExistingKey() {
+        // Given
+        let sanitizer = AttributesSanitizer(featureName: "test")
+        let sanitizedKey = "a.b.c.d.e.f.g.h.i.j_k"
+        let attributes = [
+            "a.b.c.d.e.f.g.h.i.j.k": 1,
+            sanitizedKey: 2
+        ]
+
+        // When
+        let sanitizedAttributes = sanitizer.sanitizeKeys(for: attributes)
+
+        // Then
+        XCTAssertEqual(sanitizedAttributes, [sanitizedKey: 2])
+    }
+}


### PR DESCRIPTION
### What and why?

This PR prevents a `SIGABRT` when distinct attribute keys resolve to the same sanitized key after exceeding the supported nesting depth. 
The previous implementation passed the transformed entries to `Dictionary(uniqueKeysWithValues:)`, which terminates the process when duplicate keys are present.

### How?

Constructs the sanitized dictionary while safely resolving key collisions. When a transformed key conflicts with an existing valid key, the valid attribute is preserved and the conflicting transformed attribute is dropped.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
