### PR TITLE
RUMS-6217: Avoid repeated data copies when formatting uploads

### DIFF
--- a/DatadogInternal/Sources/Upload/DataFormat.swift
+++ b/DatadogInternal/Sources/Upload/DataFormat.swift
@@ -33,8 +33,12 @@ public struct DataFormat {
     /// - Parameter data: The data sequence.
     /// - Returns: the formatted data.
     public func format(_ data: [Data]) -> Data {
+        let dataSize = data.reduce(0) { $0 + $1.count }
+        let separatorsSize = data.isEmpty ? 0 : data.count - 1
+        let capacity = prefixData.count + dataSize + separatorsSize + suffixData.count
+
         // Append to a single buffer to avoid copying the entire payload for every event.
-        var formattedData = Data()
+        var formattedData = Data(capacity: capacity)
         formattedData.append(prefixData)
 
         for (index, event) in data.enumerated() {

--- a/DatadogInternal/Sources/Upload/DataFormat.swift
+++ b/DatadogInternal/Sources/Upload/DataFormat.swift
@@ -33,13 +33,18 @@ public struct DataFormat {
     /// - Parameter data: The data sequence.
     /// - Returns: the formatted data.
     public func format(_ data: [Data]) -> Data {
-        // add prefix
-        prefixData +
-        // concat data
-        data.reduce(.init()) { $0 + $1 + [separatorByte] }
-        // drop last separator
-        .dropLast() +
-        // add suffix
-        suffixData
+        // Append to a single buffer to avoid copying the entire payload for every event.
+        var formattedData = Data()
+        formattedData.append(prefixData)
+
+        for (index, event) in data.enumerated() {
+            if index > 0 {
+                formattedData.append(separatorByte)
+            }
+            formattedData.append(event)
+        }
+
+        formattedData.append(suffixData)
+        return formattedData
     }
 }

--- a/DatadogInternal/Tests/Upload/DataFormatTests.swift
+++ b/DatadogInternal/Tests/Upload/DataFormatTests.swift
@@ -8,6 +8,35 @@ import XCTest
 @testable import DatadogInternal
 
 final class DataFormatTests: XCTestCase {
+    func testFormatWithNoData() throws {
+        let format = DataFormat(prefix: "prefix", suffix: "suffix", separator: "\n")
+
+        let formatted = format.format([])
+
+        XCTAssertEqual(String(data: formatted, encoding: .utf8), "prefixsuffix")
+    }
+
+    func testFormatWithSingleData() throws {
+        let format = DataFormat(prefix: "prefix", suffix: "suffix", separator: "\n")
+        let event = "abc".data(using: .utf8)!
+
+        let formatted = format.format([event])
+
+        XCTAssertEqual(String(data: formatted, encoding: .utf8), "prefixabcsuffix")
+    }
+
+    func testFormatWithMaximumBatchSize() throws {
+        let format = DataFormat(prefix: "", suffix: "", separator: "\n")
+        let numberOfEvents = 1_000
+        let eventSize = 5 * 1_024
+        let events = Array(repeating: Data(repeating: 0x61, count: eventSize), count: numberOfEvents)
+
+        let formatted = format.format(events)
+
+        let separatorsSize = numberOfEvents - 1
+        XCTAssertEqual(formatted.count, numberOfEvents * eventSize + separatorsSize)
+    }
+
     func testFormat() throws {
         let format = DataFormat(prefix: "prefix", suffix: "suffix", separator: "\n")
         let events = [


### PR DESCRIPTION
### What and why?

This PR fixes a crash caused by excessive memory usage when formatting large upload batches.
Repeated `Data` concatenation copied the accumulated payload for every event, eventually triggering a `SIGTRAP`.

### How?

The payload is built incrementally in a single `Data` buffer, with separators added only between events. This produces the same payload without repeatedly copying the data already formatted.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
