### PR TITLE
RUM-18055 Drop PII fields from timeseries events and nest config under Timeseries

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A0A0A0A0A0A0A0A0A0A00004 /* TimeseriesSessionCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A0A0A0A0A0A0A0A0A00003 /* TimeseriesSessionCollector.swift */; };
 		A0A0A0A0A0A0A0A0A0A00008 /* TimeseriesSessionCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A0A0A0A0A0A0A0A0A00007 /* TimeseriesSessionCollectorTests.swift */; };
+		A0A0A0A0A0A0A0A0A0A0000A /* TimeseriesConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A0A0A0A0A0A0A0A0A00009 /* TimeseriesConfigurationTests.swift */; };
 		05B9B20299CF44BB97F4A7C8 /* HeatmapIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048E335C84F4B41E3ACA3B91 /* HeatmapIdentifierTests.swift */; };
 		0904F9F42EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */; };
 		0904F9F62EE1DA6800ED9A22 /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */; };
@@ -1891,6 +1892,7 @@
 /* Begin PBXFileReference section */
 		A0A0A0A0A0A0A0A0A0A00003 /* TimeseriesSessionCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeseriesSessionCollector.swift; sourceTree = "<group>"; };
 		A0A0A0A0A0A0A0A0A0A00007 /* TimeseriesSessionCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeseriesSessionCollectorTests.swift; sourceTree = "<group>"; };
+		A0A0A0A0A0A0A0A0A0A00009 /* TimeseriesConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeseriesConfigurationTests.swift; sourceTree = "<group>"; };
 		048E335C84F4B41E3ACA3B91 /* HeatmapIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapIdentifierTests.swift; sourceTree = "<group>"; };
 		0904F9F32EE1DA6800ED9A22 /* UIKitExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensionsTests.swift; sourceTree = "<group>"; };
 		093AC3282F56F8AA00267CE1 /* ActiveSpanProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpanProvider.swift; sourceTree = "<group>"; };
@@ -3475,6 +3477,7 @@
 			isa = PBXGroup;
 			children = (
 				A0A0A0A0A0A0A0A0A0A00007 /* TimeseriesSessionCollectorTests.swift */,
+				A0A0A0A0A0A0A0A0A0A00009 /* TimeseriesConfigurationTests.swift */,
 			);
 			path = Timeseries;
 			sourceTree = "<group>";
@@ -9465,6 +9468,7 @@
 			files = (
 				6188697C2A4376F700E8996B /* RUMConfigurationTests.swift in Sources */,
 				A0A0A0A0A0A0A0A0A0A00008 /* TimeseriesSessionCollectorTests.swift in Sources */,
+				A0A0A0A0A0A0A0A0A0A0000A /* TimeseriesConfigurationTests.swift in Sources */,
 				61DCC8472C05CD0000CB59E5 /* SessionEndedMetricControllerTests.swift in Sources */,
 				D29A9FA629DDB483005C54A4 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */,
 				61C4534A2C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift in Sources */,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -139,15 +139,17 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
 
         let sessionSampleRate = configuration.debugSDK ? 100 : configuration.sessionSampleRate
 
-        let timeseriesCollector: TimeseriesCollecting? = configuration.enableTimeseries ? TimeseriesSessionCollector(
-            memoryReader: VitalMemoryReader(),
-            featureScope: featureScope,
-            batchSize: configuration.timeseriesBatchSize,
-            ciTest: ciTest,
-            syntheticsTest: syntheticsTest,
-            sessionSampleRate: Double(sessionSampleRate),
-            now: { configuration.dateProvider.now }
-        ) : nil
+        let timeseriesCollector: TimeseriesCollecting? = configuration.timeseries.map { timeseries in
+            TimeseriesSessionCollector(
+                memoryReader: VitalMemoryReader(),
+                featureScope: featureScope,
+                collectOnly: timeseries.collectOnly.map(Set.init),
+                ciTest: ciTest,
+                syntheticsTest: syntheticsTest,
+                sessionSampleRate: Double(sessionSampleRate),
+                now: { configuration.dateProvider.now }
+            )
+        }
 
         let dependencies = RUMScopeDependencies(
             featureScope: featureScope,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -139,11 +139,20 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
 
         let sessionSampleRate = configuration.debugSDK ? 100 : configuration.sessionSampleRate
 
-        let timeseriesCollector: TimeseriesCollecting? = configuration.timeseries.map { timeseries in
-            TimeseriesSessionCollector(
+        let timeseriesCollector: TimeseriesCollecting? = configuration.timeseries.flatMap { timeseries -> TimeseriesCollecting? in
+            var effectiveCollectOnly = timeseries.collectOnly.map(Set.init)
+#if os(watchOS)
+            // CPU usage is unavailable on watchOS, so a `collectOnly: [.cpu]` config would otherwise
+            // start a collector whose sampling timer runs for the whole session without ever flushing.
+            effectiveCollectOnly = effectiveCollectOnly?.subtracting([.cpu])
+            if effectiveCollectOnly?.isEmpty == true {
+                return nil
+            }
+#endif
+            return TimeseriesSessionCollector(
                 memoryReader: VitalMemoryReader(),
                 featureScope: featureScope,
-                collectOnly: timeseries.collectOnly.map(Set.init),
+                collectOnly: effectiveCollectOnly,
                 ciTest: ciTest,
                 syntheticsTest: syntheticsTest,
                 sessionSampleRate: Double(sessionSampleRate),

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -140,19 +140,21 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         let sessionSampleRate = configuration.debugSDK ? 100 : configuration.sessionSampleRate
 
         let timeseriesCollector: TimeseriesCollecting? = configuration.timeseries.flatMap { timeseries -> TimeseriesCollecting? in
-            var effectiveCollectOnly = timeseries.collectOnly.map(Set.init)
+            var effectiveCollectTypes = timeseries.collectTypes.map(Set.init)
 #if os(watchOS)
-            // CPU usage is unavailable on watchOS, so a `collectOnly: [.cpu]` config would otherwise
+            // CPU usage is unavailable on watchOS, so a `collectTypes: [.cpu]` config would otherwise
             // start a collector whose sampling timer runs for the whole session without ever flushing.
-            effectiveCollectOnly = effectiveCollectOnly?.subtracting([.cpu])
-            if effectiveCollectOnly?.isEmpty == true {
+            effectiveCollectTypes = effectiveCollectTypes?.subtracting([.cpu])
+#endif
+            // An explicit empty selection (or one emptied by the watchOS adjustment above) would still
+            // run the sampling timer for the whole session without ever producing events.
+            guard effectiveCollectTypes?.isEmpty != true else {
                 return nil
             }
-#endif
             return TimeseriesSessionCollector(
                 memoryReader: VitalMemoryReader(),
                 featureScope: featureScope,
-                collectOnly: effectiveCollectOnly,
+                collectTypes: effectiveCollectTypes,
                 ciTest: ciTest,
                 syntheticsTest: syntheticsTest,
                 sessionSampleRate: Double(sessionSampleRate),

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -140,15 +140,11 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         let sessionSampleRate = configuration.debugSDK ? 100 : configuration.sessionSampleRate
 
         let timeseriesCollector: TimeseriesCollecting? = configuration.timeseries.flatMap { timeseries -> TimeseriesCollecting? in
-            var effectiveCollectTypes = timeseries.collectTypes.map(Set.init)
-#if os(watchOS)
-            // CPU usage is unavailable on watchOS, so a `collectTypes: [.cpu]` config would otherwise
-            // start a collector whose sampling timer runs for the whole session without ever flushing.
-            effectiveCollectTypes = effectiveCollectTypes?.subtracting([.cpu])
-#endif
-            // An explicit empty selection (or one emptied by the watchOS adjustment above) would still
-            // run the sampling timer for the whole session without ever producing events.
-            guard effectiveCollectTypes?.isEmpty != true else {
+            let effectiveCollectTypes = timeseries.effectiveCollectTypes
+            // An empty effective selection (explicit `[]`, or emptied by platform availability, e.g.
+            // `collectTypes: [.cpu]` on watchOS) would run the sampling timer for the whole session
+            // without ever producing events, so skip creating the collector entirely.
+            guard !effectiveCollectTypes.isEmpty else {
                 return nil
             }
             return TimeseriesSessionCollector(

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -417,14 +417,14 @@ extension RUM {
         /// Configuration for collecting memory and CPU timeseries during a RUM session.
         @_spi(Experimental)
         public struct Timeseries {
-            /// The specific timeseries metrics to collect.
+            /// The specific timeseries types to collect.
             ///
-            /// Default: `nil` - which means all available timeseries metrics are collected.
+            /// Default: `nil` - which means all available timeseries types are collected.
             public var collectTypes: [TimeseriesType]?
 
             /// Creates a timeseries configuration.
             /// - Parameters:
-            ///   - collectTypes: The specific timeseries metrics to collect. Default: `nil` - all metrics are collected.
+            ///   - collectTypes: The specific timeseries types to collect. Default: `nil` - all types are collected.
             public init(
                 collectTypes: [TimeseriesType]? = nil
             ) {
@@ -432,12 +432,12 @@ extension RUM {
             }
         }
 
-        /// A timeseries metric that can be collected.
+        /// A timeseries type that can be collected.
         @_spi(Experimental)
         public enum TimeseriesType {
             /// Memory footprint and percentage of total device RAM.
             case memory
-            /// CPU usage, as a percentage.
+            /// CPU usage as a percentage.
             case cpu
         }
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -420,21 +420,21 @@ extension RUM {
             /// The specific timeseries metrics to collect.
             ///
             /// Default: `nil` - which means all available timeseries metrics are collected.
-            public var collectOnly: [TimeseriesMetric]?
+            public var collectTypes: [TimeseriesType]?
 
             /// Creates a timeseries configuration.
             /// - Parameters:
-            ///   - collectOnly: The specific timeseries metrics to collect. Default: `nil` - all metrics are collected.
+            ///   - collectTypes: The specific timeseries metrics to collect. Default: `nil` - all metrics are collected.
             public init(
-                collectOnly: [TimeseriesMetric]? = nil
+                collectTypes: [TimeseriesType]? = nil
             ) {
-                self.collectOnly = collectOnly
+                self.collectTypes = collectTypes
             }
         }
 
         /// A timeseries metric that can be collected.
         @_spi(Experimental)
-        public enum TimeseriesMetric {
+        public enum TimeseriesType {
             /// Memory footprint and percentage of total device RAM.
             case memory
             /// CPU usage, as a percentage.

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -434,7 +434,7 @@ extension RUM {
 
         /// A timeseries type that can be collected.
         @_spi(Experimental)
-        public enum TimeseriesType {
+        public enum TimeseriesType: CaseIterable {
             /// Memory footprint and percentage of total device RAM.
             case memory
             /// CPU usage as a percentage.

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -415,6 +415,7 @@ extension RUM {
         }
 
         /// Configuration for collecting memory and CPU timeseries during a RUM session.
+        @_spi(Experimental)
         public struct Timeseries {
             /// The specific timeseries metrics to collect.
             ///
@@ -432,6 +433,7 @@ extension RUM {
         }
 
         /// A timeseries metric that can be collected.
+        @_spi(Experimental)
         public enum TimeseriesMetric {
             /// Memory footprint and percentage of total device RAM.
             case memory

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -572,6 +572,31 @@ extension RUM.Configuration.URLSessionTracking {
     }
 }
 
+extension RUM.Configuration.TimeseriesType {
+    /// The timeseries types available for collection on the current platform.
+    internal static var allAvailableOnCurrentPlatform: Set<Self> {
+#if os(watchOS)
+        // CPU usage is unavailable on watchOS (`TimeseriesSessionCollector.processCPU()` always returns `nil`).
+        return [.memory]
+#else
+        return [.memory, .cpu]
+#endif
+    }
+}
+
+extension RUM.Configuration.Timeseries {
+    /// `collectTypes` filtered down to the types actually available on the current platform.
+    ///
+    /// Empty means timeseries collection should be disabled entirely (e.g. `collectTypes: [.cpu]` on watchOS).
+    internal var effectiveCollectTypes: Set<RUM.Configuration.TimeseriesType> {
+        let available = RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform
+        guard let collectTypes else {
+            return available
+        }
+        return Set(collectTypes).intersection(available)
+    }
+}
+
 extension RUM.Configuration {
     /// Creates RUM configuration.
     /// - Parameters:

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -330,20 +330,12 @@ extension RUM {
 
         /// Enables collection of memory and CPU timeseries events.
         ///
-        /// When enabled, memory footprint and CPU usage are sampled every second and uploaded as
+        /// When set, memory footprint and CPU usage are sampled every second and uploaded as
         /// timeseries events scoped to the RUM session.
         ///
-        /// Default: `false`.
+        /// Default: `nil` - which means timeseries collection is not enabled by default.
         @_spi(Experimental)
-        public var enableTimeseries: Bool
-
-        /// The default number of samples collected before a timeseries batch is flushed.
-        public static let defaultTimeseriesBatchSize = 120
-
-        /// The number of samples collected before a timeseries batch is flushed.
-        ///
-        /// Default: `120`.
-        public var timeseriesBatchSize: Int
+        public var timeseries: Timeseries?
 
         /// Feature flags to preview features in RUM.
         public var featureFlags: FeatureFlags
@@ -420,6 +412,31 @@ extension RUM {
             case average
             /// Every `1000ms`.
             case rare
+        }
+
+        /// Configuration for collecting memory and CPU timeseries during a RUM session.
+        public struct Timeseries {
+            /// The specific timeseries metrics to collect.
+            ///
+            /// Default: `nil` - which means all available timeseries metrics are collected.
+            public var collectOnly: [TimeseriesMetric]?
+
+            /// Creates a timeseries configuration.
+            /// - Parameters:
+            ///   - collectOnly: The specific timeseries metrics to collect. Default: `nil` - all metrics are collected.
+            public init(
+                collectOnly: [TimeseriesMetric]? = nil
+            ) {
+                self.collectOnly = collectOnly
+            }
+        }
+
+        /// A timeseries metric that can be collected.
+        public enum TimeseriesMetric {
+            /// Memory footprint and percentage of total device RAM.
+            case memory
+            /// CPU usage, as a percentage.
+            case cpu
         }
 
         // MARK: - Internal
@@ -585,7 +602,6 @@ extension RUM.Configuration {
     ///   - trackSlowFrames: Enables the collection of slow frames (view hitches). Default: `true`.
     ///   - telemetrySampleRate: The sampling rate for SDK internal telemetry utilized by Datadog. Must be a value between `0` and `100`. Default: `20`.
     ///   - collectAccessibility: Determines whether accessibility data should be collected and included in RUM view events. Default: `false`.
-    ///   - timeseriesBatchSize: The number of samples collected before a timeseries batch is flushed. Default: `120`.
     ///   - featureFlags: Experimental feature flags.
     /// 
     /// - Note: On watchOS, automatic UIKit and SwiftUI view/action tracking is unavailable. The predicate parameters will be ignored.
@@ -621,7 +637,6 @@ extension RUM.Configuration {
         trackSlowFrames: Bool = true,
         telemetrySampleRate: SampleRate = 20,
         collectAccessibility: Bool = false,
-        timeseriesBatchSize: Int = RUM.Configuration.defaultTimeseriesBatchSize,
         featureFlags: FeatureFlags = .defaults
     ) {
         self.applicationID = applicationID
@@ -651,8 +666,7 @@ extension RUM.Configuration {
         self.trackSlowFrames = trackSlowFrames
         self.telemetrySampleRate = telemetrySampleRate
         self.collectAccessibility = collectAccessibility
-        self.enableTimeseries = false
-        self.timeseriesBatchSize = timeseriesBatchSize
+        self.timeseries = nil
         self.featureFlags = featureFlags
     }
     #else
@@ -679,7 +693,6 @@ extension RUM.Configuration {
         trackSlowFrames: Bool = true,
         telemetrySampleRate: SampleRate = 20,
         collectAccessibility: Bool = false,
-        timeseriesBatchSize: Int = RUM.Configuration.defaultTimeseriesBatchSize,
         featureFlags: FeatureFlags = .defaults
     ) {
         self.applicationID = applicationID
@@ -704,8 +717,7 @@ extension RUM.Configuration {
         self.trackSlowFrames = trackSlowFrames
         self.telemetrySampleRate = telemetrySampleRate
         self.collectAccessibility = collectAccessibility
-        self.enableTimeseries = false
-        self.timeseriesBatchSize = timeseriesBatchSize
+        self.timeseries = nil
         self.featureFlags = featureFlags
     }
     #endif

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -80,7 +80,14 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     ) {
         self.memoryReader = memoryReader
         self.batchSize = max(2, batchSize)
+#if os(watchOS)
+        // CPU usage is unavailable on watchOS (`processCPU()` always returns `nil`), so drop `.cpu`
+        // from the effective set to avoid silently accepting a `collectOnly: [.cpu]` config that
+        // would never flush any events.
+        self.collectOnly = collectOnly.map { $0.subtracting([.cpu]) }
+#else
         self.collectOnly = collectOnly
+#endif
         self.samplingInterval = samplingInterval
         self.featureScope = featureScope
         self.totalRAM = totalRAM

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -69,7 +69,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         memoryReader: SamplingBasedVitalReader,
         featureScope: FeatureScope,
         batchSize: Int = 120,
-        collectTypes: Set<RUM.Configuration.TimeseriesType> = RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform,
+        collectTypes: Set<RUM.Configuration.TimeseriesType> = Set(RUM.Configuration.TimeseriesType.allCases),
         samplingInterval: TimeInterval = 1,
         cpuUsageProvider: (() -> Double?)? = nil,
         totalRAM: Double = Double(ProcessInfo.processInfo.physicalMemory),

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -41,7 +41,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private let memoryReader: SamplingBasedVitalReader
     private let cpuUsageProvider: () -> Double?
     private let batchSize: Int
-    private let collectOnly: Set<RUM.Configuration.TimeseriesMetric>?
+    private let collectTypes: Set<RUM.Configuration.TimeseriesType>?
     private let samplingInterval: TimeInterval
     private let featureScope: FeatureScope
     private let totalRAM: Double
@@ -69,7 +69,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         memoryReader: SamplingBasedVitalReader,
         featureScope: FeatureScope,
         batchSize: Int = 120,
-        collectOnly: Set<RUM.Configuration.TimeseriesMetric>? = nil,
+        collectTypes: Set<RUM.Configuration.TimeseriesType>? = nil,
         samplingInterval: TimeInterval = 1,
         cpuUsageProvider: (() -> Double?)? = nil,
         totalRAM: Double = Double(ProcessInfo.processInfo.physicalMemory),
@@ -82,11 +82,11 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         self.batchSize = max(2, batchSize)
 #if os(watchOS)
         // CPU usage is unavailable on watchOS (`processCPU()` always returns `nil`), so drop `.cpu`
-        // from the effective set to avoid silently accepting a `collectOnly: [.cpu]` config that
+        // from the effective set to avoid silently accepting a `collectTypes: [.cpu]` config that
         // would never flush any events.
-        self.collectOnly = collectOnly.map { $0.subtracting([.cpu]) }
+        self.collectTypes = collectTypes.map { $0.subtracting([.cpu]) }
 #else
-        self.collectOnly = collectOnly
+        self.collectTypes = collectTypes
 #endif
         self.samplingInterval = samplingInterval
         self.featureScope = featureScope
@@ -250,7 +250,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
 
         let timestamp = Int64.ddWithNoOverflow(currentDate.timeIntervalSince1970 * 1_000_000_000)
 
-        if collectOnly?.contains(.memory) ?? true, let bytes = memoryReader.readVitalData() {
+        if collectTypes?.contains(.memory) ?? true, let bytes = memoryReader.readVitalData() {
             let footprintKB = bytes / 1_024
             let memoryPercent = totalRAM > 0 ? bytes / totalRAM * 100 : 0
             memoryBuffer.append(MemorySample(timestamp: timestamp, footprintKB: footprintKB, percent: memoryPercent))
@@ -259,7 +259,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             }
         }
 
-        if collectOnly?.contains(.cpu) ?? true, let cpuUsage = cpuUsageProvider() {
+        if collectTypes?.contains(.cpu) ?? true, let cpuUsage = cpuUsageProvider() {
             cpuBuffer.append(CPUSample(timestamp: timestamp, usage: cpuUsage))
             if cpuBuffer.count >= batchSize {
                 flushCPU()

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -30,25 +30,18 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let timestamp: Int64
         let footprintKB: Double
         let percent: Double
-        /// The view active when this sample was collected, if any.
-        let viewID: String?
-        let viewPath: String?
-        let viewName: String?
     }
 
     /// A single CPU sample: usage as a percentage (0.0 to 100.0).
     private struct CPUSample {
         let timestamp: Int64
         let usage: Double
-        /// The view active when this sample was collected, if any.
-        let viewID: String?
-        let viewPath: String?
-        let viewName: String?
     }
 
     private let memoryReader: SamplingBasedVitalReader
     private let cpuUsageProvider: () -> Double?
     private let batchSize: Int
+    private let collectOnly: Set<RUM.Configuration.TimeseriesMetric>?
     private let samplingInterval: TimeInterval
     private let featureScope: FeatureScope
     private let totalRAM: Double
@@ -67,10 +60,6 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private var sessionType: RUMSessionType = .user
     private var timer: DispatchSourceTimer?
     private var isPaused: Bool = false
-    /// The view ID of the samples currently buffered, so a view change can trigger a flush before
-    /// mixing samples from two different views into the same batch. `nil` means either no view was
-    /// active yet, or no sample has been buffered since the last flush.
-    private var currentBatchViewID: String?
     private let now: () -> Date
 
     /// All buffer mutations and timer events run on this queue.
@@ -80,6 +69,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         memoryReader: SamplingBasedVitalReader,
         featureScope: FeatureScope,
         batchSize: Int = 120,
+        collectOnly: Set<RUM.Configuration.TimeseriesMetric>? = nil,
         samplingInterval: TimeInterval = 1,
         cpuUsageProvider: (() -> Double?)? = nil,
         totalRAM: Double = Double(ProcessInfo.processInfo.physicalMemory),
@@ -90,6 +80,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     ) {
         self.memoryReader = memoryReader
         self.batchSize = max(2, batchSize)
+        self.collectOnly = collectOnly
         self.samplingInterval = samplingInterval
         self.featureScope = featureScope
         self.totalRAM = totalRAM
@@ -162,7 +153,6 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.memoryBuffer = []
             self.cpuBuffer = []
             self.isPaused = false
-            self.currentBatchViewID = nil
 
             self.timer?.cancel()
             self.timer = self.makeTimer()
@@ -223,19 +213,6 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         }
     }
 
-    /// Returns the most recently active view among the given samples, searching from the end of the batch
-    /// backwards, or `nil` if no sample in the batch had a view.
-    private static func lastKnownView(
-        in samples: [(viewID: String?, viewPath: String?, viewName: String?)]
-    ) -> (id: String, path: String, name: String?)? {
-        for sample in samples.reversed() {
-            if let id = sample.viewID {
-                return (id: id, path: sample.viewPath ?? "", name: sample.viewName)
-            }
-        }
-        return nil
-    }
-
     private func makeTimer() -> DispatchSourceTimer {
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now() + samplingInterval, repeating: samplingInterval)
@@ -265,40 +242,18 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         }
 
         let timestamp = Int64.ddWithNoOverflow(currentDate.timeIntervalSince1970 * 1_000_000_000)
-        let activeView = activeContextReader?.activeView
-        let viewID = activeView?.id
-        let viewPath = activeView?.path
-        let viewName = activeView?.name
 
-        // Flush before mixing samples from two different views into the same batch, so each batch
-        // (and the RUM view it's attributed to) reflects a single view rather than whichever view
-        // happened to be active at the last sample or at flush time.
-        if viewID != currentBatchViewID {
-            flushMemory()
-            flushCPU()
-        }
-        currentBatchViewID = viewID
-
-        if let bytes = memoryReader.readVitalData() {
+        if collectOnly?.contains(.memory) ?? true, let bytes = memoryReader.readVitalData() {
             let footprintKB = bytes / 1_024
             let memoryPercent = totalRAM > 0 ? bytes / totalRAM * 100 : 0
-            memoryBuffer.append(
-                MemorySample(
-                    timestamp: timestamp,
-                    footprintKB: footprintKB,
-                    percent: memoryPercent,
-                    viewID: viewID,
-                    viewPath: viewPath,
-                    viewName: viewName
-                )
-            )
+            memoryBuffer.append(MemorySample(timestamp: timestamp, footprintKB: footprintKB, percent: memoryPercent))
             if memoryBuffer.count >= batchSize {
                 flushMemory()
             }
         }
 
-        if let cpuUsage = cpuUsageProvider() {
-            cpuBuffer.append(CPUSample(timestamp: timestamp, usage: cpuUsage, viewID: viewID, viewPath: viewPath, viewName: viewName))
+        if collectOnly?.contains(.cpu) ?? true, let cpuUsage = cpuUsageProvider() {
+            cpuBuffer.append(CPUSample(timestamp: timestamp, usage: cpuUsage))
             if cpuBuffer.count >= batchSize {
                 flushCPU()
             }
@@ -316,19 +271,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let sessionType = self.sessionType
         let ciTest = self.ciTest
         let syntheticsTest = self.syntheticsTest
-        let globalAttributes = self.activeContextReader?.globalAttributes ?? [:]
         let sessionSampleRate = self.sessionSampleRate
         let start = batch[0].timestamp
         let end = batch[batch.count - 1].timestamp
         let eventID = UUID().uuidString.lowercased()
-
-        // The batch is attributed to the most recently active view among its samples, not the view active
-        // at flush time — a view ending right before a scheduled flush shouldn't drop data that was
-        // genuinely collected while it was active. `view` is left `nil` if no sample in the batch had one
-        // (e.g. samples collected before the first view starts), rather than dropping the batch.
-        let view = Self.lastKnownView(
-            in: batch.map { (viewID: $0.viewID, viewPath: $0.viewPath, viewName: $0.viewName) }
-        )
 
         featureScope.eventWriteContext { context, writer in
             let offsetNs = context.serverTimeOffset.dd.toInt64Nanoseconds
@@ -337,13 +283,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             let adjustedEnd = end + offsetNs
             let event = RUMTimeseriesMemoryEvent(
                 dd: .init(configuration: .init(sessionSampleRate: sessionSampleRate)),
-                account: .init(context: context),
                 application: .init(id: applicationID),
                 buildId: context.buildId,
                 buildVersion: context.buildNumber,
                 ciTest: ciTest,
-                connectivity: .init(context: context),
-                context: .init(contextInfo: globalAttributes),
                 date: (Double(start) / 1_000_000_000 + context.serverTimeOffset).dd.toInt64Milliseconds,
                 ddtags: context.ddTags,
                 device: context.normalizedDevice(),
@@ -364,9 +307,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                     id: eventID,
                     start: adjustedStart
                 ),
-                usr: .init(context: context),
-                version: context.version,
-                view: view.map { .init(id: $0.id, name: $0.name, url: $0.path) }
+                version: context.version
             )
             writer.write(value: self.sanitizer.sanitize(event: event))
         }
@@ -383,19 +324,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let sessionType = self.sessionType
         let ciTest = self.ciTest
         let syntheticsTest = self.syntheticsTest
-        let globalAttributes = self.activeContextReader?.globalAttributes ?? [:]
         let sessionSampleRate = self.sessionSampleRate
         let start = batch[0].timestamp
         let end = batch[batch.count - 1].timestamp
         let eventID = UUID().uuidString.lowercased()
-
-        // The batch is attributed to the most recently active view among its samples, not the view active
-        // at flush time — a view ending right before a scheduled flush shouldn't drop data that was
-        // genuinely collected while it was active. `view` is left `nil` if no sample in the batch had one
-        // (e.g. samples collected before the first view starts), rather than dropping the batch.
-        let view = Self.lastKnownView(
-            in: batch.map { (viewID: $0.viewID, viewPath: $0.viewPath, viewName: $0.viewName) }
-        )
 
         featureScope.eventWriteContext { context, writer in
             let offsetNs = context.serverTimeOffset.dd.toInt64Nanoseconds
@@ -404,13 +336,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             let adjustedEnd = end + offsetNs
             let event = RUMTimeseriesCpuEvent(
                 dd: .init(configuration: .init(sessionSampleRate: sessionSampleRate)),
-                account: .init(context: context),
                 application: .init(id: applicationID),
                 buildId: context.buildId,
                 buildVersion: context.buildNumber,
                 ciTest: ciTest,
-                connectivity: .init(context: context),
-                context: .init(contextInfo: globalAttributes),
                 date: (Double(start) / 1_000_000_000 + context.serverTimeOffset).dd.toInt64Milliseconds,
                 ddtags: context.ddTags,
                 device: context.normalizedDevice(),
@@ -428,9 +357,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                     id: eventID,
                     start: adjustedStart
                 ),
-                usr: .init(context: context),
-                version: context.version,
-                view: view.map { .init(id: $0.id, name: $0.name, url: $0.path) }
+                version: context.version
             )
             writer.write(value: self.sanitizer.sanitize(event: event))
         }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -41,7 +41,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private let memoryReader: SamplingBasedVitalReader
     private let cpuUsageProvider: () -> Double?
     private let batchSize: Int
-    private let collectTypes: Set<RUM.Configuration.TimeseriesType>?
+    private let collectTypes: Set<RUM.Configuration.TimeseriesType>
     private let samplingInterval: TimeInterval
     private let featureScope: FeatureScope
     private let totalRAM: Double
@@ -69,7 +69,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         memoryReader: SamplingBasedVitalReader,
         featureScope: FeatureScope,
         batchSize: Int = 120,
-        collectTypes: Set<RUM.Configuration.TimeseriesType>? = nil,
+        collectTypes: Set<RUM.Configuration.TimeseriesType> = RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform,
         samplingInterval: TimeInterval = 1,
         cpuUsageProvider: (() -> Double?)? = nil,
         totalRAM: Double = Double(ProcessInfo.processInfo.physicalMemory),
@@ -80,14 +80,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     ) {
         self.memoryReader = memoryReader
         self.batchSize = max(2, batchSize)
-#if os(watchOS)
-        // CPU usage is unavailable on watchOS (`processCPU()` always returns `nil`), so drop `.cpu`
-        // from the effective set to avoid silently accepting a `collectTypes: [.cpu]` config that
-        // would never flush any events.
-        self.collectTypes = collectTypes.map { $0.subtracting([.cpu]) }
-#else
         self.collectTypes = collectTypes
-#endif
         self.samplingInterval = samplingInterval
         self.featureScope = featureScope
         self.totalRAM = totalRAM
@@ -250,7 +243,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
 
         let timestamp = Int64.ddWithNoOverflow(currentDate.timeIntervalSince1970 * 1_000_000_000)
 
-        if collectTypes?.contains(.memory) ?? true, let bytes = memoryReader.readVitalData() {
+        if collectTypes.contains(.memory), let bytes = memoryReader.readVitalData() {
             let footprintKB = bytes / 1_024
             let memoryPercent = totalRAM > 0 ? bytes / totalRAM * 100 : 0
             memoryBuffer.append(MemorySample(timestamp: timestamp, footprintKB: footprintKB, percent: memoryPercent))
@@ -259,7 +252,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             }
         }
 
-        if collectTypes?.contains(.cpu) ?? true, let cpuUsage = cpuUsageProvider() {
+        if collectTypes.contains(.cpu), let cpuUsage = cpuUsageProvider() {
             cpuBuffer.append(CPUSample(timestamp: timestamp, usage: cpuUsage))
             if cpuBuffer.count >= batchSize {
                 flushCPU()

--- a/DatadogRUM/Tests/Timeseries/TimeseriesConfigurationTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesConfigurationTests.swift
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@_spi(Experimental)
+@testable import DatadogRUM
+
+class TimeseriesConfigurationTests: XCTestCase {
+    func testAllAvailableOnCurrentPlatform() {
+        #if os(watchOS)
+        XCTAssertEqual(RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform, [.memory], "CPU usage is unavailable on watchOS")
+        #else
+        XCTAssertEqual(RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform, [.memory, .cpu])
+        #endif
+    }
+
+    func testWhenCollectTypesIsNil_effectiveCollectTypesReturnsAllAvailableOnCurrentPlatform() {
+        // Given
+        let timeseries = RUM.Configuration.Timeseries(collectTypes: nil)
+
+        // Then
+        XCTAssertEqual(timeseries.effectiveCollectTypes, RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform)
+    }
+
+    func testWhenCollectTypesIsMemory_effectiveCollectTypesIsMemory() {
+        // Given
+        let timeseries = RUM.Configuration.Timeseries(collectTypes: [.memory])
+
+        // Then
+        XCTAssertEqual(timeseries.effectiveCollectTypes, [.memory])
+    }
+
+    func testWhenCollectTypesIsCpu_effectiveCollectTypesIsIntersectedWithPlatformAvailability() {
+        // Given
+        let timeseries = RUM.Configuration.Timeseries(collectTypes: [.cpu])
+
+        // Then
+        #if os(watchOS)
+        XCTAssertTrue(timeseries.effectiveCollectTypes.isEmpty, "CPU is unavailable on watchOS, so requesting it alone must resolve to an empty selection")
+        #else
+        XCTAssertEqual(timeseries.effectiveCollectTypes, [.cpu])
+        #endif
+    }
+
+    func testWhenCollectTypesIsEmpty_effectiveCollectTypesIsEmpty() {
+        // Given
+        let timeseries = RUM.Configuration.Timeseries(collectTypes: [])
+
+        // Then
+        XCTAssertTrue(timeseries.effectiveCollectTypes.isEmpty, "An explicit empty selection must disable collection entirely")
+    }
+
+    func testWhenCollectTypesIsBothTypes_effectiveCollectTypesIsIntersectedWithPlatformAvailability() {
+        // Given
+        let timeseries = RUM.Configuration.Timeseries(collectTypes: [.memory, .cpu])
+
+        // Then
+        XCTAssertEqual(timeseries.effectiveCollectTypes, RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform)
+    }
+}

--- a/DatadogRUM/Tests/Timeseries/TimeseriesConfigurationTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesConfigurationTests.swift
@@ -19,7 +19,7 @@ class TimeseriesConfigurationTests: XCTestCase {
 
     func testWhenCollectTypesIsNil_effectiveCollectTypesReturnsAllAvailableOnCurrentPlatform() {
         // Given
-        let timeseries = RUM.Configuration.Timeseries(collectTypes: nil)
+        let timeseries = RUM.Configuration.Timeseries()
 
         // Then
         XCTAssertEqual(timeseries.effectiveCollectTypes, RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform)

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import TestUtilities
 import DatadogInternal
+@_spi(Experimental)
 @testable import DatadogRUM
 
 class TimeseriesSessionCollectorTests: XCTestCase {

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -132,16 +132,16 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(cpuEvent.timeseries.data.values.cpuUsage[0], 75.0)
     }
 
-    // MARK: - collectOnly
+    // MARK: - collectTypes
 
-    func testWhenCollectOnlyIsNil_itCollectsBothMemoryAndCpu() {
+    func testWhenCollectTypesIsNil_itCollectsBothMemoryAndCpu() {
         // Given
         memoryReader.vitalData = 1_024_000
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
             featureScope: featureScope,
             batchSize: 2,
-            collectOnly: nil,
+            collectTypes: nil,
             samplingInterval: 0.05,
             cpuUsageProvider: { 42.5 },
             totalRAM: 4_000_000_000
@@ -159,18 +159,18 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-collect-all")
 
         // Then
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectOnly is nil")
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectOnly is nil")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectTypes is nil")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectTypes is nil")
     }
 
-    func testWhenCollectOnlyIsMemory_itCollectsOnlyMemory() {
+    func testWhenCollectTypesIsMemory_itCollectsOnlyMemory() {
         // Given
         memoryReader.vitalData = 1_024_000
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
             featureScope: featureScope,
             batchSize: 2,
-            collectOnly: [.memory],
+            collectTypes: [.memory],
             samplingInterval: 0.05,
             cpuUsageProvider: { 42.5 },
             totalRAM: 4_000_000_000
@@ -188,18 +188,18 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-collect-memory")
 
         // Then
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectOnly is [.memory]")
-        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected no CPU events when collectOnly is [.memory]")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectTypes is [.memory]")
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected no CPU events when collectTypes is [.memory]")
     }
 
-    func testWhenCollectOnlyIsCpu_itCollectsOnlyCpu() {
+    func testWhenCollectTypesIsCpu_itCollectsOnlyCpu() {
         // Given
         memoryReader.vitalData = 1_024_000
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
             featureScope: featureScope,
             batchSize: 2,
-            collectOnly: [.cpu],
+            collectTypes: [.cpu],
             samplingInterval: 0.05,
             cpuUsageProvider: { 42.5 },
             totalRAM: 4_000_000_000
@@ -217,18 +217,18 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-collect-cpu")
 
         // Then
-        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected no memory events when collectOnly is [.cpu]")
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectOnly is [.cpu]")
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected no memory events when collectTypes is [.cpu]")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectTypes is [.cpu]")
     }
 
-    func testWhenCollectOnlyIsBothMetrics_itCollectsBothMemoryAndCpu() {
+    func testWhenCollectTypesIsBothMetrics_itCollectsBothMemoryAndCpu() {
         // Given
         memoryReader.vitalData = 1_024_000
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
             featureScope: featureScope,
             batchSize: 2,
-            collectOnly: [.memory, .cpu],
+            collectTypes: [.memory, .cpu],
             samplingInterval: 0.05,
             cpuUsageProvider: { 42.5 },
             totalRAM: 4_000_000_000
@@ -246,8 +246,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-collect-both")
 
         // Then
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectOnly is [.memory, .cpu]")
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectOnly is [.memory, .cpu]")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectTypes is [.memory, .cpu]")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectTypes is [.memory, .cpu]")
     }
 
     func testWhenServerTimeOffsetIsNonZero_itAdjustsEventDate() {

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -131,6 +131,124 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(cpuEvent.timeseries.data.values.cpuUsage[0], 75.0)
     }
 
+    // MARK: - collectOnly
+
+    func testWhenCollectOnlyIsNil_itCollectsBothMemoryAndCpu() {
+        // Given
+        memoryReader.vitalData = 1_024_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            collectOnly: nil,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 42.5 },
+            totalRAM: 4_000_000_000
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        // When
+        let expectation = self.expectation(description: "both batches written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-collect-all", applicationID: "app-collect-all", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop(sessionID: "session-collect-all")
+
+        // Then
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectOnly is nil")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectOnly is nil")
+    }
+
+    func testWhenCollectOnlyIsMemory_itCollectsOnlyMemory() {
+        // Given
+        memoryReader.vitalData = 1_024_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            collectOnly: [.memory],
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 42.5 },
+            totalRAM: 4_000_000_000
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        // When
+        let expectation = self.expectation(description: "memory batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-collect-memory", applicationID: "app-collect-memory", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop(sessionID: "session-collect-memory")
+
+        // Then
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectOnly is [.memory]")
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected no CPU events when collectOnly is [.memory]")
+    }
+
+    func testWhenCollectOnlyIsCpu_itCollectsOnlyCpu() {
+        // Given
+        memoryReader.vitalData = 1_024_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            collectOnly: [.cpu],
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 42.5 },
+            totalRAM: 4_000_000_000
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        // When
+        let expectation = self.expectation(description: "cpu batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-collect-cpu", applicationID: "app-collect-cpu", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop(sessionID: "session-collect-cpu")
+
+        // Then
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected no memory events when collectOnly is [.cpu]")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectOnly is [.cpu]")
+    }
+
+    func testWhenCollectOnlyIsBothMetrics_itCollectsBothMemoryAndCpu() {
+        // Given
+        memoryReader.vitalData = 1_024_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            collectOnly: [.memory, .cpu],
+            samplingInterval: 0.05,
+            cpuUsageProvider: { 42.5 },
+            totalRAM: 4_000_000_000
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+
+        // When
+        let expectation = self.expectation(description: "both batches written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-collect-both", applicationID: "app-collect-both", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop(sessionID: "session-collect-both")
+
+        // Then
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectOnly is [.memory, .cpu]")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectOnly is [.memory, .cpu]")
+    }
+
     func testWhenServerTimeOffsetIsNonZero_itAdjustsEventDate() {
         // Given
         memoryReader.vitalData = 1_000_000
@@ -195,38 +313,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(events[0].source, .reactNative)
     }
 
-    func testWhenActiveViewExists_itAttachesViewToEvent() {
-        // Given
-        memoryReader.vitalData = 1_000_000
-        let scope = FeatureScopeMock(context: .mockWith(additionalContext: []))
-        let collector = TimeseriesSessionCollector(
-            memoryReader: memoryReader,
-            featureScope: scope,
-            batchSize: 2,
-            samplingInterval: 0.05,
-            cpuUsageProvider: { nil },
-            totalRAM: 4_000_000_000
-        )
-        let contextReader = RUMActiveContextReaderMock(activeView: (id: "view-abc", path: "/view/abc", name: nil))
-        collector.activeContextReader = contextReader
-
-        // When
-        let expectation = self.expectation(description: "batch written")
-        expectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
-
-        collector.start(sessionID: "session-view", applicationID: "app-view", sessionType: .user)
-        waitForExpectations(timeout: 2)
-        collector.stop(sessionID: "session-view")
-
-        // Then
-        let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
-        XCTAssertFalse(events.isEmpty)
-        XCTAssertEqual(events[0].view?.id, "view-abc")
-        XCTAssertEqual(events[0].view?.url, "/view/abc")
-    }
-
-    func testWhenActiveViewHasName_itAttachesViewNameToEvent() {
+    func testWhenActiveViewExists_itStillWritesEventWithoutView() {
         // Given
         memoryReader.vitalData = 1_000_000
         let scope = FeatureScopeMock(context: .mockWith(additionalContext: []))
@@ -246,14 +333,14 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         expectation.assertForOverFulfill = false
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
 
-        collector.start(sessionID: "session-view-name", applicationID: "app-view-name", sessionType: .user)
+        collector.start(sessionID: "session-view", applicationID: "app-view", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop(sessionID: "session-view-name")
+        collector.stop(sessionID: "session-view")
 
-        // Then
+        // Then — `view` is never populated on timeseries events, even when a view is active
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
         XCTAssertFalse(events.isEmpty)
-        XCTAssertEqual(events[0].view?.name, "ViewController")
+        XCTAssertNil(events[0].view)
     }
 
     func testWhenSessionReplayHasReplay_itAttachesHasReplayToEvent() {
@@ -316,43 +403,6 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
         XCTAssertFalse(events.isEmpty)
         XCTAssertEqual(events[0].dd.configuration?.sessionSampleRate, 42)
-    }
-
-    func testWhenViewEndsRightBeforeFlush_itStillAttachesTheViewSamplesWereCollectedUnder() {
-        // Given
-        memoryReader.vitalData = 1_000_000
-        let scope = FeatureScopeMock(context: .mockWith(additionalContext: []))
-        let collector = TimeseriesSessionCollector(
-            memoryReader: memoryReader,
-            featureScope: scope,
-            batchSize: 100, // won't auto-flush — only the explicit stop() below triggers the flush
-            samplingInterval: 0.05,
-            cpuUsageProvider: { nil },
-            totalRAM: 4_000_000_000
-        )
-        let contextReader = RUMActiveContextReaderMock(activeView: (id: "view-ending", path: "/view/ending", name: nil))
-        collector.activeContextReader = contextReader
-
-        // When — samples are collected while a view is active
-        let expectation = self.expectation(description: "samples collected under an active view")
-        expectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
-        collector.start(sessionID: "session-ending-view", applicationID: "app-ending-view", sessionType: .user)
-        waitForExpectations(timeout: 2)
-
-        // The view ends right before the batch is flushed
-        contextReader.activeView = (nil, nil, nil)
-
-        let syncExpectation = self.expectation(description: "stop completed")
-        collector.stop(sessionID: "session-ending-view")
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-
-        // Then — the batch is still written, attributed to the view it was actually collected under
-        let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
-        XCTAssertFalse(events.isEmpty, "Expected the batch collected under an active view to be flushed, not dropped")
-        XCTAssertEqual(events[0].view?.id, "view-ending")
-        XCTAssertEqual(events[0].view?.url, "/view/ending")
     }
 
     func testWhenNoActiveView_itWritesEventWithoutView() {
@@ -730,9 +780,6 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
         XCTAssertFalse(events.isEmpty)
         let event = events[0]
-        XCTAssertEqual(event.usr?.id, "user-abc")
-        XCTAssertEqual(event.account?.id, "account-abc")
-        XCTAssertNotNil(event.connectivity)
         XCTAssertNotNil(event.device)
         XCTAssertNotNil(event.os)
         XCTAssertEqual(event.buildId, "build-abc")
@@ -741,18 +788,30 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(event.synthetics?.testId, "synthetics-test")
     }
 
-    func testItPopulatesContextFromActiveContextReader() {
+    func testItNeverPopulatesPrivacySensitiveOrContextualFields() {
         // Given
         memoryReader.vitalData = 1_000_000
-        let scope = FeatureScopeMock(context: .mockWith(additionalContext: []))
+        let userInfo = UserInfo(id: "user-abc", name: "Jane", email: "jane@example.com", extraInfo: [:])
+        let accountInfo = AccountInfo(id: "account-abc", name: "Acme", extraInfo: [:])
+        let scope = FeatureScopeMock(
+            context: .mockWith(
+                userInfo: userInfo,
+                accountInfo: accountInfo,
+                additionalContext: [RUMCoreContext.mockAny()]
+            )
+        )
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
             featureScope: scope,
             batchSize: 2,
             samplingInterval: 0.05,
-            cpuUsageProvider: { nil }
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000
         )
-        let contextReader = RUMActiveContextReaderMock(globalAttributes: ["custom-key": "custom-value"])
+        let contextReader = RUMActiveContextReaderMock(
+            globalAttributes: ["custom-key": "custom-value"],
+            activeView: (id: "view-abc", path: "/view/abc", name: "ViewController")
+        )
         collector.activeContextReader = contextReader
 
         // When
@@ -760,14 +819,22 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         expectation.assertForOverFulfill = false
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
 
-        collector.start(sessionID: "session-context", applicationID: "app-context", sessionType: .user)
+        collector.start(sessionID: "session-privacy", applicationID: "app-privacy", sessionType: .user)
         waitForExpectations(timeout: 2)
-        collector.stop(sessionID: "session-context")
+        collector.stop(sessionID: "session-privacy")
 
-        // Then
+        // Then — these fields are never populated on timeseries events, regardless of available context
         let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
         XCTAssertFalse(events.isEmpty)
-        XCTAssertEqual(events[0].context?.contextInfo["custom-key"] as? String, "custom-value")
+        let event = events[0]
+        XCTAssertNil(event.usr)
+        XCTAssertNil(event.account)
+        XCTAssertNil(event.context)
+        XCTAssertNil(event.connectivity)
+        XCTAssertNil(event.view)
+        XCTAssertNil(event.tab)
+        XCTAssertNil(event.stream)
+        XCTAssertNil(event.display)
     }
 
     // MARK: - Timeseries range

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -134,14 +134,13 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
     // MARK: - collectTypes
 
-    func testWhenCollectTypesIsNil_itCollectsBothMemoryAndCpu() {
+    func testWhenCollectTypesIsDefault_itCollectsBothMemoryAndCpu() {
         // Given
         memoryReader.vitalData = 1_024_000
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
             featureScope: featureScope,
             batchSize: 2,
-            collectTypes: nil,
             samplingInterval: 0.05,
             cpuUsageProvider: { 42.5 },
             totalRAM: 4_000_000_000
@@ -159,8 +158,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-collect-all")
 
         // Then
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectTypes is nil")
-        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectTypes is nil")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected memory events when collectTypes defaults to all available types")
+        XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectTypes defaults to all available types")
     }
 
     func testWhenCollectTypesIsMemory_itCollectsOnlyMemory() {
@@ -221,7 +220,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesCpuEvent.self).isEmpty, "Expected CPU events when collectTypes is [.cpu]")
     }
 
-    func testWhenCollectTypesIsBothMetrics_itCollectsBothMemoryAndCpu() {
+    func testWhenCollectTypesIsBothTypes_itCollectsBothMemoryAndCpu() {
         // Given
         memoryReader.vitalData = 1_024_000
         let collector = TimeseriesSessionCollector(

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -423,12 +423,6 @@ public enum RUM
         public var collectAccessibility: Bool
         public var timeseries: Timeseries?
         public var featureFlags: FeatureFlags
-        public struct Timeseries
-            public var collectOnly: [TimeseriesMetric]?
-            public init(collectOnly: [TimeseriesMetric]? = nil)
-        public enum TimeseriesMetric
-            case memory
-            case cpu
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing?
             public var resourceAttributesProvider: RUM.ResourceAttributesProvider?
@@ -438,6 +432,12 @@ public enum RUM
             case frequent
             case average
             case rare
+        public struct Timeseries
+            public var collectOnly: [TimeseriesMetric]?
+            public init(collectOnly: [TimeseriesMetric]? = nil)
+        public enum TimeseriesMetric
+            case memory
+            case cpu
 [?] extension RUM.Configuration.URLSessionTracking
     public enum FirstPartyHostsTracing
         case trace(hosts: Set<String>,sampleRate: Float = .maxSampleRate,traceControlInjection: TraceContextInjection = .sampled)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -433,9 +433,9 @@ public enum RUM
             case average
             case rare
         public struct Timeseries
-            public var collectOnly: [TimeseriesMetric]?
-            public init(collectOnly: [TimeseriesMetric]? = nil)
-        public enum TimeseriesMetric
+            public var collectTypes: [TimeseriesType]?
+            public init(collectTypes: [TimeseriesType]? = nil)
+        public enum TimeseriesType
             case memory
             case cpu
 [?] extension RUM.Configuration.URLSessionTracking

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -435,7 +435,7 @@ public enum RUM
         public struct Timeseries
             public var collectTypes: [TimeseriesType]?
             public init(collectTypes: [TimeseriesType]? = nil)
-        public enum TimeseriesType
+        public enum TimeseriesType: CaseIterable
             case memory
             case cpu
 [?] extension RUM.Configuration.URLSessionTracking

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -421,10 +421,14 @@ public enum RUM
         public var trackSlowFrames: Bool
         public var telemetrySampleRate: SampleRate
         public var collectAccessibility: Bool
-        public var enableTimeseries: Bool
-        public static let defaultTimeseriesBatchSize = 120
-        public var timeseriesBatchSize: Int
+        public var timeseries: Timeseries?
         public var featureFlags: FeatureFlags
+        public struct Timeseries
+            public var collectOnly: [TimeseriesMetric]?
+            public init(collectOnly: [TimeseriesMetric]? = nil)
+        public enum TimeseriesMetric
+            case memory
+            case cpu
         public struct URLSessionTracking
             public var firstPartyHostsTracing: FirstPartyHostsTracing?
             public var resourceAttributesProvider: RUM.ResourceAttributesProvider?
@@ -447,7 +451,7 @@ public enum RUM
         case matchHeaders([String])
     public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,trackResourceHeaders: TrackResourceHeaders = .disabled,disallowList: [String] = [])
 [?] extension RUM.Configuration
-    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,timeseriesBatchSize: Int = RUM.Configuration.defaultTimeseriesBatchSize,featureFlags: FeatureFlags = .defaults)
+    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,featureFlags: FeatureFlags = .defaults)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration
     public var configurationTelemetrySampleRate: Float
 [?] extension RUM.Configuration


### PR DESCRIPTION
### What and why?

Timeseries events (`RUMTimeseriesMemoryEvent`/`RUMTimeseriesCpuEvent`) no longer populate `usr`, `account`, `context`, `connectivity`, `view`, `tab`, `stream`, or `display`, since these fields aren't needed for the memory/CPU timeseries use case and only add unnecessary PII/context surface.

The config API is also replaced: instead of a flat `enableTimeseries`/`timeseriesBatchSize`, `RUM.Configuration` now exposes a single optional `timeseries: Timeseries?`, where `Timeseries` has a `collectOnly: [TimeseriesMetric]?` property to select specific metrics (`nil` = collect all). Batch size is now a fixed internal default, no longer user-configurable. Still marked `@_spi(Experimental)`.