### PR TITLE
Decouple App Hang backtrace generation from Crash Reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [FEATURE] Add an experimental Core Animation recording pipeline for Session Replay, available through the `compositionTreeRecording` feature flag. See [#3127][]
 - [FEATURE] Add `disallowList` to `RUM.Configuration.URLSessionTracking` to exclude URLs from automatic RUM resource tracking, with `*` wildcard support. [#3097][]
-- [FEATURE] Add `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled.
+- [FEATURE] Add `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled. See [#3136][]
 - [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
 - [FIX] Fix `EXC_BREAKPOINT` crash when a log or RUM attribute's `encode(to:)` throws after partially encoding a value. [#3134][]
 
@@ -1230,6 +1230,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3127]: https://github.com/DataDog/dd-sdk-ios/pull/3127
 [#3097]: https://github.com/DataDog/dd-sdk-ios/pull/3097
 [#3134]: https://github.com/DataDog/dd-sdk-ios/pull/3134
+[#3136]: https://github.com/DataDog/dd-sdk-ios/pull/3136
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [FEATURE] Add an experimental Core Animation recording pipeline for Session Replay, available through the `compositionTreeRecording` feature flag. See [#3127][]
 - [FEATURE] Add `disallowList` to `RUM.Configuration.URLSessionTracking` to exclude URLs from automatic RUM resource tracking, with `*` wildcard support. [#3097][]
+- [FEATURE] Add `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled.
 - [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
 - [FIX] Fix `EXC_BREAKPOINT` crash when a log or RUM attribute's `encode(to:)` throws after partially encoding a value. [#3134][]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
 
+- [FEATURE] Add `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled. See [#3136][]
+
 # 3.16.0 / 19-08-2026
 
 - [FEATURE] Add an experimental Core Animation recording pipeline for Session Replay, available through the `compositionTreeRecording` feature flag. See [#3127][]
 - [FEATURE] Add `disallowList` to `RUM.Configuration.URLSessionTracking` to exclude URLs from automatic RUM resource tracking, with `*` wildcard support. [#3097][]
-- [FEATURE] Add `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled. See [#3136][]
 - [IMPROVEMENT] Forward `local_cache_hit` signal on RUM resources [#3074][]
 - [FIX] Fix `EXC_BREAKPOINT` crash when a log or RUM attribute's `encode(to:)` throws after partially encoding a value. [#3134][]
 

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 		267134902D688D280048CB54 /* AccountInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2671348F2D688D230048CB54 /* AccountInfo.swift */; };
 		269035A22E41F94800F1A830 /* UserConfigurationContextMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269035A12E41F93F00F1A830 /* UserConfigurationContextMocks.swift */; };
 		269035A62E41FAAC00F1A830 /* AccountConfigurationContextMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269035A42E41FAA500F1A830 /* AccountConfigurationContextMocks.swift */; };
+		26D89095303F398E00B5C5D0 /* CrashReportingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D89094303F398E00B5C5D0 /* CrashReportingConfiguration.swift */; };
 		27A047D86EB162480FF0C5AC /* EvaluationLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63A979F48771C3277A41396 /* EvaluationLogger.swift */; };
 		319A8FF248543C79F2980418 /* DatadogCoreProtocol+Heatmaps.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1B70A65975B9FEDEDA74E /* DatadogCoreProtocol+Heatmaps.swift */; };
 		3AFF4EF865EAECBA7BEDABDA /* FlagEvaluationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D115C155135BEF011C5D0A3F /* FlagEvaluationEvent.swift */; };
@@ -2109,6 +2110,7 @@
 		2671348F2D688D230048CB54 /* AccountInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfo.swift; sourceTree = "<group>"; };
 		269035A12E41F93F00F1A830 /* UserConfigurationContextMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserConfigurationContextMocks.swift; sourceTree = "<group>"; };
 		269035A42E41FAA500F1A830 /* AccountConfigurationContextMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountConfigurationContextMocks.swift; sourceTree = "<group>"; };
+		26D89094303F398E00B5C5D0 /* CrashReportingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingConfiguration.swift; sourceTree = "<group>"; };
 		2B6A3B154836FEB32C07EB50 /* EvaluationAggregator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EvaluationAggregator.swift; sourceTree = "<group>"; };
 		333D0D8EAED64F559835F384 /* RecordingComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordingComponents.swift; sourceTree = "<group>"; };
 		3C08F9CF2C2D652D002B0FF2 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
@@ -5379,6 +5381,7 @@
 				6167E6F52B81E94C00C3CA2D /* DDThread.swift */,
 				6167E6F82B81E95900C3CA2D /* BinaryImage.swift */,
 				3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */,
+				26D89094303F398E00B5C5D0 /* CrashReportingConfiguration.swift */,
 			);
 			path = CrashReporting;
 			sourceTree = "<group>";
@@ -9000,6 +9003,7 @@
 				D2D7483A2DC2306100C61353 /* TraceID.swift in Sources */,
 				D2D7483B2DC2306100C61353 /* SpanID.swift in Sources */,
 				D2671944300A662E002B90AD /* DDTag.swift in Sources */,
+				26D89095303F398E00B5C5D0 /* CrashReportingConfiguration.swift in Sources */,
 				D23039F3298D5236001A1FA3 /* DynamicCodingKey.swift in Sources */,
 				D2BEEDB22B335DA90065F3AC /* URLSessionTaskDelegateSwizzler.swift in Sources */,
 				D23039FE298D5236001A1FA3 /* FeatureRequestBuilder.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -59,6 +59,10 @@
             argument = "DD_DEBUG_RUM"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "DD_DISABLE_APP_HANG_BACKTRACES"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/Datadog/Example/Base.lproj/Main iOS.storyboard
+++ b/Datadog/Example/Base.lproj/Main iOS.storyboard
@@ -1369,6 +1369,65 @@
                                             <constraint firstAttribute="height" constant="20" id="WDI-xM-t2N"/>
                                         </constraints>
                                     </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App Hang" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ah1-Ti-tLe">
+                                        <rect key="frame" x="0.0" y="392" width="384" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ah2-Gp-g10" userLabel="Vertical gap 5">
+                                        <rect key="frame" x="0.0" y="412.5" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="5" id="Ah3-Cn-st5"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Backtraces: ON" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ah4-St-lbl">
+                                        <rect key="frame" x="0.0" y="417.5" width="384" height="14.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ah5-Gp-g10" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="432" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="Ah6-Cn-st10"/>
+                                        </constraints>
+                                    </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Ah7-Sv-stk">
+                                        <rect key="frame" x="0.0" y="442" width="384" height="44"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ah8-Bt-btn">
+                                                <rect key="frame" x="0.0" y="0.0" width="384" height="44"/>
+                                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="Hang main thread for 2s">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="7"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="didTapHangMainThread:" destination="dzc-N5-XBR" eventType="touchUpInside" id="Ah9-Ac-act"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="AhA-Cn-h44"/>
+                                        </constraints>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AhB-Gp-g20" userLabel="Vertical gap 20">
+                                        <rect key="frame" x="0.0" y="486" width="384" height="20"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="AhC-Cn-h20"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                             </stackView>
                         </subviews>
@@ -1382,6 +1441,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="UG5-SU-NkM"/>
                     <connections>
+                        <outlet property="appHangBacktraceStatusLabel" destination="Ah4-St-lbl" id="AhD-Ou-out"/>
                         <outlet property="rumServiceNameTextField" destination="Bco-7y-w7S" id="cBg-pr-cZ4"/>
                         <outlet property="viewNameTextField" destination="bXI-gy-gbl" id="ZaZ-Sh-Nrd"/>
                     </connections>

--- a/Datadog/Example/Debugging/DebugCrashReportingWithRUMViewController.swift
+++ b/Datadog/Example/Debugging/DebugCrashReportingWithRUMViewController.swift
@@ -14,6 +14,9 @@ class DebugCrashReportingWithRUMViewController: UIViewController {
         super.viewDidLoad()
         rumServiceNameTextField.text = serviceName
         viewNameTextField.placeholder = viewName
+        appHangBacktraceStatusLabel.text = Environment.isAppHangBacktraceEnabled()
+            ? "Backtraces: ON — launch with `DD_DISABLE_APP_HANG_BACKTRACES` to turn them off"
+            : "Backtraces: OFF — `appHangBacktraceEnabled: false`"
     }
 
     private func crash() {
@@ -45,6 +48,22 @@ class DebugCrashReportingWithRUMViewController: UIViewController {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             self?.crash()
+        }
+    }
+
+    // MARK: - App Hang
+
+    @IBOutlet weak var appHangBacktraceStatusLabel: UILabel!
+
+    /// Blocks the main thread for longer than the `appHangThreshold` configured in `ExampleAppDelegate`,
+    /// so RUM reports an App Hang error. Whether that error carries a stack trace depends on
+    /// `CrashReporting.Configuration.appHangBacktraceEnabled`.
+    @IBAction func didTapHangMainThread(_ sender: Any) {
+        (sender as? UIButton)?.disableFor(seconds: 0.5)
+
+        rumMonitor.startView(key: viewName, name: viewName, attributes: [:])
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            Thread.sleep(forTimeInterval: 2)
         }
     }
 

--- a/Datadog/Example/Environment.swift
+++ b/Datadog/Example/Environment.swift
@@ -11,6 +11,8 @@ internal struct Environment {
     struct Argument {
         static let isRunningUnitTests       = "IS_RUNNING_UNIT_TESTS"
         static let isRunningUITests         = "IS_RUNNING_UI_TESTS"
+        /// Launches the app with `CrashReporting.Configuration.appHangBacktraceEnabled` set to `false`.
+        static let disableAppHangBacktraces = "DD_DISABLE_APP_HANG_BACKTRACES"
     }
 
     struct InfoPlistKey {
@@ -35,6 +37,13 @@ internal struct Environment {
     /// If running `Example` in interactive, debug mode (launching it with 'Run' in Xcode or by tapping on the app icon).
     static func isRunningInteractive() -> Bool {
         return !isRunningUITests() && !isRunningUnitTests()
+    }
+
+    /// Whether App Hangs detected by RUM should carry a stack trace.
+    ///
+    /// Add `DD_DISABLE_APP_HANG_BACKTRACES` to the scheme's launch arguments to exercise the opt-out.
+    static func isAppHangBacktraceEnabled() -> Bool {
+        return !ProcessInfo.processInfo.arguments.contains(Argument.disableAppHangBacktraces)
     }
 
     // MARK: - Info.plist

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -61,7 +61,11 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
         )
 
         // Enable Crash Reporting
-        CrashReporting.enable()
+        CrashReporting.enable(
+            with: CrashReporting.Configuration(
+                appHangBacktraceEnabled: Environment.isAppHangBacktraceEnabled()
+            )
+        )
 
         // Set highest verbosity level to see debugging logs from the SDK
         Datadog.verbosityLevel = .debug
@@ -87,6 +91,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
                     }
                 ),
                 trackBackgroundEvents: true,
+                appHangThreshold: 0.5,
                 trackWatchdogTerminations: true,
                 customEndpoint: Environment.readCustomRUMURL(),
                 telemetrySampleRate: 100

--- a/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
+++ b/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
@@ -59,6 +59,29 @@ class GeneratingBacktraceTests: XCTestCase {
         )
     }
 
+    func testGivenAppHangBacktracesDisabled_whenGeneratingBacktrace_itStillGeneratesIt() throws {
+        #if os(watchOS)
+        throw XCTSkip("Backtrace generation is not supported on watchOS")
+        #endif
+        // Given
+        CrashReporting.enable(with: .init(appHangBacktraceEnabled: false), in: core)
+
+        // Then
+        XCTAssertNotNil(core.get(feature: BacktraceReportingFeature.self), "`BacktraceReportingFeature` must still be registered")
+        XCTAssertFalse(core.isAppHangBacktraceEnabled)
+
+        // Only the App Hangs consumer is gated - other consumers must keep working:
+        let backtrace = try XCTUnwrap(core.backtraceReporter.generateBacktrace())
+        XCTAssertGreaterThan(backtrace.threads.count, 0, "Some thread(s) should be recorded")
+        XCTAssertGreaterThan(backtrace.binaryImages.count, 0, "Some binary image(s) should be recorded")
+    }
+
+    func testGivenCrashReportingNotEnabled_thenAppHangBacktracesAreNotDisabled() {
+        // Then (backtrace generation is *unavailable*, not *disabled*)
+        XCTAssertNil(core.get(feature: BacktraceReportingFeature.self))
+        XCTAssertTrue(core.isAppHangBacktraceEnabled)
+    }
+
     func testGeneratingBacktraceOfTheMainThread() throws {
         #if os(watchOS)
         throw XCTSkip("Backtrace generation is not supported on watchOS")

--- a/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
+++ b/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
@@ -59,6 +59,15 @@ class GeneratingBacktraceTests: XCTestCase {
         )
     }
 
+    /// Reads the setting the way RUM does: by name, through `CrashReportingConfiguration`.
+    ///
+    /// `nil` means Crash Reporting was never enabled. Resolving the `?? true` fallback here instead would make the
+    /// assertions pass even if nothing were registered at all.
+    private func appHangBacktraceEnabled(in core: DatadogCoreProtocol) -> Bool? {
+        core.feature(named: Feature.crashReporting, type: CrashReportingConfiguration.self)?
+            .appHangBacktraceEnabled
+    }
+
     func testGivenAppHangBacktracesDisabled_whenGeneratingBacktrace_itStillGeneratesIt() throws {
         #if os(watchOS)
         throw XCTSkip("Backtrace generation is not supported on watchOS")
@@ -67,8 +76,7 @@ class GeneratingBacktraceTests: XCTestCase {
         CrashReporting.enable(with: .init(appHangBacktraceEnabled: false), in: core)
 
         // Then
-        XCTAssertNotNil(core.get(feature: BacktraceReportingFeature.self), "`BacktraceReportingFeature` must still be registered")
-        XCTAssertFalse(core.isAppHangBacktraceEnabled)
+        XCTAssertEqual(appHangBacktraceEnabled(in: core), false)
 
         // Only the App Hangs consumer is gated - other consumers must keep working:
         let backtrace = try XCTUnwrap(core.backtraceReporter.generateBacktrace())
@@ -76,10 +84,10 @@ class GeneratingBacktraceTests: XCTestCase {
         XCTAssertGreaterThan(backtrace.binaryImages.count, 0, "Some binary image(s) should be recorded")
     }
 
-    func testGivenCrashReportingNotEnabled_thenAppHangBacktracesAreNotDisabled() {
-        // Then (backtrace generation is *unavailable*, not *disabled*)
-        XCTAssertNil(core.get(feature: BacktraceReportingFeature.self))
-        XCTAssertTrue(core.isAppHangBacktraceEnabled)
+    func testGivenCrashReportingNotEnabled_itPublishesNoOptOut() {
+        // Then (nothing is published, so backtrace generation is *unavailable* rather than *disabled* - it is the
+        // `?? true` fallback at the RUM call site, not this Feature, that decides what an absent configuration means)
+        XCTAssertNil(appHangBacktraceEnabled(in: core))
     }
 
     func testGeneratingBacktraceOfTheMainThread() throws {

--- a/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
+++ b/Datadog/IntegrationUnitTests/CrashReporting/GeneratingBacktraceTests.swift
@@ -68,6 +68,81 @@ class GeneratingBacktraceTests: XCTestCase {
             .appHangBacktraceEnabled
     }
 
+    /// Number of warnings emitted about the opt-out being undone.
+    ///
+    /// Filtered by substring because `KSCrash` is a process singleton: from the second enabling test onwards it
+    /// prints its own "already installed" warning, which is unrelated. The phrase is unique to the console
+    /// warning, so this cannot start counting the telemetry message that accompanies it.
+    private func optOutWarnings(in spy: PrintFunctionSpy) -> Int {
+        spy.printedMessages.filter { $0.contains("undoes the earlier opt-out") }.count
+    }
+
+    func testWhenCrashReportingIsEnabledOnce_itDoesNotWarnAboutTheOptOut() {
+        // Given
+        let printFunction = PrintFunctionSpy()
+        consolePrint = printFunction.print
+        defer { consolePrint = { message, _ in print(message) } }
+
+        // When
+        CrashReporting.enable(with: .init(appHangBacktraceEnabled: false), in: core)
+
+        // Then
+        XCTAssertEqual(appHangBacktraceEnabled(in: core), false)
+        XCTAssertEqual(optOutWarnings(in: printFunction), 0, "There is no earlier value to undo")
+    }
+
+    func testWhenCrashReportingIsReEnabledWithoutTheOptOut_itWarnsAndAppliesTheLatestValue() {
+        // Given (`register(feature:)` overwrites by name, so a second `enable` replaces the configuration too)
+        let printFunction = PrintFunctionSpy()
+        consolePrint = printFunction.print
+        defer { consolePrint = { message, _ in print(message) } }
+
+        CrashReporting.enable(with: .init(appHangBacktraceEnabled: false), in: core)
+
+        // When (a wrapper SDK enables Crash Reporting again with defaults)
+        CrashReporting.enable(in: core)
+
+        // Then
+        XCTAssertEqual(appHangBacktraceEnabled(in: core), true, "The latest call wins")
+        XCTAssertEqual(optOutWarnings(in: printFunction), 1, "Undoing an explicit opt-out must not pass unnoticed")
+    }
+
+    func testWhenCrashReportingIsReEnabledWithTheOptOut_itDoesNotWarn() {
+        // Given (the app opts out *after* something else enabled Crash Reporting with defaults)
+        let printFunction = PrintFunctionSpy()
+        consolePrint = printFunction.print
+        defer { consolePrint = { message, _ in print(message) } }
+
+        CrashReporting.enable(in: core)
+
+        // When
+        CrashReporting.enable(with: .init(appHangBacktraceEnabled: false), in: core)
+
+        // Then
+        XCTAssertEqual(appHangBacktraceEnabled(in: core), false)
+        XCTAssertEqual(
+            optOutWarnings(in: printFunction),
+            0,
+            "This ends in the state the app asked for, so warning would report a correct outcome"
+        )
+    }
+
+    func testWhenCrashReportingIsReEnabledWithTheSameOptOut_itDoesNotWarn() {
+        // Given
+        let printFunction = PrintFunctionSpy()
+        consolePrint = printFunction.print
+        defer { consolePrint = { message, _ in print(message) } }
+
+        CrashReporting.enable(with: .init(appHangBacktraceEnabled: false), in: core)
+
+        // When
+        CrashReporting.enable(with: .init(appHangBacktraceEnabled: false), in: core)
+
+        // Then
+        XCTAssertEqual(appHangBacktraceEnabled(in: core), false)
+        XCTAssertEqual(optOutWarnings(in: printFunction), 0, "Nothing changed")
+    }
+
     func testGivenAppHangBacktracesDisabled_whenGeneratingBacktrace_itStillGeneratesIt() throws {
         #if os(watchOS)
         throw XCTSkip("Backtrace generation is not supported on watchOS")

--- a/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
@@ -116,6 +116,39 @@ class AppHangsMonitoringTests: XCTestCase {
         #endif
     }
 
+    func testGivenAppHangBacktracesDisabledInCrashReporting_whenMainThreadHangs_itTracksAppHangWithNoStackTrace() throws {
+        // Given (initialize SDK on the main thread)
+        let crashReportingConfig = CrashReporting.Configuration(appHangBacktraceEnabled: false)
+        oneOf([ // no matter of RUM or CR initialization order
+            {
+                RUM.enable(with: self.rumConfig, in: self.core)
+                CrashReporting.enable(with: crashReportingConfig, in: self.core)
+            },
+            {
+                CrashReporting.enable(with: crashReportingConfig, in: self.core)
+                RUM.enable(with: self.rumConfig, in: self.core)
+            },
+        ])
+
+        // When
+        mainQueue.sync {
+            Thread.sleep(forTimeInterval: hangDuration)
+        }
+
+        // Then
+        try flushHangsMonitoring()
+        let errors = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: RUMErrorEvent.self)
+        let appHangError = try XCTUnwrap(errors.first)
+
+        XCTAssertEqual(appHangError.error.message, AppHangsMonitor.Constants.appHangErrorMessage)
+        XCTAssertEqual(appHangError.error.type, AppHangsMonitor.Constants.appHangErrorType)
+        XCTAssertEqual(appHangError.error.stack, AppHangsMonitor.Constants.appHangStackDisabledErrorMessage)
+        XCTAssertEqual(appHangError.error.source, .source)
+        XCTAssertNil(appHangError.error.threads, "Threads should be unavailable as App Hang backtraces were disabled")
+        XCTAssertNil(appHangError.error.binaryImages, "Binary Images should be unavailable as App Hang backtraces were disabled")
+        XCTAssertNil(appHangError.error.wasTruncated, "Truncation flag should be unavailable as App Hang backtraces were disabled")
+    }
+
     func testGivenOnlyRUMEnabled_whenMainThreadHangs_itTracksAppHangWithNoStackTrace() throws {
         // Given
         mainQueue.sync {

--- a/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/AppHangsMonitoringTests.swift
@@ -116,19 +116,28 @@ class AppHangsMonitoringTests: XCTestCase {
         #endif
     }
 
-    func testGivenAppHangBacktracesDisabledInCrashReporting_whenMainThreadHangs_itTracksAppHangWithNoStackTrace() throws {
+    func testGivenAppHangBacktracesDisabledInCrashReporting_whenRUMIsEnabledFirst_itTracksAppHangWithNoStackTrace() throws {
+        try assertAppHangIsTrackedWithNoStackTrace { crashReportingConfig in
+            RUM.enable(with: self.rumConfig, in: self.core)
+            CrashReporting.enable(with: crashReportingConfig, in: self.core)
+        }
+    }
+
+    func testGivenAppHangBacktracesDisabledInCrashReporting_whenCrashReportingIsEnabledFirst_itTracksAppHangWithNoStackTrace() throws {
+        try assertAppHangIsTrackedWithNoStackTrace { crashReportingConfig in
+            CrashReporting.enable(with: crashReportingConfig, in: self.core)
+            RUM.enable(with: self.rumConfig, in: self.core)
+        }
+    }
+
+    /// Asserts that a hang is tracked with no stack trace, with the SDK enabled by `enableSDK`.
+    ///
+    /// Both enablement orders get their own test rather than being picked at random: only the RUM-first order
+    /// proves that the opt-out is read per hang instead of being captured when RUM is enabled, so randomizing
+    /// would let that regression pass half of the runs.
+    private func assertAppHangIsTrackedWithNoStackTrace(enableSDK: (CrashReporting.Configuration) -> Void) throws {
         // Given (initialize SDK on the main thread)
-        let crashReportingConfig = CrashReporting.Configuration(appHangBacktraceEnabled: false)
-        oneOf([ // no matter of RUM or CR initialization order
-            {
-                RUM.enable(with: self.rumConfig, in: self.core)
-                CrashReporting.enable(with: crashReportingConfig, in: self.core)
-            },
-            {
-                CrashReporting.enable(with: crashReportingConfig, in: self.core)
-                RUM.enable(with: self.rumConfig, in: self.core)
-            },
-        ])
+        enableSDK(CrashReporting.Configuration(appHangBacktraceEnabled: false))
 
         // When
         mainQueue.sync {

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -73,6 +73,13 @@
 
 - (void)testDatadogCrashReporterAPI {
     [DDCrashReporter enable];
+
+    DDCrashReporterConfiguration *configuration = [DDCrashReporterConfiguration new];
+    XCTAssertTrue(configuration.appHangBacktraceEnabled, @"App Hang backtraces are enabled by default");
+    configuration.appHangBacktraceEnabled = NO;
+    XCTAssertFalse(configuration.appHangBacktraceEnabled, @"The setter must write through to the wrapped configuration");
+
+    [DDCrashReporter enableWith:configuration];
 }
 
 #pragma clang diagnostic pop

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -26,9 +26,10 @@ public final class CrashReporting {
         /// Set this to `false` to keep receiving App Hang errors without a stack trace. Crash reports and every other
         /// stack trace collected by the SDK are unaffected.
         ///
-        /// Generating the backtrace snapshots all running threads while the main thread is still blocked, so its cost
-        /// adds to the duration of the hang being measured. Turning it off trades stack traces in App Hang errors for a
-        /// smaller footprint, which matters most for apps setting a small `RUM.Configuration.appHangThreshold`.
+        /// The backtrace is generated while the main thread is still blocked, so the cost of walking and symbolicating
+        /// its stack adds to the duration of the hang being measured. Turning it off trades stack traces in App Hang
+        /// errors for a smaller footprint, which matters most for apps setting a small
+        /// `RUM.Configuration.appHangThreshold`.
         ///
         /// Default: `true`.
         public var appHangBacktraceEnabled: Bool
@@ -112,24 +113,17 @@ public final class CrashReporting {
             crashContextProvider: contextProvider,
             sender: MessageBusSender(core: core),
             messageReceiver: contextProvider,
-            telemetry: core.telemetry
+            telemetry: core.telemetry,
+            appHangBacktraceEnabled: configuration.appHangBacktraceEnabled
         )
 
+        // `reporter` carries `appHangBacktraceEnabled` and is registered unconditionally, so the setting reaches RUM
+        // through `CrashReportingConfiguration` whether or not the plugin provides a backtrace reporter, and
+        // regardless of the order the two Features are registered in.
         try core.register(feature: reporter)
 
         if let backtraceReporter = plugin.backtraceReporter {
-            try core.register(
-                backtraceReporter: backtraceReporter,
-                appHangBacktraceEnabled: configuration.appHangBacktraceEnabled
-            )
-        } else if !configuration.appHangBacktraceEnabled {
-            // A custom plugin may provide no backtrace reporter. Record the opt-out anyway, so that it stays
-            // reportable as such rather than as "Crash Reporting was never enabled".
-            //
-            // Only when opting out: with the default there is no policy to record, so a reporter-less
-            // `BacktraceReportingFeature` would carry no information at all. A reporter registered later still
-            // installs either way, through `BacktraceReportingFeature.adoptReporterIfAbsent(_:)`.
-            try core.register(appHangBacktraceEnabled: false)
+            try core.register(backtraceReporter: backtraceReporter)
         }
 
         reporter.sendCrashReportIfFound()

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -19,10 +19,42 @@ import DatadogInternal
 ///
 /// Your crash reports appear in [Error Tracking](https://app.datadoghq.com/rum/error-tracking).
 public final class CrashReporting {
+    /// The Crash Reporting configuration.
+    public struct Configuration {
+        /// Determines whether backtraces are generated for App Hangs detected by RUM.
+        ///
+        /// Set this to `false` to keep receiving App Hang errors without a stack trace. Crash reports and every other
+        /// stack trace collected by the SDK are unaffected.
+        ///
+        /// Generating the backtrace snapshots all running threads while the main thread is still blocked, so its cost
+        /// adds to the duration of the hang being measured. Turning it off trades stack traces in App Hang errors for a
+        /// smaller footprint, which matters most for apps setting a small `RUM.Configuration.appHangThreshold`.
+        ///
+        /// Default: `true`.
+        public var appHangBacktraceEnabled: Bool
+
+        /// Creates a Crash Reporting configuration object.
+        ///
+        /// - Parameter appHangBacktraceEnabled: Whether backtraces are generated for App Hangs detected by RUM.
+        public init(appHangBacktraceEnabled: Bool = true) {
+            self.appHangBacktraceEnabled = appHangBacktraceEnabled
+        }
+    }
+
     /// Initializes the Datadog Crash Reporter using the default
     /// `KSCrash` plugin.
     public static func enable(in core: DatadogCoreProtocol = CoreRegistry.default) {
-        enable(with: try KSCrashPlugin(telemetry: core.telemetry), in: core)
+        enable(with: Configuration(), in: core)
+    }
+
+    /// Initializes the Datadog Crash Reporter using the default
+    /// `KSCrash` plugin.
+    ///
+    /// - Parameters:
+    ///   - configuration: The Crash Reporting configuration.
+    ///   - core: The instance of Datadog SDK to enable Crash Reporting in (global instance by default).
+    public static func enable(with configuration: Configuration, in core: DatadogCoreProtocol = CoreRegistry.default) {
+        enable(with: try KSCrashPlugin(telemetry: core.telemetry), configuration: configuration, in: core)
     }
 
     /// Initializes the Datadog Crash Reporter with a custom Crash Reporting Plugin.
@@ -31,19 +63,27 @@ public final class CrashReporting {
     /// - Provide crash report
     /// - Store context data associated with crashes
     /// - Provide backtraces
-    public static func enable(with plugin: @autoclosure () throws -> CrashReportingPlugin, in core: DatadogCoreProtocol = CoreRegistry.default) {
+    public static func enable(
+        with plugin: @autoclosure () throws -> CrashReportingPlugin,
+        configuration: Configuration = .init(),
+        in core: DatadogCoreProtocol = CoreRegistry.default
+    ) {
         do {
             // To ensure the correct registration order between Core and Features,
             // the entire initialization flow is synchronized on the main thread.
             try runOnMainThreadSync {
-                try enableOrThrow(with: plugin(), in: core)
+                try enableOrThrow(with: plugin(), in: core, configuration: configuration)
             }
         } catch let error {
             consolePrint("\(error)", .error)
         }
     }
 
-    internal static func enableOrThrow(with plugin: CrashReportingPlugin, in core: DatadogCoreProtocol) throws {
+    internal static func enableOrThrow(
+        with plugin: CrashReportingPlugin,
+        in core: DatadogCoreProtocol,
+        configuration: Configuration = .init()
+    ) throws {
         guard !(core is NOPDatadogCore) else {
             throw ProgrammerError(
                 description: "Datadog SDK must be initialized before calling `CrashReporting.enable()`."
@@ -63,7 +103,10 @@ public final class CrashReporting {
         try core.register(feature: reporter)
 
         if let backtraceReporter = plugin.backtraceReporter {
-            try core.register(backtraceReporter: backtraceReporter)
+            try core.register(
+                backtraceReporter: backtraceReporter,
+                appHangBacktraceEnabled: configuration.appHangBacktraceEnabled
+            )
         }
 
         reporter.sendCrashReportIfFound()
@@ -90,5 +133,36 @@ public final class objc_CrashReporting: NSObject {
     @objc
     public static func enable() {
         CrashReporting.enable()
+    }
+
+    /// Initializes the Datadog Crash Reporter with the given configuration.
+    /// - Parameter configuration: The Crash Reporting configuration.
+    @objc
+    public static func enable(with configuration: objc_CrashReportingConfiguration) {
+        CrashReporting.enable(with: configuration.configuration)
+    }
+}
+
+/// The Crash Reporting configuration.
+@available(swift, obsoleted: 1)
+@objc(DDCrashReporterConfiguration)
+@objcMembers
+public final class objc_CrashReportingConfiguration: NSObject {
+    internal var configuration: CrashReporting.Configuration
+
+    /// Determines whether backtraces are generated for App Hangs detected by RUM.
+    ///
+    /// Set this to `NO` to keep receiving App Hang errors without a stack trace. Crash reports and every other
+    /// stack trace collected by the SDK are unaffected.
+    ///
+    /// Default: `YES`.
+    public var appHangBacktraceEnabled: Bool {
+        get { configuration.appHangBacktraceEnabled }
+        set { configuration.appHangBacktraceEnabled = newValue }
+    }
+
+    /// Creates a Crash Reporting configuration object.
+    override public init() {
+        configuration = .init()
     }
 }

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -122,10 +122,14 @@ public final class CrashReporting {
                 backtraceReporter: backtraceReporter,
                 appHangBacktraceEnabled: configuration.appHangBacktraceEnabled
             )
-        } else {
-            // A custom plugin may provide no backtrace reporter. Register the policy anyway, so that opting out of
-            // App Hang backtraces stays reportable as such rather than as "Crash Reporting was never enabled".
-            try core.register(appHangBacktraceEnabled: configuration.appHangBacktraceEnabled)
+        } else if !configuration.appHangBacktraceEnabled {
+            // A custom plugin may provide no backtrace reporter. Record the opt-out anyway, so that it stays
+            // reportable as such rather than as "Crash Reporting was never enabled".
+            //
+            // Only when opting out: registering unconditionally would claim the single `BacktraceReportingFeature`
+            // slot with a reporter-less Feature, and the `get(feature:) == nil` guard in `register(backtraceReporter:)`
+            // would then silently drop any reporter registered later.
+            try core.register(appHangBacktraceEnabled: false)
         }
 
         reporter.sendCrashReportIfFound()

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -63,9 +63,24 @@ public final class CrashReporting {
     /// - Provide crash report
     /// - Store context data associated with crashes
     /// - Provide backtraces
+    public static func enable(with plugin: @autoclosure () throws -> CrashReportingPlugin, in core: DatadogCoreProtocol = CoreRegistry.default) {
+        enable(with: try plugin(), configuration: Configuration(), in: core)
+    }
+
+    /// Initializes the Datadog Crash Reporter with a custom Crash Reporting Plugin.
+    ///
+    /// The custom plugin will be responsible for:
+    /// - Provide crash report
+    /// - Store context data associated with crashes
+    /// - Provide backtraces
+    ///
+    /// - Parameters:
+    ///   - plugin: The custom Crash Reporting Plugin.
+    ///   - configuration: The Crash Reporting configuration.
+    ///   - core: The instance of Datadog SDK to enable Crash Reporting in (global instance by default).
     public static func enable(
         with plugin: @autoclosure () throws -> CrashReportingPlugin,
-        configuration: Configuration = .init(),
+        configuration: Configuration,
         in core: DatadogCoreProtocol = CoreRegistry.default
     ) {
         do {
@@ -107,6 +122,10 @@ public final class CrashReporting {
                 backtraceReporter: backtraceReporter,
                 appHangBacktraceEnabled: configuration.appHangBacktraceEnabled
             )
+        } else {
+            // A custom plugin may provide no backtrace reporter. Register the policy anyway, so that opting out of
+            // App Hang backtraces stays reportable as such rather than as "Crash Reporting was never enabled".
+            try core.register(appHangBacktraceEnabled: configuration.appHangBacktraceEnabled)
         }
 
         reporter.sendCrashReportIfFound()

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -106,6 +106,24 @@ public final class CrashReporting {
             )
         }
 
+        // `register(feature:)` overwrites by name, so enabling Crash Reporting twice replaces this Feature - and with
+        // it the configuration it carries. That is reachable when an app opts out natively and a wrapper SDK later
+        // calls `enable()` with defaults. Last write still wins, as it did before this option existed, but an
+        // opt-out being undone that way is worth saying out loud.
+        //
+        // Only that direction: replacing the default *with* an opt-out ends in the state the app asked for, so
+        // warning about it would report a correct outcome on every launch.
+        if let current = core.feature(named: Feature.crashReporting, type: CrashReportingConfiguration.self),
+           !current.appHangBacktraceEnabled, configuration.appHangBacktraceEnabled {
+            consolePrint(
+                "Crash Reporting is being enabled again without `appHangBacktraceEnabled: false`, which undoes the"
+                + " earlier opt-out: App Hang errors will carry stack traces again. Pass the same configuration to"
+                + " every `CrashReporting.enable` call to keep the opt-out.",
+                .warn
+            )
+            core.telemetry.debug("Crash Reporting re-enabled without the earlier appHangBacktraceEnabled opt-out")
+        }
+
         let contextProvider = CrashContextCoreProvider()
 
         let reporter = CrashReportingFeature(

--- a/DatadogCrashReporting/Sources/CrashReporting.swift
+++ b/DatadogCrashReporting/Sources/CrashReporting.swift
@@ -126,9 +126,9 @@ public final class CrashReporting {
             // A custom plugin may provide no backtrace reporter. Record the opt-out anyway, so that it stays
             // reportable as such rather than as "Crash Reporting was never enabled".
             //
-            // Only when opting out: registering unconditionally would claim the single `BacktraceReportingFeature`
-            // slot with a reporter-less Feature, and the `get(feature:) == nil` guard in `register(backtraceReporter:)`
-            // would then silently drop any reporter registered later.
+            // Only when opting out: with the default there is no policy to record, so a reporter-less
+            // `BacktraceReportingFeature` would carry no information at all. A reporter registered later still
+            // installs either way, through `BacktraceReportingFeature.adoptReporterIfAbsent(_:)`.
             try core.register(appHangBacktraceEnabled: false)
         }
 

--- a/DatadogCrashReporting/Sources/CrashReportingFeature.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingFeature.swift
@@ -8,10 +8,14 @@ import Foundation
 @_spi(Internal)
 import DatadogInternal
 
-internal final class CrashReportingFeature: DatadogFeature {
-    static let name = "crash-reporter"
-
+internal final class CrashReportingFeature: DatadogFeature, CrashReportingConfiguration {
     let messageReceiver: FeatureMessageReceiver
+
+    /// Determines whether backtraces may be generated for App Hangs detected by RUM.
+    ///
+    /// RUM reads it through `CrashReportingConfiguration` when a hang is detected, so this Feature is the single
+    /// source of truth for the setting and neither module needs to import the other.
+    let appHangBacktraceEnabled: Bool
 
     /// Queue for synchronizing internal operations.
     private let queue: DispatchQueue
@@ -30,7 +34,8 @@ internal final class CrashReportingFeature: DatadogFeature {
         crashContextProvider: CrashContextProvider,
         sender: CrashReportSender,
         messageReceiver: FeatureMessageReceiver,
-        telemetry: Telemetry
+        telemetry: Telemetry,
+        appHangBacktraceEnabled: Bool = true
     ) {
         self.queue = DispatchQueue(
             label: "com.datadoghq.crash-reporter",
@@ -41,6 +46,7 @@ internal final class CrashReportingFeature: DatadogFeature {
         self.crashContextProvider = crashContextProvider
         self.messageReceiver = messageReceiver
         self.telemetry = telemetry
+        self.appHangBacktraceEnabled = appHangBacktraceEnabled
 
         // Inject current `CrashContext`
         if let context = crashContextProvider.currentCrashContext {

--- a/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
@@ -143,6 +143,42 @@ class CrashReportingFeatureTests: XCTestCase {
         )
     }
 
+    func testGivenPluginWithNoBacktraceReporter_whenAppHangBacktracesAreEnabled_itLeavesRegistrationOpenForALaterReporter() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+        let plugin = CrashReportingPluginMock()
+        plugin.injectedBacktraceReporter = nil
+
+        // When
+        try CrashReporting.enableOrThrow(with: plugin, in: core)
+
+        // Then
+        XCTAssertTrue(core.isAppHangBacktraceEnabled)
+
+        try core.register(backtraceReporter: BacktraceReporterMock())
+        XCTAssertNotNil(
+            try core.backtraceReporter.generateBacktrace(),
+            "Nothing must claim the backtrace reporter registration when there is no opt-out to record, otherwise "
+            + "the `already registered` guard silently drops a reporter registered later"
+        )
+    }
+
+    func testWhenEnablingWithPluginThroughThePublicAPI_itForwardsTheConfiguration() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+        let plugin = CrashReportingPluginMock()
+        plugin.injectedBacktraceReporter = BacktraceReporterMock()
+
+        // When (through the public API, so that the overload's own argument forwarding is covered)
+        CrashReporting.enable(with: plugin, configuration: .init(appHangBacktraceEnabled: false), in: core)
+
+        // Then
+        XCTAssertFalse(
+            core.isAppHangBacktraceEnabled,
+            "The public overload must forward its `configuration`, not a default-constructed one"
+        )
+    }
+
     // MARK: - Crash Report Reading Tests
 
     func testItSendsLaunchReportWhenNoPendingCrash() {

--- a/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
@@ -83,6 +83,25 @@ class CrashReportingFeatureTests: XCTestCase {
 
     // MARK: - Configuration Tests
 
+    /// The setting as RUM resolves it, through `CrashReportingConfiguration` without importing
+    /// `DatadogCrashReporting`. `nil` means Crash Reporting was never enabled, in which case backtrace generation is
+    /// *unavailable* rather than *disabled* and App Hangs report it differently.
+    ///
+    /// Note: `FeatureRegistrationCoreMock` resolves by type and ignores the name, so these tests cannot catch a
+    /// divergence between the registered and the looked-up name - `testFeatureNameMatchesTheSharedConstant()` and the
+    /// real-core tests in `GeneratingBacktraceTests` cover that.
+    private func appHangBacktraceEnabled(in core: DatadogCoreProtocol) -> Bool? {
+        core.feature(named: Feature.crashReporting, type: CrashReportingConfiguration.self)?
+            .appHangBacktraceEnabled
+    }
+
+    func testFeatureNameMatchesTheSharedConstant() {
+        // `CrashReportingFeature` declares no `name` of its own - it comes from the `CrashReportingConfiguration`
+        // extension. A local one that diverged from this constant would shadow it and silently break RUM's lookup,
+        // which resolves by the constant.
+        XCTAssertEqual(CrashReportingFeature.name, Feature.crashReporting)
+    }
+
     func testByDefault_itRegistersBacktraceReporterWithAppHangBacktracesEnabled() throws {
         // Given
         let core = FeatureRegistrationCoreMock()
@@ -94,7 +113,12 @@ class CrashReportingFeatureTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(try core.backtraceReporter.generateBacktrace(), "Backtrace reporter must be registered")
-        XCTAssertTrue(core.isAppHangBacktraceEnabled)
+        XCTAssertEqual(
+            appHangBacktraceEnabled(in: core),
+            true,
+            "The default must be published as `true` by a registered Feature. Asserting the resolved `?? true` "
+            + "fallback instead would also pass if nothing were registered at all"
+        )
     }
 
     func testWhenAppHangBacktracesAreDisabled_itStillRegistersBacktraceReporter() throws {
@@ -115,7 +139,7 @@ class CrashReportingFeatureTests: XCTestCase {
             try core.backtraceReporter.generateBacktrace(),
             "Other consumers of backtrace generation must keep working"
         )
-        XCTAssertFalse(core.isAppHangBacktraceEnabled)
+        XCTAssertEqual(appHangBacktraceEnabled(in: core), false)
     }
 
     func testGivenPluginWithNoBacktraceReporter_whenAppHangBacktracesAreDisabled_itStillRecordsTheOptOut() throws {
@@ -132,8 +156,9 @@ class CrashReportingFeatureTests: XCTestCase {
         )
 
         // Then
-        XCTAssertFalse(
-            core.isAppHangBacktraceEnabled,
+        XCTAssertEqual(
+            appHangBacktraceEnabled(in: core),
+            false,
             "Opting out must be recorded even when the plugin provides no backtrace reporter, so that App Hangs "
             + "report the stack trace as disabled rather than as Crash Reporting never having been enabled"
         )
@@ -143,28 +168,8 @@ class CrashReportingFeatureTests: XCTestCase {
         )
     }
 
-    func testGivenPluginWithNoBacktraceReporter_whenAppHangBacktracesAreEnabled_itLeavesRegistrationOpenForALaterReporter() throws {
-        // Given
-        let core = FeatureRegistrationCoreMock()
-        let plugin = CrashReportingPluginMock()
-        plugin.injectedBacktraceReporter = nil
-
-        // When
-        try CrashReporting.enableOrThrow(with: plugin, in: core)
-
-        // Then
-        XCTAssertTrue(core.isAppHangBacktraceEnabled)
-
-        try core.register(backtraceReporter: BacktraceReporterMock())
-        XCTAssertNotNil(
-            try core.backtraceReporter.generateBacktrace(),
-            "Nothing must claim the backtrace reporter registration when there is no opt-out to record, otherwise "
-            + "the `already registered` guard silently drops a reporter registered later"
-        )
-    }
-
     func testGivenPluginWithNoBacktraceReporter_whenAppHangBacktracesAreDisabled_itStillAcceptsALaterReporter() throws {
-        // Given (the opt-out is recorded by a Feature that carries no reporter)
+        // Given
         let core = FeatureRegistrationCoreMock()
         let plugin = CrashReportingPluginMock()
         plugin.injectedBacktraceReporter = nil
@@ -181,21 +186,22 @@ class CrashReportingFeatureTests: XCTestCase {
         // Then
         XCTAssertNotNil(
             try core.backtraceReporter.generateBacktrace(),
-            "Recording the opt-out must not permanently block backtrace generation for the consumers this "
-            + "configuration promises are unaffected - crash reports, binary images on logs and RUM view events, "
-            + "and the public `backtraceReporter` API"
+            "Recording the opt-out must not block backtrace generation for the consumers this configuration "
+            + "promises are unaffected - crash reports, binary images on logs and RUM view events, and the public "
+            + "`backtraceReporter` API"
         )
-        XCTAssertFalse(
-            core.isAppHangBacktraceEnabled,
-            "Adopting a reporter must not revert the opt-out"
+        XCTAssertEqual(
+            appHangBacktraceEnabled(in: core),
+            false,
+            "Registering a backtrace reporter must not disturb the opt-out - they live on separate Features"
         )
     }
 
     func testGivenBacktraceReporterAlreadyRegistered_whenAppHangBacktracesAreDisabled_itStillRecordsTheOptOut() throws {
-        // Given (a reporter claimed the single registration slot before Crash Reporting was enabled)
+        // Given (a backtrace reporter was registered before Crash Reporting was enabled)
         let core = FeatureRegistrationCoreMock()
         try core.register(backtraceReporter: BacktraceReporterMock())
-        XCTAssertTrue(core.isAppHangBacktraceEnabled)
+        XCTAssertNil(appHangBacktraceEnabled(in: core), "Crash Reporting is not enabled yet")
 
         let plugin = CrashReportingPluginMock()
         plugin.injectedBacktraceReporter = BacktraceReporterMock()
@@ -208,32 +214,11 @@ class CrashReportingFeatureTests: XCTestCase {
         )
 
         // Then
-        XCTAssertFalse(
-            core.isAppHangBacktraceEnabled,
-            "The opt-out must be applied even though the first reporter keeps the registration, otherwise App Hangs "
-            + "keep snapshotting all threads after the app explicitly asked them not to"
-        )
-    }
-
-    func testGivenAppHangBacktracesDisabled_whenRegisteringAnotherBacktraceReporter_itKeepsTheOptOut() throws {
-        // Given
-        let core = FeatureRegistrationCoreMock()
-        let plugin = CrashReportingPluginMock()
-        plugin.injectedBacktraceReporter = BacktraceReporterMock()
-        try CrashReporting.enableOrThrow(
-            with: plugin,
-            in: core,
-            configuration: .init(appHangBacktraceEnabled: false)
-        )
-
-        // When
-        try core.register(backtraceReporter: BacktraceReporterMock())
-
-        // Then
-        XCTAssertFalse(
-            core.isAppHangBacktraceEnabled,
-            "`register(backtraceReporter:)` passes `true` as a compatibility default, not as an explicit request, "
-            + "so it must not revert an opt-out"
+        XCTAssertEqual(
+            appHangBacktraceEnabled(in: core),
+            false,
+            "The opt-out lives on `CrashReportingFeature`, so an already-registered backtrace reporter cannot "
+            + "swallow it - otherwise App Hangs keep collecting stack traces after the app asked them not to"
         )
     }
 
@@ -247,8 +232,9 @@ class CrashReportingFeatureTests: XCTestCase {
         CrashReporting.enable(with: plugin, configuration: .init(appHangBacktraceEnabled: false), in: core)
 
         // Then
-        XCTAssertFalse(
-            core.isAppHangBacktraceEnabled,
+        XCTAssertEqual(
+            appHangBacktraceEnabled(in: core),
+            false,
             "The public overload must forward its `configuration`, not a default-constructed one"
         )
     }

--- a/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
@@ -163,6 +163,34 @@ class CrashReportingFeatureTests: XCTestCase {
         )
     }
 
+    func testGivenPluginWithNoBacktraceReporter_whenAppHangBacktracesAreDisabled_itStillAcceptsALaterReporter() throws {
+        // Given (the opt-out is recorded by a Feature that carries no reporter)
+        let core = FeatureRegistrationCoreMock()
+        let plugin = CrashReportingPluginMock()
+        plugin.injectedBacktraceReporter = nil
+        try CrashReporting.enableOrThrow(
+            with: plugin,
+            in: core,
+            configuration: .init(appHangBacktraceEnabled: false)
+        )
+        XCTAssertNil(try core.backtraceReporter.generateBacktrace())
+
+        // When
+        try core.register(backtraceReporter: BacktraceReporterMock())
+
+        // Then
+        XCTAssertNotNil(
+            try core.backtraceReporter.generateBacktrace(),
+            "Recording the opt-out must not permanently block backtrace generation for the consumers this "
+            + "configuration promises are unaffected - crash reports, binary images on logs and RUM view events, "
+            + "and the public `backtraceReporter` API"
+        )
+        XCTAssertFalse(
+            core.isAppHangBacktraceEnabled,
+            "Adopting a reporter must not revert the opt-out"
+        )
+    }
+
     func testGivenBacktraceReporterAlreadyRegistered_whenAppHangBacktracesAreDisabled_itStillRecordsTheOptOut() throws {
         // Given (a reporter claimed the single registration slot before Crash Reporting was enabled)
         let core = FeatureRegistrationCoreMock()

--- a/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
@@ -118,6 +118,31 @@ class CrashReportingFeatureTests: XCTestCase {
         XCTAssertFalse(core.isAppHangBacktraceEnabled)
     }
 
+    func testGivenPluginWithNoBacktraceReporter_whenAppHangBacktracesAreDisabled_itStillRecordsTheOptOut() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+        let plugin = CrashReportingPluginMock()
+        plugin.injectedBacktraceReporter = nil
+
+        // When
+        try CrashReporting.enableOrThrow(
+            with: plugin,
+            in: core,
+            configuration: .init(appHangBacktraceEnabled: false)
+        )
+
+        // Then
+        XCTAssertFalse(
+            core.isAppHangBacktraceEnabled,
+            "Opting out must be recorded even when the plugin provides no backtrace reporter, so that App Hangs "
+            + "report the stack trace as disabled rather than as Crash Reporting never having been enabled"
+        )
+        XCTAssertNil(
+            try core.backtraceReporter.generateBacktrace(),
+            "Backtrace generation stays unavailable when the plugin provides no reporter"
+        )
+    }
+
     // MARK: - Crash Report Reading Tests
 
     func testItSendsLaunchReportWhenNoPendingCrash() {

--- a/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
@@ -163,6 +163,52 @@ class CrashReportingFeatureTests: XCTestCase {
         )
     }
 
+    func testGivenBacktraceReporterAlreadyRegistered_whenAppHangBacktracesAreDisabled_itStillRecordsTheOptOut() throws {
+        // Given (a reporter claimed the single registration slot before Crash Reporting was enabled)
+        let core = FeatureRegistrationCoreMock()
+        try core.register(backtraceReporter: BacktraceReporterMock())
+        XCTAssertTrue(core.isAppHangBacktraceEnabled)
+
+        let plugin = CrashReportingPluginMock()
+        plugin.injectedBacktraceReporter = BacktraceReporterMock()
+
+        // When
+        try CrashReporting.enableOrThrow(
+            with: plugin,
+            in: core,
+            configuration: .init(appHangBacktraceEnabled: false)
+        )
+
+        // Then
+        XCTAssertFalse(
+            core.isAppHangBacktraceEnabled,
+            "The opt-out must be applied even though the first reporter keeps the registration, otherwise App Hangs "
+            + "keep snapshotting all threads after the app explicitly asked them not to"
+        )
+    }
+
+    func testGivenAppHangBacktracesDisabled_whenRegisteringAnotherBacktraceReporter_itKeepsTheOptOut() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+        let plugin = CrashReportingPluginMock()
+        plugin.injectedBacktraceReporter = BacktraceReporterMock()
+        try CrashReporting.enableOrThrow(
+            with: plugin,
+            in: core,
+            configuration: .init(appHangBacktraceEnabled: false)
+        )
+
+        // When
+        try core.register(backtraceReporter: BacktraceReporterMock())
+
+        // Then
+        XCTAssertFalse(
+            core.isAppHangBacktraceEnabled,
+            "`register(backtraceReporter:)` passes `true` as a compatibility default, not as an explicit request, "
+            + "so it must not revert an opt-out"
+        )
+    }
+
     func testWhenEnablingWithPluginThroughThePublicAPI_itForwardsTheConfiguration() throws {
         // Given
         let core = FeatureRegistrationCoreMock()

--- a/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
+++ b/DatadogCrashReporting/Tests/CrashReportingFeatureTests.swift
@@ -81,6 +81,43 @@ class CrashReportingFeatureTests: XCTestCase {
         XCTAssertTrue(user["invalid"] is NSNull)
     }
 
+    // MARK: - Configuration Tests
+
+    func testByDefault_itRegistersBacktraceReporterWithAppHangBacktracesEnabled() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+        let plugin = CrashReportingPluginMock()
+        plugin.injectedBacktraceReporter = BacktraceReporterMock()
+
+        // When
+        try CrashReporting.enableOrThrow(with: plugin, in: core)
+
+        // Then
+        XCTAssertNotNil(try core.backtraceReporter.generateBacktrace(), "Backtrace reporter must be registered")
+        XCTAssertTrue(core.isAppHangBacktraceEnabled)
+    }
+
+    func testWhenAppHangBacktracesAreDisabled_itStillRegistersBacktraceReporter() throws {
+        // Given
+        let core = FeatureRegistrationCoreMock()
+        let plugin = CrashReportingPluginMock()
+        plugin.injectedBacktraceReporter = BacktraceReporterMock()
+
+        // When
+        try CrashReporting.enableOrThrow(
+            with: plugin,
+            in: core,
+            configuration: .init(appHangBacktraceEnabled: false)
+        )
+
+        // Then
+        XCTAssertNotNil(
+            try core.backtraceReporter.generateBacktrace(),
+            "Other consumers of backtrace generation must keep working"
+        )
+        XCTAssertFalse(core.isAppHangBacktraceEnabled)
+    }
+
     // MARK: - Crash Report Reading Tests
 
     func testItSendsLaunchReportWhenNoPendingCrash() {

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -96,13 +96,18 @@ extension DatadogCoreProtocol {
     ///   - backtraceReporter: the implementation of backtrace reporter.
     ///   - appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM.
     public func register(backtraceReporter: BacktraceReporting, appHangBacktraceEnabled: Bool) throws {
-        guard get(feature: BacktraceReportingFeature.self) == nil else {
-            DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
-            return
+        guard let registered = get(feature: BacktraceReportingFeature.self) else {
+            let feature = BacktraceReportingFeature(reporter: backtraceReporter, appHangBacktraceEnabled: appHangBacktraceEnabled)
+            return try register(feature: feature)
         }
 
-        let feature = BacktraceReportingFeature(reporter: backtraceReporter, appHangBacktraceEnabled: appHangBacktraceEnabled)
-        try register(feature: feature)
+        DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
+
+        // The first reporter keeps the registration, but an opt-out arriving with a later one must not be dropped
+        // along with it - see `BacktraceReportingFeature.disableAppHangBacktrace()`.
+        if !appHangBacktraceEnabled {
+            registered.disableAppHangBacktrace()
+        }
     }
 
     /// Registers the App Hang backtrace policy in Core when no backtrace reporter is available.
@@ -113,13 +118,15 @@ extension DatadogCoreProtocol {
     ///
     /// - Parameter appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM.
     public func register(appHangBacktraceEnabled: Bool) throws {
-        guard get(feature: BacktraceReportingFeature.self) == nil else {
-            DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
-            return
+        guard let registered = get(feature: BacktraceReportingFeature.self) else {
+            let feature = BacktraceReportingFeature(reporter: nil, appHangBacktraceEnabled: appHangBacktraceEnabled)
+            return try register(feature: feature)
         }
 
-        let feature = BacktraceReportingFeature(reporter: nil, appHangBacktraceEnabled: appHangBacktraceEnabled)
-        try register(feature: feature)
+        // A reporter already holds the registration - keep it and only record the policy, as above.
+        if !appHangBacktraceEnabled {
+            registered.disableAppHangBacktrace()
+        }
     }
 
     /// Backtrace reporter. Use it to snapshot all running threads in the current process.
@@ -129,10 +136,11 @@ extension DatadogCoreProtocol {
 
     /// Whether backtraces may be generated for App Hangs detected by RUM.
     ///
-    /// It is `false` only when Crash Reporting was enabled with App Hang backtraces turned off — whether or not a
-    /// backtrace reporter came with it. Until then it is `true`: in that state backtrace generation may still be
-    /// *unavailable* rather than *disabled*, and callers must keep distinguishing the two. Read it at the moment a
-    /// backtrace is needed, as the reporter may be registered after the reading Feature was enabled.
+    /// It is `false` once Crash Reporting was enabled with App Hang backtraces turned off — whether or not a
+    /// backtrace reporter came with it, and whichever order registrations happened in. Until then it is `true`: in
+    /// that state backtrace generation may still be *unavailable* rather than *disabled*, and callers must keep
+    /// distinguishing the two. Read it at the moment a backtrace is needed, as the reporter may be registered after
+    /// the reading Feature was enabled.
     public var isAppHangBacktraceEnabled: Bool {
         // `self.` is required: a bare `get(...)` here parses as a `get` accessor.
         self.get(feature: BacktraceReportingFeature.self)?.appHangBacktraceEnabled ?? true

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -66,7 +66,7 @@ internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
             return nil
         }
 
-        guard let backtraceFeature = core.get(feature: BacktraceReportingFeature.self) else {
+        guard let reporter = core.get(feature: BacktraceReportingFeature.self)?.reporter else {
             DD.logger.warn(
                 """
                 Backtrace will not be generated as this capability is not available.
@@ -75,11 +75,11 @@ internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
             )
             return nil
         }
-        return try backtraceFeature.reporter.generateBacktrace(threadID: threadID)
+        return try reporter.generateBacktrace(threadID: threadID)
     }
 
     func binaryImages() throws -> [BinaryImage]? {
-        try core?.get(feature: BacktraceReportingFeature.self)?.reporter.binaryImages()
+        try core?.get(feature: BacktraceReportingFeature.self)?.reporter?.binaryImages()
     }
 }
 
@@ -96,6 +96,23 @@ extension DatadogCoreProtocol {
         }
 
         let feature = BacktraceReportingFeature(reporter: backtraceReporter, appHangBacktraceEnabled: appHangBacktraceEnabled)
+        try register(feature: feature)
+    }
+
+    /// Registers the App Hang backtrace policy in Core when no backtrace reporter is available.
+    ///
+    /// Use it when Crash Reporting is enabled with a custom plugin that provides no backtrace reporter: backtraces
+    /// cannot be generated at all in that case, but recording the policy keeps "generation was turned off" reportable
+    /// as such instead of being mistaken for "Crash Reporting was never enabled".
+    ///
+    /// - Parameter appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM.
+    public func register(appHangBacktraceEnabled: Bool) throws {
+        guard get(feature: BacktraceReportingFeature.self) == nil else {
+            DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
+            return
+        }
+
+        let feature = BacktraceReportingFeature(reporter: nil, appHangBacktraceEnabled: appHangBacktraceEnabled)
         try register(feature: feature)
     }
 

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -66,7 +66,7 @@ internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
             return nil
         }
 
-        guard let reporter = core.get(feature: BacktraceReportingFeature.self)?.reporter else {
+        guard let backtraceFeature = core.get(feature: BacktraceReportingFeature.self) else {
             DD.logger.warn(
                 """
                 Backtrace will not be generated as this capability is not available.
@@ -75,11 +75,11 @@ internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
             )
             return nil
         }
-        return try reporter.generateBacktrace(threadID: threadID)
+        return try backtraceFeature.reporter.generateBacktrace(threadID: threadID)
     }
 
     func binaryImages() throws -> [BinaryImage]? {
-        try core?.get(feature: BacktraceReportingFeature.self)?.reporter?.binaryImages()
+        try core?.get(feature: BacktraceReportingFeature.self)?.reporter.binaryImages()
     }
 }
 
@@ -88,66 +88,17 @@ extension DatadogCoreProtocol {
     /// Registers backtrace reporter in Core.
     /// - Parameter backtraceReporter: the implementation of backtrace reporter.
     public func register(backtraceReporter: BacktraceReporting) throws {
-        try register(backtraceReporter: backtraceReporter, appHangBacktraceEnabled: true)
-    }
-
-    /// Registers backtrace reporter in Core.
-    /// - Parameters:
-    ///   - backtraceReporter: the implementation of backtrace reporter.
-    ///   - appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM.
-    public func register(backtraceReporter: BacktraceReporting, appHangBacktraceEnabled: Bool) throws {
-        guard let registered = get(feature: BacktraceReportingFeature.self) else {
-            let feature = BacktraceReportingFeature(reporter: backtraceReporter, appHangBacktraceEnabled: appHangBacktraceEnabled)
-            return try register(feature: feature)
-        }
-
-        // A Feature registered only to record an App Hang opt-out holds no reporter yet, so let this one fill the
-        // empty slot instead of being dropped - see `BacktraceReportingFeature.adoptReporterIfAbsent(_:)`.
-        if !registered.adoptReporterIfAbsent(backtraceReporter) {
+        guard get(feature: BacktraceReportingFeature.self) == nil else {
             DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
+            return
         }
 
-        // The first reporter keeps the registration, but an opt-out arriving with a later one must not be dropped
-        // along with it - see `BacktraceReportingFeature.disableAppHangBacktrace()`.
-        if !appHangBacktraceEnabled {
-            registered.disableAppHangBacktrace()
-        }
-    }
-
-    /// Registers the App Hang backtrace policy in Core when no backtrace reporter is available.
-    ///
-    /// Use it when Crash Reporting is enabled with a custom plugin that provides no backtrace reporter: backtraces
-    /// cannot be generated until some other component registers one, but recording the policy keeps "generation was
-    /// turned off" reportable as such instead of being mistaken for "Crash Reporting was never enabled". A reporter
-    /// registered afterwards still installs, through `BacktraceReportingFeature.adoptReporterIfAbsent(_:)`.
-    ///
-    /// - Parameter appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM.
-    public func register(appHangBacktraceEnabled: Bool) throws {
-        guard let registered = get(feature: BacktraceReportingFeature.self) else {
-            let feature = BacktraceReportingFeature(reporter: nil, appHangBacktraceEnabled: appHangBacktraceEnabled)
-            return try register(feature: feature)
-        }
-
-        // A reporter already holds the registration - keep it and only record the policy, as above.
-        if !appHangBacktraceEnabled {
-            registered.disableAppHangBacktrace()
-        }
+        let feature = BacktraceReportingFeature(reporter: backtraceReporter)
+        try register(feature: feature)
     }
 
     /// Backtrace reporter. Use it to snapshot all running threads in the current process.
     ///
     /// It requires `BacktraceReportingFeature` registered to Datadog core. Otherwise reported backtraces will be `nil`.
     public var backtraceReporter: BacktraceReporting { CoreBacktraceReporter(core: self) }
-
-    /// Whether backtraces may be generated for App Hangs detected by RUM.
-    ///
-    /// It is `false` once Crash Reporting was enabled with App Hang backtraces turned off — whether or not a
-    /// backtrace reporter came with it, and whichever order registrations happened in. Until then it is `true`: in
-    /// that state backtrace generation may still be *unavailable* rather than *disabled*, and callers must keep
-    /// distinguishing the two. Read it at the moment a backtrace is needed, as the reporter may be registered after
-    /// the reading Feature was enabled.
-    public var isAppHangBacktraceEnabled: Bool {
-        // `self.` is required: a bare `get(...)` here parses as a `get` accessor.
-        self.get(feature: BacktraceReportingFeature.self)?.appHangBacktraceEnabled ?? true
-    }
 }

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -86,10 +86,16 @@ internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
 /// Adds capability of reporting backtraces.
 extension DatadogCoreProtocol {
     /// Registers backtrace reporter in Core.
+    /// - Parameter backtraceReporter: the implementation of backtrace reporter.
+    public func register(backtraceReporter: BacktraceReporting) throws {
+        try register(backtraceReporter: backtraceReporter, appHangBacktraceEnabled: true)
+    }
+
+    /// Registers backtrace reporter in Core.
     /// - Parameters:
     ///   - backtraceReporter: the implementation of backtrace reporter.
-    ///   - appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM. Default: `true`.
-    public func register(backtraceReporter: BacktraceReporting, appHangBacktraceEnabled: Bool = true) throws {
+    ///   - appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM.
+    public func register(backtraceReporter: BacktraceReporting, appHangBacktraceEnabled: Bool) throws {
         guard get(feature: BacktraceReportingFeature.self) == nil else {
             DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
             return
@@ -123,10 +129,10 @@ extension DatadogCoreProtocol {
 
     /// Whether backtraces may be generated for App Hangs detected by RUM.
     ///
-    /// It is `false` only when a backtrace reporter was registered with App Hang backtraces turned off. Before any
-    /// reporter is registered it is `true`: in that state backtrace generation is *unavailable* rather than
-    /// *disabled*, and callers must keep distinguishing the two. Read it at the moment a backtrace is needed, as
-    /// the reporter may be registered after the reading Feature was enabled.
+    /// It is `false` only when Crash Reporting was enabled with App Hang backtraces turned off — whether or not a
+    /// backtrace reporter came with it. Until then it is `true`: in that state backtrace generation may still be
+    /// *unavailable* rather than *disabled*, and callers must keep distinguishing the two. Read it at the moment a
+    /// backtrace is needed, as the reporter may be registered after the reading Feature was enabled.
     public var isAppHangBacktraceEnabled: Bool {
         // `self.` is required: a bare `get(...)` here parses as a `get` accessor.
         self.get(feature: BacktraceReportingFeature.self)?.appHangBacktraceEnabled ?? true

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -101,7 +101,11 @@ extension DatadogCoreProtocol {
             return try register(feature: feature)
         }
 
-        DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
+        // A Feature registered only to record an App Hang opt-out holds no reporter yet, so let this one fill the
+        // empty slot instead of being dropped - see `BacktraceReportingFeature.adoptReporterIfAbsent(_:)`.
+        if !registered.adoptReporterIfAbsent(backtraceReporter) {
+            DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
+        }
 
         // The first reporter keeps the registration, but an opt-out arriving with a later one must not be dropped
         // along with it - see `BacktraceReportingFeature.disableAppHangBacktrace()`.
@@ -113,8 +117,9 @@ extension DatadogCoreProtocol {
     /// Registers the App Hang backtrace policy in Core when no backtrace reporter is available.
     ///
     /// Use it when Crash Reporting is enabled with a custom plugin that provides no backtrace reporter: backtraces
-    /// cannot be generated at all in that case, but recording the policy keeps "generation was turned off" reportable
-    /// as such instead of being mistaken for "Crash Reporting was never enabled".
+    /// cannot be generated until some other component registers one, but recording the policy keeps "generation was
+    /// turned off" reportable as such instead of being mistaken for "Crash Reporting was never enabled". A reporter
+    /// registered afterwards still installs, through `BacktraceReportingFeature.adoptReporterIfAbsent(_:)`.
     ///
     /// - Parameter appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM.
     public func register(appHangBacktraceEnabled: Bool) throws {

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReporter.swift
@@ -86,14 +86,16 @@ internal struct CoreBacktraceReporter: BacktraceReporting, @unchecked Sendable {
 /// Adds capability of reporting backtraces.
 extension DatadogCoreProtocol {
     /// Registers backtrace reporter in Core.
-    /// - Parameter backtraceReporter: the implementation of backtrace reporter.
-    public func register(backtraceReporter: BacktraceReporting) throws {
+    /// - Parameters:
+    ///   - backtraceReporter: the implementation of backtrace reporter.
+    ///   - appHangBacktraceEnabled: whether backtraces may be generated for App Hangs detected by RUM. Default: `true`.
+    public func register(backtraceReporter: BacktraceReporting, appHangBacktraceEnabled: Bool = true) throws {
         guard get(feature: BacktraceReportingFeature.self) == nil else {
             DD.logger.debug("Backtrace reporter is already registered to this core. Skipping registration of next one.")
             return
         }
 
-        let feature = BacktraceReportingFeature(reporter: backtraceReporter)
+        let feature = BacktraceReportingFeature(reporter: backtraceReporter, appHangBacktraceEnabled: appHangBacktraceEnabled)
         try register(feature: feature)
     }
 
@@ -101,4 +103,15 @@ extension DatadogCoreProtocol {
     ///
     /// It requires `BacktraceReportingFeature` registered to Datadog core. Otherwise reported backtraces will be `nil`.
     public var backtraceReporter: BacktraceReporting { CoreBacktraceReporter(core: self) }
+
+    /// Whether backtraces may be generated for App Hangs detected by RUM.
+    ///
+    /// It is `false` only when a backtrace reporter was registered with App Hang backtraces turned off. Before any
+    /// reporter is registered it is `true`: in that state backtrace generation is *unavailable* rather than
+    /// *disabled*, and callers must keep distinguishing the two. Read it at the moment a backtrace is needed, as
+    /// the reporter may be registered after the reading Feature was enabled.
+    public var isAppHangBacktraceEnabled: Bool {
+        // `self.` is required: a bare `get(...)` here parses as a `get` accessor.
+        self.get(feature: BacktraceReportingFeature.self)?.appHangBacktraceEnabled ?? true
+    }
 }

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
@@ -22,7 +22,11 @@ internal final class BacktraceReportingFeature: DatadogFeature {
     ///
     /// It only gates the App Hangs consumer. All other consumers of `reporter` (crash reports, binary images
     /// attached to logs and RUM view events, the public `backtraceReporter` API) are unaffected by this value.
-    let appHangBacktraceEnabled: Bool
+    ///
+    /// Only `disableAppHangBacktrace()` can change it after initialization. It is read from the App Hangs watchdog
+    /// thread, hence the lock.
+    @ReadWriteLock
+    private(set) var appHangBacktraceEnabled: Bool
 
     /// Creates `BacktraceReportingFeature`.
     /// - Parameters:
@@ -31,5 +35,18 @@ internal final class BacktraceReportingFeature: DatadogFeature {
     init(reporter: BacktraceReporting?, appHangBacktraceEnabled: Bool = true) {
         self.reporter = reporter
         self.appHangBacktraceEnabled = appHangBacktraceEnabled
+    }
+
+    /// Turns off backtrace generation for App Hangs.
+    ///
+    /// Needed because only the first registration installs its `reporter`, while an opt-out arriving with a later one
+    /// must still take effect — otherwise an app that registered a backtrace reporter before enabling Crash Reporting
+    /// would keep snapshotting all threads after explicitly asking it not to.
+    ///
+    /// Turning it back on is deliberately not offered: `register(backtraceReporter:)` passes `true` as a compatibility
+    /// default rather than as an explicit request, so honouring it would silently revert an opt-out. Opting out is
+    /// therefore one-way, which also makes the outcome independent of registration order.
+    func disableAppHangBacktrace() {
+        _appHangBacktraceEnabled.mutate { $0 = false }
     }
 }

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
@@ -14,9 +14,18 @@ internal final class BacktraceReportingFeature: DatadogFeature {
     /// A type capable of generating backtrace reports.
     let reporter: BacktraceReporting
 
+    /// Determines whether backtraces may be generated for App Hangs detected by RUM.
+    ///
+    /// It only gates the App Hangs consumer. All other consumers of `reporter` (crash reports, binary images
+    /// attached to logs and RUM view events, the public `backtraceReporter` API) are unaffected by this value.
+    let appHangBacktraceEnabled: Bool
+
     /// Creates `BacktraceReportingFeature`.
-    /// - Parameter reporter: An external implementation of a type capable of generating backtrace reports.
-    init(reporter: BacktraceReporting) {
+    /// - Parameters:
+    ///   - reporter: An external implementation of a type capable of generating backtrace reports.
+    ///   - appHangBacktraceEnabled: Whether backtraces may be generated for App Hangs. Default: `true`.
+    init(reporter: BacktraceReporting, appHangBacktraceEnabled: Bool = true) {
         self.reporter = reporter
+        self.appHangBacktraceEnabled = appHangBacktraceEnabled
     }
 }

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
@@ -12,7 +12,11 @@ internal final class BacktraceReportingFeature: DatadogFeature {
     let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
 
     /// A type capable of generating backtrace reports.
-    let reporter: BacktraceReporting
+    ///
+    /// It is `nil` when Crash Reporting was enabled with a custom plugin that provides no backtrace reporter. The
+    /// Feature is still registered in that case, so that `appHangBacktraceEnabled` is recorded and backtrace
+    /// generation stays distinguishable from Crash Reporting never having been enabled.
+    let reporter: BacktraceReporting?
 
     /// Determines whether backtraces may be generated for App Hangs detected by RUM.
     ///
@@ -22,9 +26,9 @@ internal final class BacktraceReportingFeature: DatadogFeature {
 
     /// Creates `BacktraceReportingFeature`.
     /// - Parameters:
-    ///   - reporter: An external implementation of a type capable of generating backtrace reports.
+    ///   - reporter: An external implementation of a type capable of generating backtrace reports, if any.
     ///   - appHangBacktraceEnabled: Whether backtraces may be generated for App Hangs. Default: `true`.
-    init(reporter: BacktraceReporting, appHangBacktraceEnabled: Bool = true) {
+    init(reporter: BacktraceReporting?, appHangBacktraceEnabled: Bool = true) {
         self.reporter = reporter
         self.appHangBacktraceEnabled = appHangBacktraceEnabled
     }

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
@@ -12,67 +12,11 @@ internal final class BacktraceReportingFeature: DatadogFeature {
     let messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
 
     /// A type capable of generating backtrace reports.
-    ///
-    /// It is `nil` when Crash Reporting was enabled with a custom plugin that provides no backtrace reporter. The
-    /// Feature is still registered in that case, so that `appHangBacktraceEnabled` is recorded and backtrace
-    /// generation stays distinguishable from Crash Reporting never having been enabled.
-    ///
-    /// Only `adoptReporterIfAbsent(_:)` can change it after initialization. It is read from every thread that
-    /// generates a backtrace, hence the lock.
-    @ReadWriteLock
-    private(set) var reporter: BacktraceReporting?
-
-    /// Determines whether backtraces may be generated for App Hangs detected by RUM.
-    ///
-    /// It only gates the App Hangs consumer. All other consumers of `reporter` (crash reports, binary images
-    /// attached to logs and RUM view events, the public `backtraceReporter` API) are unaffected by this value.
-    ///
-    /// Only `disableAppHangBacktrace()` can change it after initialization. It is read from the App Hangs watchdog
-    /// thread, hence the lock.
-    @ReadWriteLock
-    private(set) var appHangBacktraceEnabled: Bool
+    let reporter: BacktraceReporting
 
     /// Creates `BacktraceReportingFeature`.
-    /// - Parameters:
-    ///   - reporter: An external implementation of a type capable of generating backtrace reports, if any.
-    ///   - appHangBacktraceEnabled: Whether backtraces may be generated for App Hangs. Default: `true`.
-    init(reporter: BacktraceReporting?, appHangBacktraceEnabled: Bool = true) {
+    /// - Parameter reporter: An external implementation of a type capable of generating backtrace reports.
+    init(reporter: BacktraceReporting) {
         self.reporter = reporter
-        self.appHangBacktraceEnabled = appHangBacktraceEnabled
-    }
-
-    /// Installs `reporter` if this Feature does not have one yet.
-    ///
-    /// A Feature registered only to record an App Hang opt-out carries no reporter, yet it occupies the single
-    /// registration slot. Without adoption, a reporter offered afterwards would be dropped by the "already
-    /// registered" rule and crash reports, binary images on logs and RUM view events, and the public
-    /// `backtraceReporter` API would stay unavailable for the rest of the process — none of which the App Hang
-    /// opt-out promises to affect.
-    ///
-    /// - Parameter reporter: The reporter to install.
-    /// - Returns: `true` if it was installed, `false` if one was already present and has been kept.
-    func adoptReporterIfAbsent(_ reporter: BacktraceReporting) -> Bool {
-        var adopted = false
-        _reporter.mutate { current in
-            guard current == nil else {
-                return // the first reporter wins
-            }
-            current = reporter
-            adopted = true
-        }
-        return adopted
-    }
-
-    /// Turns off backtrace generation for App Hangs.
-    ///
-    /// Needed because only the first registration installs its `reporter`, while an opt-out arriving with a later one
-    /// must still take effect — otherwise an app that registered a backtrace reporter before enabling Crash Reporting
-    /// would keep snapshotting all threads after explicitly asking it not to.
-    ///
-    /// Turning it back on is deliberately not offered: `register(backtraceReporter:)` passes `true` as a compatibility
-    /// default rather than as an explicit request, so honouring it would silently revert an opt-out. Opting out is
-    /// therefore one-way, which also makes the outcome independent of registration order.
-    func disableAppHangBacktrace() {
-        _appHangBacktraceEnabled.mutate { $0 = false }
     }
 }

--- a/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
+++ b/DatadogInternal/Sources/BacktraceReporting/BacktraceReportingFeature.swift
@@ -16,7 +16,11 @@ internal final class BacktraceReportingFeature: DatadogFeature {
     /// It is `nil` when Crash Reporting was enabled with a custom plugin that provides no backtrace reporter. The
     /// Feature is still registered in that case, so that `appHangBacktraceEnabled` is recorded and backtrace
     /// generation stays distinguishable from Crash Reporting never having been enabled.
-    let reporter: BacktraceReporting?
+    ///
+    /// Only `adoptReporterIfAbsent(_:)` can change it after initialization. It is read from every thread that
+    /// generates a backtrace, hence the lock.
+    @ReadWriteLock
+    private(set) var reporter: BacktraceReporting?
 
     /// Determines whether backtraces may be generated for App Hangs detected by RUM.
     ///
@@ -35,6 +39,28 @@ internal final class BacktraceReportingFeature: DatadogFeature {
     init(reporter: BacktraceReporting?, appHangBacktraceEnabled: Bool = true) {
         self.reporter = reporter
         self.appHangBacktraceEnabled = appHangBacktraceEnabled
+    }
+
+    /// Installs `reporter` if this Feature does not have one yet.
+    ///
+    /// A Feature registered only to record an App Hang opt-out carries no reporter, yet it occupies the single
+    /// registration slot. Without adoption, a reporter offered afterwards would be dropped by the "already
+    /// registered" rule and crash reports, binary images on logs and RUM view events, and the public
+    /// `backtraceReporter` API would stay unavailable for the rest of the process — none of which the App Hang
+    /// opt-out promises to affect.
+    ///
+    /// - Parameter reporter: The reporter to install.
+    /// - Returns: `true` if it was installed, `false` if one was already present and has been kept.
+    func adoptReporterIfAbsent(_ reporter: BacktraceReporting) -> Bool {
+        var adopted = false
+        _reporter.mutate { current in
+            guard current == nil else {
+                return // the first reporter wins
+            }
+            current = reporter
+            adopted = true
+        }
+        return adopted
     }
 
     /// Turns off backtrace generation for App Hangs.

--- a/DatadogInternal/Sources/Feature.swift
+++ b/DatadogInternal/Sources/Feature.swift
@@ -7,6 +7,8 @@
 import Foundation
 
 public enum Feature {
+    public static let crashReporting = "crash-reporter"
+
     public static let networkInstrumentation = "network-instrumentation"
 
     public static let rum = "rum"

--- a/DatadogInternal/Sources/Models/CrashReporting/CrashReportingConfiguration.swift
+++ b/DatadogInternal/Sources/Models/CrashReporting/CrashReportingConfiguration.swift
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// The Crash Reporting shared configuration.
+///
+/// The Feature object named `crash-reporter` will be registered to the core
+/// when enabling Crash Reporting. If available, the configuration can be retrieved
+/// with:
+///
+///     let crashReporting = core.feature(
+///         named: Feature.crashReporting,
+///         type: CrashReportingConfiguration.self
+///     )
+///
+/// A `nil` result means Crash Reporting was never enabled, which is distinct from it being enabled with a
+/// capability turned off. Read it at the moment the capability is needed, as Crash Reporting may be enabled
+/// after the Feature doing the reading.
+public protocol CrashReportingConfiguration {
+    /// Determines whether backtraces may be generated for App Hangs detected by RUM.
+    ///
+    /// It only gates the App Hangs consumer. Crash reports, binary images attached to logs and RUM view events,
+    /// and the public `backtraceReporter` API are unaffected by this value.
+    ///
+    /// When this configuration is absent, read it as `true`: backtrace generation is then *unavailable* (Crash
+    /// Reporting was never enabled) rather than *disabled*, and consumers report the two differently.
+    ///
+    /// It is read from arbitrary threads - the App Hangs watchdog reads it while the main thread is blocked - so
+    /// conforming types must make it safe to read concurrently. Backing it with an immutable value is enough.
+    var appHangBacktraceEnabled: Bool { get }
+}
+
+extension DatadogFeature where Self: CrashReportingConfiguration {
+    public static var name: String { Feature.crashReporting }
+}

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -314,7 +314,7 @@ Event mappers allow modifying or dropping events before upload:
 
 ## Feature Interactions
 
-- **Crash Reporting**: Enhances App Hang monitoring with stack traces
+- **Crash Reporting**: Enhances App Hang monitoring with stack traces. Set `CrashReporting.Configuration.appHangBacktraceEnabled` to `false` to keep crash reports but drop App Hang stack traces
 - **Tracing**: Network resources can create distributed traces via `firstPartyHostsTracing`
 - **Session Replay**: RUM must be enabled for Session Replay to work
 - **WebView Tracking**: Enables RUM tracking in web views. Requires:

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -250,7 +250,7 @@ Requires configuration to be set, otherwise disabled by default:
 
 ### Performance Monitoring
 - **Long tasks**: `longTaskThreshold` (default: 0.1s)
-- **App hangs**: `appHangThreshold` (default: nil/disabled)
+- **App hangs**: `appHangThreshold` (default: nil/disabled) — stack traces require Crash Reporting, and can be opted out of with `CrashReporting.Configuration.appHangBacktraceEnabled`
 - **Vitals**: `vitalsUpdateFrequency` (default: .average)
 - **Slow frames**: `trackSlowFrames` (default: true) — captures view hitches and attaches them to the corresponding RUM view
 

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -1,7 +1,7 @@
 ---
-last_updated: 2026-08-19
+last_updated: 2026-08-26
 sdk_version: 3.16.0
-verified_against_commit: fee1ac701
+verified_against_commit: 5d65cab08
 tracked_files:
   - DatadogRUM/Sources/RUM.swift
   - DatadogRUM/Sources/RUMConfiguration.swift

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -243,6 +243,14 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         firstFrameReader.publish(to: monitor)
         dependencies.renderLoopObserver?.register(firstFrameReader)
 
+        // Resolved on each hang rather than captured here, as Crash Reporting - which owns this setting - can be
+        // enabled after RUM. A missing Crash Reporting Feature means backtrace generation is *unavailable* rather
+        // than *disabled*, which the App Hangs monitor reports differently, hence the `true` default.
+        let isAppHangBacktraceEnabled: @Sendable () -> Bool = { [weak core] in
+            core?.feature(named: Feature.crashReporting, type: CrashReportingConfiguration.self)?
+                .appHangBacktraceEnabled ?? true
+        }
+
         #if !os(watchOS)
         var memoryWarningMonitor: MemoryWarningMonitor?
         if configuration.trackMemoryWarnings {
@@ -276,8 +284,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             memoryWarningMonitor: memoryWarningMonitor,
             uuidGenerator: configuration.uuidGenerator,
             heatmapIdentifierRegistry: heatmapIdentifierStore,
-            // Read on each hang, as Crash Reporting - which owns this setting - can be enabled after RUM:
-            isAppHangBacktraceEnabled: { [weak core] in core?.isAppHangBacktraceEnabled ?? true }
+            isAppHangBacktraceEnabled: isAppHangBacktraceEnabled
         )
         #else
         self.instrumentation = RUMInstrumentation(
@@ -294,8 +301,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             watchdogTermination: watchdogTermination,
             memoryWarningMonitor: nil,
             uuidGenerator: configuration.uuidGenerator,
-            // Read on each hang, as Crash Reporting - which owns this setting - can be enabled after RUM:
-            isAppHangBacktraceEnabled: { [weak core] in core?.isAppHangBacktraceEnabled ?? true }
+            isAppHangBacktraceEnabled: isAppHangBacktraceEnabled
         )
         #endif
         self.requestBuilder = RequestBuilder(

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -275,7 +275,9 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             watchdogTermination: watchdogTermination,
             memoryWarningMonitor: memoryWarningMonitor,
             uuidGenerator: configuration.uuidGenerator,
-            heatmapIdentifierRegistry: heatmapIdentifierStore
+            heatmapIdentifierRegistry: heatmapIdentifierStore,
+            // Read on each hang, as Crash Reporting - which owns this setting - can be enabled after RUM:
+            isAppHangBacktraceEnabled: { [weak core] in core?.isAppHangBacktraceEnabled ?? true }
         )
         #else
         self.instrumentation = RUMInstrumentation(
@@ -291,7 +293,9 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             bundleType: bundleType,
             watchdogTermination: watchdogTermination,
             memoryWarningMonitor: nil,
-            uuidGenerator: configuration.uuidGenerator
+            uuidGenerator: configuration.uuidGenerator,
+            // Read on each hang, as Crash Reporting - which owns this setting - can be enabled after RUM:
+            isAppHangBacktraceEnabled: { [weak core] in core?.isAppHangBacktraceEnabled ?? true }
         )
         #endif
         self.requestBuilder = RequestBuilder(

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHang.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHang.swift
@@ -19,6 +19,9 @@ internal struct AppHang: Codable {
         /// Indicates that backtrace generation is unavailable.
         /// It is the case when `BacktraceReportingFeature` is not available in core (when Crash Reporting feature was not enabled).
         case notAvailable
+        /// Indicates that backtrace generation was turned off in `CrashReporting.Configuration`.
+        /// Unlike `notAvailable`, Crash Reporting **is** enabled - it was asked not to provide App Hang backtraces.
+        case disabled
     }
 
     /// The date of hang start.

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHang.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHang.swift
@@ -12,7 +12,7 @@ internal struct AppHang: Codable {
     /// The result of generating backtrace for this hang.
     enum BacktraceGenerationResult: Codable {
         /// Indicates that backtrace generation succeeded.
-        /// The associated `BacktraceReport` includes the snapshot of all running threads during the hang.
+        /// The associated `BacktraceReport` includes the snapshot of the main thread during the hang.
         case succeeded(BacktraceReport)
         /// Indicates that backtrace generation failed due to an internal error.
         case failed

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsMonitor.swift
@@ -17,6 +17,8 @@ internal final class AppHangsMonitor {
         static let appHangStackNotAvailableErrorMessage = "Stack trace was not collected because `DatadogCrashReporting` had not been enabled."
         /// The standardized `error.stack` when backtrace generation failed due to an internal error.
         static let appHangStackGenerationFailedErrorMessage = "Failed to collect the stack trace."
+        /// The standardized `error.stack` when backtrace generation was turned off in `CrashReporting.Configuration`.
+        static let appHangStackDisabledErrorMessage = "Stack trace was not collected because backtrace generation for App Hangs was disabled."
     }
 
     /// Watchdog thread that monitors the main queue for App Hangs.
@@ -34,7 +36,8 @@ internal final class AppHangsMonitor {
         fatalErrorContext: FatalErrorContextNotifying,
         dateProvider: DateProvider,
         uuidGenerator: RUMUUIDGenerator,
-        processID: UUID
+        processID: UUID,
+        isAppHangBacktraceEnabled: @escaping @Sendable () -> Bool = { true }
     ) {
         self.init(
             featureScope: featureScope,
@@ -43,7 +46,8 @@ internal final class AppHangsMonitor {
                 queue: observedQueue,
                 dateProvider: dateProvider,
                 backtraceReporter: backtraceReporter,
-                telemetry: featureScope.telemetry
+                telemetry: featureScope.telemetry,
+                isAppHangBacktraceEnabled: isAppHangBacktraceEnabled
             ),
             fatalErrorContext: fatalErrorContext,
             processID: processID,

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
@@ -165,7 +165,7 @@ internal final class AppHangsWatchdogThread: Thread, AppHangsObservingThread {
                 continue // ignore likely false-positive
             }
 
-            // Capture the stack trace of all running threads with promoting the main thread stack.
+            // Capture the stack trace of the main thread.
             guard let backtraceResult = generateBacktrace() else {
                 continue // unexpected
             }
@@ -194,19 +194,21 @@ internal final class AppHangsWatchdogThread: Thread, AppHangsObservingThread {
         }
     }
 
-    /// Generates the backtrace of all running threads, promoting the main thread stack.
+    /// Generates the backtrace of the main thread.
     ///
     /// - Returns: The result of generation or `nil` if the hang must be skipped (main thread ID could not be determined).
     private func generateBacktrace() -> AppHang.BacktraceGenerationResult? {
-        guard isAppHangBacktraceEnabled() else {
-            // Checked before reading `mainThreadID` and before calling the reporter, so no work is done for the
-            // hang and it is still reported when the main thread ID is unknown.
-            return .disabled
-        }
-
+        // Checked first: an unresolved main thread ID means generation was never possible, whatever the setting
+        // says, so it keeps hitting the telemetry error rather than being reported as an opt-out. `.disabled` is
+        // reserved for hangs where generation would otherwise have been attempted.
         guard let mainThreadID = mainThreadID else {
             telemetry.error("Failed to determine main thread ID for backtrace generation")
             return nil // unexpected
+        }
+
+        // Checked before calling the reporter, so no stack is walked or symbolicated for this hang.
+        guard isAppHangBacktraceEnabled() else {
+            return .disabled
         }
 
         do {

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/AppHangsWatchdogThread.swift
@@ -57,6 +57,11 @@ internal final class AppHangsWatchdogThread: Thread, AppHangsObservingThread {
     private let dateProvider: DateProvider
     /// Backtrace reporter for hang's stack trace generation.
     private let backtraceReporter: BacktraceReporting
+    /// Tells whether backtraces may be generated for App Hangs.
+    ///
+    /// It is read on each hang instead of once on initialization, because Crash Reporting - which owns this
+    /// setting - can be enabled after RUM.
+    private let isAppHangBacktraceEnabled: @Sendable () -> Bool
     /// The hang's duration threshold to consider it a false-positive.
     private let falsePositiveThreshold: TimeInterval
     /// An identifier of the main thread required for backtrace generation.
@@ -83,19 +88,22 @@ internal final class AppHangsWatchdogThread: Thread, AppHangsObservingThread {
     ///   - dateProvider: Date provider.
     ///   - backtraceReporter: Backtrace reporter for hang's stack trace generation.
     ///   - telemetry: The handler to report issues through RUM Telemetry.
+    ///   - isAppHangBacktraceEnabled: Tells whether backtraces may be generated for App Hangs. It is queried on each hang.
     init(
         appHangThreshold: TimeInterval,
         queue: DispatchQueue,
         dateProvider: DateProvider,
         backtraceReporter: BacktraceReporting,
         telemetry: Telemetry,
-        falsePositiveThreshold: TimeInterval = Constants.falsePositiveThreshold
+        falsePositiveThreshold: TimeInterval = Constants.falsePositiveThreshold,
+        isAppHangBacktraceEnabled: @escaping @Sendable () -> Bool = { true }
     ) {
         self.appHangThreshold = appHangThreshold
         self.idleInterval = appHangThreshold * Constants.tolerance
         self.mainQueue = queue
         self.dateProvider = dateProvider
         self.backtraceReporter = backtraceReporter
+        self.isAppHangBacktraceEnabled = isAppHangBacktraceEnabled
         self.falsePositiveThreshold = falsePositiveThreshold
         self.telemetry = telemetry
 
@@ -158,22 +166,8 @@ internal final class AppHangsWatchdogThread: Thread, AppHangsObservingThread {
             }
 
             // Capture the stack trace of all running threads with promoting the main thread stack.
-            guard let mainThreadID = mainThreadID else {
-                telemetry.error("Failed to determine main thread ID for backtrace generation")
+            guard let backtraceResult = generateBacktrace() else {
                 continue // unexpected
-            }
-
-            let backtraceResult: AppHang.BacktraceGenerationResult
-            do {
-                if let backtrace = try backtraceReporter.generateBacktrace(threadID: mainThreadID) {
-                    backtraceResult = .succeeded(backtrace)
-                } else {
-                    backtraceResult = .notAvailable
-                }
-            } catch let error {
-                backtraceResult = .failed
-                DD.logger.error("Encountered an error when generating App Hang backtrace", error: error)
-                telemetry.error("Failed to generate App Hang backtrace", error: error)
             }
 
             let hang = AppHang(
@@ -197,6 +191,34 @@ internal final class AppHangsWatchdogThread: Thread, AppHangsObservingThread {
             }
 
             delegate?.hangEnded(hang, duration: hangDuration)
+        }
+    }
+
+    /// Generates the backtrace of all running threads, promoting the main thread stack.
+    ///
+    /// - Returns: The result of generation or `nil` if the hang must be skipped (main thread ID could not be determined).
+    private func generateBacktrace() -> AppHang.BacktraceGenerationResult? {
+        guard isAppHangBacktraceEnabled() else {
+            // Checked before reading `mainThreadID` and before calling the reporter, so no work is done for the
+            // hang and it is still reported when the main thread ID is unknown.
+            return .disabled
+        }
+
+        guard let mainThreadID = mainThreadID else {
+            telemetry.error("Failed to determine main thread ID for backtrace generation")
+            return nil // unexpected
+        }
+
+        do {
+            if let backtrace = try backtraceReporter.generateBacktrace(threadID: mainThreadID) {
+                return .succeeded(backtrace)
+            } else {
+                return .notAvailable
+            }
+        } catch let error {
+            DD.logger.error("Encountered an error when generating App Hang backtrace", error: error)
+            telemetry.error("Failed to generate App Hang backtrace", error: error)
+            return .failed
         }
     }
 

--- a/DatadogRUM/Sources/Instrumentation/AppHangs/NonFatalAppHangsHandler.swift
+++ b/DatadogRUM/Sources/Instrumentation/AppHangs/NonFatalAppHangsHandler.swift
@@ -38,27 +38,28 @@ internal extension AppHang.BacktraceGenerationResult {
         case .succeeded(let backtrace): return backtrace.stack
         case .failed: return AppHangsMonitor.Constants.appHangStackGenerationFailedErrorMessage
         case .notAvailable: return AppHangsMonitor.Constants.appHangStackNotAvailableErrorMessage
+        case .disabled: return AppHangsMonitor.Constants.appHangStackDisabledErrorMessage
         }
     }
 
     var threads: [DDThread]? {
         switch self {
         case .succeeded(let backtrace): return backtrace.threads
-        case .failed, .notAvailable: return nil
+        case .failed, .notAvailable, .disabled: return nil
         }
     }
 
     var binaryImages: [BinaryImage]? {
         switch self {
         case .succeeded(let backtrace): return backtrace.binaryImages
-        case .failed, .notAvailable: return nil
+        case .failed, .notAvailable, .disabled: return nil
         }
     }
 
     var wasTruncated: Bool? {
         switch self {
         case .succeeded(let backtrace): return backtrace.wasTruncated
-        case .failed, .notAvailable: return nil
+        case .failed, .notAvailable, .disabled: return nil
         }
     }
 }

--- a/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMInstrumentation.swift
@@ -76,7 +76,8 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         watchdogTermination: WatchdogTerminationMonitor?,
         memoryWarningMonitor: MemoryWarningMonitor?,
         uuidGenerator: RUMUUIDGenerator,
-        heatmapIdentifierRegistry: any HeatmapIdentifierRegistry
+        heatmapIdentifierRegistry: any HeatmapIdentifierRegistry,
+        isAppHangBacktraceEnabled: @escaping @Sendable () -> Bool = { true }
     ) {
         // Always create views handler (we can't know if it will be used by SwiftUI manual instrumentation)
         // and only activate `UIViewControllerSwizzler` if automatic instrumentation for UIKit or SwiftUI is configured:
@@ -182,7 +183,8 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
             backtraceReporter: backtraceReporter,
             fatalErrorContext: fatalErrorContext,
             processID: processID,
-            uuidGenerator: uuidGenerator
+            uuidGenerator: uuidGenerator,
+            isAppHangBacktraceEnabled: isAppHangBacktraceEnabled
         )
         self.watchdogTermination = watchdogTermination
         self.memoryWarningMonitor = memoryWarningMonitor
@@ -214,7 +216,8 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         bundleType: BundleType,
         watchdogTermination: WatchdogTerminationMonitor?,
         memoryWarningMonitor: MemoryWarningMonitor?,
-        uuidGenerator: RUMUUIDGenerator
+        uuidGenerator: RUMUUIDGenerator,
+        isAppHangBacktraceEnabled: @escaping @Sendable () -> Bool = { true }
     ) {
         // Always create views handler (we can't know if it will be used by manual instrumentation)
         self.viewsHandler = RUMViewsHandler(dateProvider: dateProvider, notificationCenter: notificationCenter)
@@ -230,7 +233,8 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
             backtraceReporter: backtraceReporter,
             fatalErrorContext: fatalErrorContext,
             processID: processID,
-            uuidGenerator: uuidGenerator
+            uuidGenerator: uuidGenerator,
+            isAppHangBacktraceEnabled: isAppHangBacktraceEnabled
         )
         self.watchdogTermination = watchdogTermination
         self.memoryWarningMonitor = memoryWarningMonitor
@@ -297,7 +301,8 @@ private extension AppHangsMonitor {
         backtraceReporter: BacktraceReporting,
         fatalErrorContext: FatalErrorContextNotifying,
         processID: UUID,
-        uuidGenerator: RUMUUIDGenerator
+        uuidGenerator: RUMUUIDGenerator,
+        isAppHangBacktraceEnabled: @escaping @Sendable () -> Bool
     ) {
         guard bundleType == .iOSApp, var appHangThreshold = appHangThreshold else {
             return nil
@@ -316,7 +321,8 @@ private extension AppHangsMonitor {
             fatalErrorContext: fatalErrorContext,
             dateProvider: dateProvider,
             uuidGenerator: uuidGenerator,
-            processID: processID
+            processID: processID,
+            isAppHangBacktraceEnabled: isAppHangBacktraceEnabled
         )
     }
 }

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -190,6 +190,7 @@ extension RUM {
         ///         some hangs lasting very close to this threshold may not be reported.
         ///
         /// - Note: App Hangs monitoring requires Datadog Crash Reporting to be enabled. Otherwise stack trace will be not reported in App Hang errors.
+        ///         Stack traces can also be opted out of while keeping Crash Reporting enabled, with `CrashReporting.Configuration.appHangBacktraceEnabled`.
         ///
         /// - Default: `nil` (hangs monitoring disabled).
         public var appHangThreshold: TimeInterval?

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
@@ -87,6 +87,15 @@ class AppHangsMonitorTests: XCTestCase {
         XCTAssertEqual(command.isStackTraceTruncated, hang.backtraceResult.wasTruncated)
     }
 
+    func testDisabledAndNotAvailableStackMessagesAreDistinct() {
+        // Each message is otherwise only asserted against its own constant, so copy-pasting them equal would keep
+        // every test green while silently collapsing "Crash Reporting opted out" into "Crash Reporting never enabled".
+        XCTAssertNotEqual(
+            AppHangsMonitor.Constants.appHangStackDisabledErrorMessage,
+            AppHangsMonitor.Constants.appHangStackNotAvailableErrorMessage
+        )
+    }
+
     func testWhenAppHangEndsWithBacktraceGenerationDisabled_itSendsAppHangCommandWithNoStackTrace() throws {
         // Given
         let subscriber = RUMCommandSubscriberMock()

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsMonitorTests.swift
@@ -87,6 +87,27 @@ class AppHangsMonitorTests: XCTestCase {
         XCTAssertEqual(command.isStackTraceTruncated, hang.backtraceResult.wasTruncated)
     }
 
+    func testWhenAppHangEndsWithBacktraceGenerationDisabled_itSendsAppHangCommandWithNoStackTrace() throws {
+        // Given
+        let subscriber = RUMCommandSubscriberMock()
+        monitor.nonFatalHangsHandler.publish(to: subscriber)
+        monitor.start()
+        defer { monitor.stop() }
+
+        // When
+        let hang: AppHang = .mockWith(backtraceResult: .disabled)
+        watchdogThread.delegate?.hangEnded(hang, duration: .mockRandom(min: 1, max: 4))
+
+        // Then
+        let command = try XCTUnwrap(subscriber.lastReceivedCommand as? RUMAddCurrentViewAppHangCommand)
+        XCTAssertEqual(command.message, AppHangsMonitor.Constants.appHangErrorMessage)
+        XCTAssertEqual(command.type, AppHangsMonitor.Constants.appHangErrorType)
+        XCTAssertEqual(command.stack, AppHangsMonitor.Constants.appHangStackDisabledErrorMessage)
+        XCTAssertNil(command.threads)
+        XCTAssertNil(command.binaryImages)
+        XCTAssertNil(command.isStackTraceTruncated)
+    }
+
     // MARK: - Fatal App Hangs Monitoring
 
     func testGivenFatalErrorViewContextAvailable_whenAppHangStarts_itSavesPendingAppHangToDataStore() throws {

--- a/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsWatchdogThreadTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/AppHangs/AppHangsWatchdogThreadTests.swift
@@ -212,6 +212,81 @@ class AppHangsWatchdogThreadTests: XCTestCase {
         watchdogThread.cancel()
     }
 
+    func testWhenBacktraceGenerationIsDisabled_itTracksAppHangWithErrorMessageAndDoesNotGenerateBacktrace() {
+        let trackHangStart = expectation(description: "track start of App Hang")
+        let trackHangEnd = expectation(description: "track end of App Hang")
+
+        // Given
+        let appHangThreshold: TimeInterval = 0.25
+        let hangDuration: TimeInterval = appHangThreshold * 2
+        let queue = DispatchQueue(label: "main-queue", qos: .userInteractive)
+        let backtraceReporter = BacktraceReporterMock(backtrace: .mockWith(stack: "Main thread stack"))
+
+        let watchdogThread = AppHangsWatchdogThread(
+            appHangThreshold: appHangThreshold,
+            queue: queue,
+            dateProvider: DateProviderMock(now: .mockDecember15th2019At10AMUTC()),
+            backtraceReporter: backtraceReporter,
+            telemetry: TelemetryMock(),
+            isAppHangBacktraceEnabled: { false } // backtrace generation disabled
+        )
+        delegate.onHangStarted = { hang in
+            XCTAssertEqual(hang.backtraceResult.stack, AppHangsMonitor.Constants.appHangStackDisabledErrorMessage)
+            trackHangStart.fulfill()
+        }
+        delegate.onHangEnded = { hang, _ in
+            XCTAssertEqual(hang.backtraceResult.stack, AppHangsMonitor.Constants.appHangStackDisabledErrorMessage)
+            trackHangEnd.fulfill()
+        }
+        delegate.onHangCancelled = { _ in XCTFail("It should not cancel the hang") }
+        watchdogThread.start(with: delegate)
+
+        // When
+        queue.async {
+            Thread.sleep(forTimeInterval: hangDuration)
+        }
+
+        // Then
+        waitForExpectations(timeout: hangDuration * 10)
+        watchdogThread.cancel()
+        XCTAssertEqual(backtraceReporter.generateBacktraceCallsCount, 0, "It must not pay the cost of backtrace generation")
+    }
+
+    func testWhenBacktraceGenerationIsEnabled_itGeneratesBacktrace() {
+        let trackHangEnd = expectation(description: "track end of App Hang")
+
+        // Given
+        let appHangThreshold: TimeInterval = 0.25
+        let hangDuration: TimeInterval = appHangThreshold * 2
+        let queue = DispatchQueue(label: "main-queue", qos: .userInteractive)
+        let backtraceReporter = BacktraceReporterMock(backtrace: .mockWith(stack: "Main thread stack"))
+
+        let watchdogThread = AppHangsWatchdogThread(
+            appHangThreshold: appHangThreshold,
+            queue: queue,
+            dateProvider: DateProviderMock(now: .mockDecember15th2019At10AMUTC()),
+            backtraceReporter: backtraceReporter,
+            telemetry: TelemetryMock(),
+            isAppHangBacktraceEnabled: { true }
+        )
+        delegate.onHangEnded = { hang, _ in
+            XCTAssertEqual(hang.backtraceResult.stack, "Main thread stack")
+            trackHangEnd.fulfill()
+        }
+        delegate.onHangCancelled = { _ in XCTFail("It should not cancel the hang") }
+        watchdogThread.start(with: delegate)
+
+        // When
+        queue.async {
+            Thread.sleep(forTimeInterval: hangDuration)
+        }
+
+        // Then
+        waitForExpectations(timeout: hangDuration * 10)
+        watchdogThread.cancel()
+        XCTAssertGreaterThan(backtraceReporter.generateBacktraceCallsCount, 0)
+    }
+
     func testWhenHangDurationExceedsFalsePositiveThreshold_itReportsHangCancellation() {
         let trackHangStart = expectation(description: "track start of App Hang")
         let trackHangCancel = expectation(description: "track cancellation of App Hang")

--- a/TestUtilities/Sources/Mocks/CrashReporting/BacktraceReportingMocks.swift
+++ b/TestUtilities/Sources/Mocks/CrashReporting/BacktraceReportingMocks.swift
@@ -38,7 +38,9 @@ public struct BacktraceReporterMock: BacktraceReporting, @unchecked Sendable {
     }
 
     public func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport? {
-        generateBacktraceCallsCount += 1
+        // `+=` through the wrapper would take the read and the write lock separately, losing increments under
+        // concurrent calls. `mutate` acquires the write lock once.
+        _generateBacktraceCallsCount.mutate { $0 += 1 }
         try throwIfNeeded()
         return backtrace
     }

--- a/TestUtilities/Sources/Mocks/CrashReporting/BacktraceReportingMocks.swift
+++ b/TestUtilities/Sources/Mocks/CrashReporting/BacktraceReportingMocks.swift
@@ -17,6 +17,9 @@ public struct BacktraceReporterMock: BacktraceReporting, @unchecked Sendable {
     /// The binary images returned by this mock. If not set, binary images are derived from `backtrace`.
     @ReadWriteLock
     public var binaryImagesList: [BinaryImage]?
+    /// The number of times `generateBacktrace(threadID:)` was called on this mock.
+    @ReadWriteLock
+    public var generateBacktraceCallsCount: Int
 
     /// Creates backtrace reporter mock.
     /// - Parameters:
@@ -31,9 +34,11 @@ public struct BacktraceReporterMock: BacktraceReporting, @unchecked Sendable {
         self.backtrace = backtrace
         self.backtraceGenerationError = backtraceGenerationError
         self.binaryImagesList = binaryImages
+        self.generateBacktraceCallsCount = 0
     }
 
     public func generateBacktrace(threadID: ThreadID) throws -> BacktraceReport? {
+        generateBacktraceCallsCount += 1
         try throwIfNeeded()
         return backtrace
     }

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -1709,7 +1709,8 @@ extension AppHang.BacktraceGenerationResult: AnyMockable, RandomMockable {
         return [
             .succeeded(.mockRandom()),
             .failed,
-            .notAvailable
+            .notAvailable,
+            .disabled
         ].randomElement()!
     }
 }

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -583,9 +583,16 @@ public enum PerformanceMetric
 # ----------------------------------
 
 public final class CrashReporting
+    public struct Configuration
+        public var appHangBacktraceEnabled: Bool
+        public init(appHangBacktraceEnabled: Bool = true)
     public static func enable(in core: DatadogCoreProtocol = CoreRegistry.default)
-    public static func enable(with plugin: @autoclosure () throws -> CrashReportingPlugin, in core: DatadogCoreProtocol = CoreRegistry.default)
+    public static func enable(with configuration: Configuration, in core: DatadogCoreProtocol = CoreRegistry.default)
+    public static func enable(with plugin: @autoclosure () throws -> CrashReportingPlugin,configuration: Configuration = .init(),in core: DatadogCoreProtocol = CoreRegistry.default)
 public static func enable()
+public static func enable(with configuration: objc_CrashReportingConfiguration)
+public var appHangBacktraceEnabled: Bool
+override public init()
 public protocol CrashReportingPlugin: AnyObject
     func readPendingCrashReport(completion: @escaping (DDCrashReport?) -> Bool)
     func inject(context: Data)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -588,7 +588,8 @@ public final class CrashReporting
         public init(appHangBacktraceEnabled: Bool = true)
     public static func enable(in core: DatadogCoreProtocol = CoreRegistry.default)
     public static func enable(with configuration: Configuration, in core: DatadogCoreProtocol = CoreRegistry.default)
-    public static func enable(with plugin: @autoclosure () throws -> CrashReportingPlugin,configuration: Configuration = .init(),in core: DatadogCoreProtocol = CoreRegistry.default)
+    public static func enable(with plugin: @autoclosure () throws -> CrashReportingPlugin, in core: DatadogCoreProtocol = CoreRegistry.default)
+    public static func enable(with plugin: @autoclosure () throws -> CrashReportingPlugin,configuration: Configuration,in core: DatadogCoreProtocol = CoreRegistry.default)
 public static func enable()
 public static func enable(with configuration: objc_CrashReportingConfiguration)
 public var appHangBacktraceEnabled: Bool


### PR DESCRIPTION
### What and why?

Until now, the only way to stop generating stack traces for App Hangs was to not link `DatadogCrashReporting` at all — which also gave up crash reports. `CrashReporting.enable(in:)` is what registers `BacktraceReportingFeature` in core, and `AppHangsWatchdogThread` calls into it unconditionally, so there was no supported way to have both real crash reports **and** App Hang errors without stack traces.

Two customer motivations:

1. **Performance.** Generating the backtrace snapshots all running threads *while the main thread is still blocked*, so its cost is added to the very hang being measured. `RUM.Configuration.appHangThreshold` supports sub-second values (minimum `0.1s`), so this cost can be a meaningful fraction of the reported hang duration. Apps tuned to a small threshold may not want to pay it.
2. **Privacy / policy.** Some apps are not permitted to collect thread stacks but still want crash reports and hang *counts*.

This is an iOS-specific gap. For context on why no equivalent flag is being added elsewhere: on Android, ANR backtraces are self-contained in the RUM module (`Thread.getAllStackTraces()` in the ANR detector, and `ApplicationExitInfo` for fatal ANRs) and never depend on a separate crash-reporting module being installed, so the coupling does not exist there. Android's ANR threshold is also a fixed 5000ms, which makes the same backtrace cost negligible — whereas iOS explicitly supports sub-second thresholds. Wrappers (React Native / Flutter / KMP / Unity) call `CrashReporting.enable(in:)` and so keep the default; surfacing the option per-wrapper is separate, opt-in work.

`CHANGELOG.md` has a `[FEATURE]` entry under `# Unreleased`.

### How?

The new option lives on **Crash Reporting**, not `RUM.Configuration`, because backtrace generation is a Crash Reporting capability — RUM only consumes it. `RUM.Configuration.appHangThreshold` stays purely about detection.

```swift
// Crash reports: yes. App Hang stack traces: no.
CrashReporting.enable(with: .init(appHangBacktraceEnabled: false))
```

The flag travels through `DatadogInternal`, since `DatadogCrashReporting` and `DatadogRUM` must not import each other:

```
CrashReporting.Configuration.appHangBacktraceEnabled
  → core.register(backtraceReporter:appHangBacktraceEnabled:)   [DatadogInternal]
  → BacktraceReportingFeature.appHangBacktraceEnabled           [DatadogInternal]
  → core.isAppHangBacktraceEnabled  (lazy, order-independent)
  → AppHangsWatchdogThread.isAppHangBacktraceEnabled: () -> Bool [DatadogRUM]
  → AppHang.BacktraceGenerationResult.disabled
```

#### Every API change is purely additive

No existing declaration gained a defaulted parameter, because that changes the compound name and the mangled symbol even though ordinary call sites keep compiling. `CrashReporting.enable(in:)` and `core.register(backtraceReporter:)` are kept as their own declarations, and the new forms are overloads next to them:

| Existing, unchanged | Added |
|---|---|
| `CrashReporting.enable(in:)` | `CrashReporting.enable(with:in:)` |
| `CrashReporting.enable(with:in:)` *(plugin)* | `CrashReporting.enable(with:configuration:in:)` *(plugin)* |
| `core.register(backtraceReporter:)` | `core.register(backtraceReporter:appHangBacktraceEnabled:)` |
| — | `core.register(appHangBacktraceEnabled:)`, `core.isAppHangBacktraceEnabled` |

Keeping `enable(in:)` separate is also required rather than merely preferred: a default value on `configuration` would make the existing `CrashReporting.enable()` call ambiguous.

Note for future changes in this area: `make api-surface-verify` would not have caught a symbol change in `DatadogInternal`, because that module is not in `DATADOG_MODULES` (`Makefile:414`) and so none of its public surface is tracked in `api-surface-swift`. The additions above were kept additive by hand. The flip side is that they do not widen the customer-facing API surface either.

#### Notable points

- **`BacktraceReportingFeature` is still registered when the flag is `false`.** That feature is shared by crash reports, `error.binary_images` on RUM view events, `binaryImages` on error logs, and the public `core.backtraceReporter` API — so the flag cannot be implemented by skipping registration. Only the App Hangs watchdog path is gated.
- **The registration slot is single, and the default path never claims it.** Both `register(backtraceReporter:…)` and `register(appHangBacktraceEnabled:)` no-op when a `BacktraceReportingFeature` is already registered. So the reporter-less `register(appHangBacktraceEnabled:)` is called **only** when a custom plugin provides no backtrace reporter *and* the app opted out — the one case where there is a policy worth recording. With the default, nothing extra is registered and a reporter registered later still installs, exactly as on `develop`.
- **Resolved lazily, per hang**, not captured when `AppHangsMonitor` is constructed, so `CrashReporting.enable` may be called before *or* after `RUM.enable`. A `@Sendable () -> Bool` closure is injected into the watchdog thread (defaulting to `{ true }`), keeping the hot loop free of feature lookups it does not own and the unit under test injectable.
- **"Disabled" and "unavailable" are deliberately distinct states.** Reporting "`DatadogCrashReporting` had not been enabled" to someone who *did* enable it and opted out of hang backtraces would be misleading, so `.disabled` carries its own `error.stack` message. Never enabling Crash Reporting still yields the pre-existing message.
- **`AppHang.BacktraceGenerationResult` gains a case.** It is `Codable` and fatal hangs are persisted at hang start and replayed on next launch; existing cases keep their synthesized keys, so hangs persisted by an earlier SDK version still decode.
- **Behavior change, deliberate:** previously, if the watchdog could not resolve the main thread's `ThreadID` it reported telemetry and dropped the hang entirely. With backtraces disabled the thread ID is not needed, so the hang is now reported instead of dropped.

No default behavior changes — an app that does not touch the new option behaves exactly as before.

Resulting App Hang error fields:

| Crash Reporting state | `error.stack` | `threads` / `binary_images` / `was_truncated` |
|---|---|---|
| Enabled, default, generation succeeds | real stack | populated |
| Enabled, `appHangBacktraceEnabled: false` | "Stack trace was not collected because backtrace generation for App Hangs was disabled." | `nil` |
| Enabled, generation throws | "Failed to collect the stack trace." | `nil` |
| Not enabled | "Stack trace was not collected because `DatadogCrashReporting` had not been enabled." | `nil` |

The last two rows are pre-existing and covered by untouched tests.

**Example app.** It never set `appHangThreshold`, so App Hangs were not detected there at all and the flag had no reachable effect. The second commit sets a `0.5s` threshold and adds an "App Hang" section to the Crash Reporting debug screen with a "Hang main thread for 2s" button. The flag is fixed at `CrashReporting.enable` time so it cannot be a runtime toggle — it reads a `DD_DISABLE_APP_HANG_BACKTRACES` launch argument instead, matching the existing `Environment.Argument` pattern, and a label shows which state is active.

**Feature docs.** `DatadogRUM/RUM_FEATURE.md` is re-verified in its own commit: `DatadogRUM/Sources/RUMConfiguration.swift` is one of its `tracked_files` and this branch amends the `appHangThreshold` doc-comment, so `make feature-docs-verify` failed until the App Hangs entries and the frontmatter baseline were updated.

### How to validate

```bash
make dependencies && make repo-setup
make test-ios SCHEME="DatadogRUM"
make test-ios SCHEME="DatadogCrashReporting"
make test-ios SCHEME="DatadogCore"              # ObjC API tests
make test-ios SCHEME="DatadogIntegrationTests"
make api-surface-verify
make feature-docs-verify
./tools/lint/run-linter.sh
```

All green locally with this branch rebased onto `develop`: `DatadogRUM` 777 tests, `DatadogCrashReporting` 64 (1 pre-existing skip), `DatadogCore` 764, `DatadogIntegrationTests` 211 — 0 failures; linter 0 violations in 677 files; api-surface (Swift + ObjC) up to date, delta vs `develop` is 8 insertions and 0 deletions; all 5 `*_FEATURE.md` docs verified.

Twelve added tests, each confirmed passing by name:

| Test | Covers |
|---|---|
| `AppHangsWatchdogThreadTests.testWhenBacktraceGenerationIsDisabled_itTracksAppHangWithErrorMessageAndDoesNotGenerateBacktrace` | Disabled ⇒ disabled message, and the reporter is **never invoked** — proves the cost is avoided, not just the result discarded |
| `AppHangsWatchdogThreadTests.testWhenBacktraceGenerationIsEnabled_itGeneratesBacktrace` | Regression guard on the default path |
| `AppHangsMonitorTests.testWhenAppHangEndsWithBacktraceGenerationDisabled_itSendsAppHangCommandWithNoStackTrace` | `.disabled` ⇒ disabled message + `nil` threads / images / truncation |
| `CrashReportingFeatureTests.testByDefault_itRegistersBacktraceReporterWithAppHangBacktracesEnabled` | Default registers with the flag on |
| `CrashReportingFeatureTests.testWhenAppHangBacktracesAreDisabled_itStillRegistersBacktraceReporter` | `false` still registers the feature, with the flag off |
| `CrashReportingFeatureTests.testGivenPluginWithNoBacktraceReporter_whenAppHangBacktracesAreDisabled_itStillRecordsTheOptOut` | Custom plugin with no reporter ⇒ the opt-out is still recorded, so it does not read as "never enabled" |
| `CrashReportingFeatureTests.testGivenPluginWithNoBacktraceReporter_whenAppHangBacktracesAreEnabled_itLeavesRegistrationOpenForALaterReporter` | The default path must **not** claim the single registration slot, otherwise a reporter registered later is silently dropped |
| `CrashReportingFeatureTests.testWhenEnablingWithPluginThroughThePublicAPI_itForwardsTheConfiguration` | The public overload forwards its `configuration` rather than a default-constructed one |
| `GeneratingBacktraceTests.testGivenAppHangBacktracesDisabled_whenGeneratingBacktrace_itStillGeneratesIt` | `core.backtraceReporter` unaffected |
| `GeneratingBacktraceTests.testGivenCrashReportingNotEnabled_thenAppHangBacktracesAreNotDisabled` | unavailable ≠ disabled |
| `AppHangsMonitoringTests.testGivenAppHangBacktracesDisabledInCrashReporting_whenRUMIsEnabledFirst_itTracksAppHangWithNoStackTrace` | End-to-end through `AppRunner`, Crash Reporting enabled **after** RUM — the order that proves the per-hang read |
| `AppHangsMonitoringTests.testGivenAppHangBacktracesDisabledInCrashReporting_whenCrashReportingIsEnabledFirst_itTracksAppHangWithNoStackTrace` | Same, with the opposite enablement order |

The two enablement orders are separate tests rather than one randomized case: only the RUM-first order proves the opt-out is read per hang instead of captured when RUM is enabled, so randomizing would let that regression pass roughly half of CI runs.

`DDConfiguration+apiTests.m` also gained assertions on the `DDCrashReporterConfiguration` default value and setter write-through, and `TestUtilities`' `BacktraceReporterMock` gained a generation counter so "never invoked" is assertable.

Manual check in the Example app: *Debug Crash Reporting with RUM* → "Hang main thread for 2s", then relaunch with the `DD_DISABLE_APP_HANG_BACKTRACES` launch argument and compare `error.stack` between the two runs.

No Synthetics e2e scenario was added: `E2ETests/` has no App Hangs scenario for *any* App Hang behavior today, its assertions live in server-side monitors rather than in this repo, and deliberately hanging the main thread sits poorly with how those scenarios are driven. The `AppHangsMonitoringTests` cases above are the deepest in-repo coverage.

### Known, out of scope

`objc_CrashReporting` and `objc_CrashReportingConfiguration` live in `DatadogCrashReporting/Sources/CrashReporting.swift` rather than in a `+objc.swift` file. The api-surface generator routes by filename suffix, so this module's Objective-C surface is absent from `api-surface-objc` and its members instead appear un-indented in `api-surface-swift`. That predates this PR; moving the existing type is a separate change.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference — **no JIRA ticket exists for this work; flagging for a reviewer to attach one if required**
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) — `DDCrashReporterConfiguration` + `DDCrashReporter.enableWith:`
- [x] Run `make api-surface` when adding new APIs
