### PR TITLE
RUMS-6216: Reject oversized events before JSON serialization

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		115792EC2F4608A200AEE829 /* BinaryImageResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115792EB2F4608A200AEE829 /* BinaryImageResolverTests.swift */; };
 		1157930A2F51F05100AEE829 /* binary_image_resolver_testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 115793092F51F05100AEE829 /* binary_image_resolver_testing.h */; };
 		11582D80302DF335003E3106 /* AttributesSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11582D7F302DF335003E3106 /* AttributesSanitizerTests.swift */; };
+		11582D82302E6771003E3106 /* WatchdogTerminationReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11582D81302E6771003E3106 /* WatchdogTerminationReporterTests.swift */; };
 		115F480C2E0BFE11006FAB07 /* DeterministicSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */; };
 		116232382F866ACF00F20ABC /* OperationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118848522F6C4E0C008D2919 /* OperationMessage.swift */; };
 		1162323A2F866B4000F20ABC /* MockThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D0E2182E40E34A00BA4113 /* MockThread.swift */; };
@@ -284,7 +285,6 @@
 		3C3EF2B02C1AEBAB009E9E57 /* LaunchReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */; };
 		3C41693C29FBF4D50042B9D2 /* DatadogWebViewTracking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CE119FE29F7BE0100202522 /* DatadogWebViewTracking.framework */; };
 		3C43A3882C188974000BFB21 /* WatchdogTerminationMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */; };
-		B21F9B173E636896FBBF638B /* WatchdogTerminationReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A0F1FDC6F852757B99EF56 /* WatchdogTerminationReporterTests.swift */; };
 		3C4CF9922C47BE07006DE1C0 /* MemoryWarningMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5CD8C12C3EBA1700B12303 /* MemoryWarningMonitor.swift */; };
 		3C4CF9982C47CC91006DE1C0 /* MemoryWarningMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4CF9972C47CC8C006DE1C0 /* MemoryWarningMonitorTests.swift */; };
 		3C4CF99B2C47DAA5006DE1C0 /* MemoryWarningMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C4CF99A2C47DAA5006DE1C0 /* MemoryWarningMocks.swift */; };
@@ -1946,6 +1946,7 @@
 		115792EB2F4608A200AEE829 /* BinaryImageResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryImageResolverTests.swift; sourceTree = "<group>"; };
 		115793092F51F05100AEE829 /* binary_image_resolver_testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = binary_image_resolver_testing.h; sourceTree = "<group>"; };
 		11582D7F302DF335003E3106 /* AttributesSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesSanitizerTests.swift; sourceTree = "<group>"; };
+		11582D81302E6771003E3106 /* WatchdogTerminationReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationReporterTests.swift; sourceTree = "<group>"; };
 		115F480A2E0BFE02006FAB07 /* DeterministicSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicSamplerTests.swift; sourceTree = "<group>"; };
 		1162323D2F87D8F600F20ABC /* ProfilingContextMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingContextMessageReceiver.swift; sourceTree = "<group>"; };
 		1162323F2F87FA5D00F20ABC /* ProfilingSamplerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingSamplerProvider.swift; sourceTree = "<group>"; };
@@ -2126,7 +2127,6 @@
 		3C3C9E2E2C64F470003AF22F /* Data+CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+CryptoTests.swift"; sourceTree = "<group>"; };
 		3C3EF2AF2C1AEBAB009E9E57 /* LaunchReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchReport.swift; sourceTree = "<group>"; };
 		3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationMonitorTests.swift; sourceTree = "<group>"; };
-		11A0F1FDC6F852757B99EF56 /* WatchdogTerminationReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchdogTerminationReporterTests.swift; sourceTree = "<group>"; };
 		3C4CF9972C47CC8C006DE1C0 /* MemoryWarningMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWarningMonitorTests.swift; sourceTree = "<group>"; };
 		3C4CF99A2C47DAA5006DE1C0 /* MemoryWarningMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWarningMocks.swift; sourceTree = "<group>"; };
 		3C5CD8C12C3EBA1700B12303 /* MemoryWarningMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWarningMonitor.swift; sourceTree = "<group>"; };
@@ -3988,7 +3988,7 @@
 				3CFF4FA32C0E0FE5006F191D /* WatchdogTerminationCheckerTests.swift */,
 				3CEC57752C16FDD30042B5F2 /* AppStateManagerTests.swift */,
 				3C43A3862C188970000BFB21 /* WatchdogTerminationMonitorTests.swift */,
-				11A0F1FDC6F852757B99EF56 /* WatchdogTerminationReporterTests.swift */,
+				11582D81302E6771003E3106 /* WatchdogTerminationReporterTests.swift */,
 			);
 			path = WatchdogTerminations;
 			sourceTree = "<group>";
@@ -9481,6 +9481,7 @@
 				D29A9FAB29DDB483005C54A4 /* RUMUserActionScopeTests.swift in Sources */,
 				864A70802DE092AD00AC0619 /* AccessibilityReaderTests.swift in Sources */,
 				615B0F8B2BB33C2800E9ED6C /* AppHangsMonitorTests.swift in Sources */,
+				11582D82302E6771003E3106 /* WatchdogTerminationReporterTests.swift in Sources */,
 				61C713B32A3C3A0B00FA735A /* RUMMonitorProtocol+InternalTests.swift in Sources */,
 				D29A9FA329DDB483005C54A4 /* RUMDeviceInfoTests.swift in Sources */,
 				D29A9FBC29DDB483005C54A4 /* RUMResourceScopeTests.swift in Sources */,
@@ -9504,7 +9505,6 @@
 				3C4CF99B2C47DAA5006DE1C0 /* MemoryWarningMocks.swift in Sources */,
 				5B1D02942E8ED6C000AB2391 /* FlagEvaluationReceiverTests.swift in Sources */,
 				3C43A3882C188974000BFB21 /* WatchdogTerminationMonitorTests.swift in Sources */,
-				B21F9B173E636896FBBF638B /* WatchdogTerminationReporterTests.swift in Sources */,
 				D29A9F9D29DDB483005C54A4 /* ValuePublisherTests.swift in Sources */,
 				6174D61A2BFE449300EC7469 /* SessionEndedMetricTests.swift in Sources */,
 				9654971D2D774060006428EE /* SwiftUIViewNameExtractorTests.swift in Sources */,

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -787,6 +787,11 @@ class CrashReportReceiverTests: XCTestCase {
 
         let modifiedViewName = String.mockRandom()
         let errorFingerprint = String.mockRandom()
+        let oversizedAttributeKey = "oversized"
+        let oversizedAttribute = String(
+            repeating: "a",
+            count: RUMEventSanitizer.maxTotalAttributeBytes
+        )
         let receiver: CrashReportReceiver = .mockWith(
             featureScope: featureScope,
             dateProvider: RelativeDateProvider(using: crashDate),
@@ -796,11 +801,17 @@ class CrashReportReceiverTests: XCTestCase {
                 viewEventMapper: { event in
                     var event = event
                     event.view.name = modifiedViewName
+                    event.context = RUMEventAttributes(
+                        contextInfo: [oversizedAttributeKey: oversizedAttribute]
+                    )
                     return event
                 },
                 errorEventMapper: { event in
                     var event = event
                     event.error.fingerprint = errorFingerprint
+                    event.context = RUMEventAttributes(
+                        contextInfo: [oversizedAttributeKey: oversizedAttribute]
+                    )
                     return event
                 }
             )
@@ -816,9 +827,54 @@ class CrashReportReceiverTests: XCTestCase {
         // Then
         let sendRUMViewEvent = featureScope.eventsWritten(ofType: RUMViewEvent.self).last
         XCTAssertEqual(sendRUMViewEvent?.view.name, modifiedViewName, "Must send event mapper modified view event")
+        XCTAssertNil(sendRUMViewEvent?.context?.contextInfo[oversizedAttributeKey])
 
         let sendRUMErrorEvent = featureScope.eventsWritten(ofType: RUMErrorEvent.self)[0]
         XCTAssertEqual(sendRUMErrorEvent.error.fingerprint, errorFingerprint, "Must send event mapper modified error event")
+        XCTAssertNil(sendRUMErrorEvent.context?.contextInfo[oversizedAttributeKey])
+    }
+
+    func testGivenStaleCrashWithOversizedLastRUMAttributesAndNilErrorMapper_whenSending_itSanitizesOriginalError() throws {
+        let oversizedAttributeKey = "oversized"
+        let smallAttributeKey = "small"
+        let crashDate: Date = .mockDecember15th2019At10AMUTC()
+        let lastRUMAttributes = RUMEventAttributes(
+            contextInfo: [
+                smallAttributeKey: "value",
+                oversizedAttributeKey: String(
+                    repeating: "a",
+                    count: RUMEventSanitizer.maxTotalAttributeBytes
+                ),
+            ]
+        )
+        let crashContext: CrashContext = .mockWith(
+            trackingConsent: .granted,
+            lastRUMViewEvent: .mockRandomWith(crashCount: 0),
+            lastRUMAttributes: lastRUMAttributes
+        )
+        let receiver: CrashReportReceiver = .mockWith(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(
+                using: crashDate.addingTimeInterval(
+                    FatalErrorBuilder.Constants.viewEventAvailabilityThreshold + 1
+                )
+            ),
+            eventsMapper: .mockWith(errorEventMapper: { _ in nil })
+        )
+
+        // When
+        XCTAssertTrue(
+            receiver.receive(
+                message: .payload(Crash(report: .mockWith(date: crashDate), context: crashContext)),
+                from: NOPDatadogCore()
+            )
+        )
+
+        // Then
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMViewEvent.self).isEmpty)
+        let sentRUMError = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).last)
+        XCTAssertNotNil(sentRUMError.context?.contextInfo[smallAttributeKey])
+        XCTAssertNil(sentRUMError.context?.contextInfo[oversizedAttributeKey])
     }
 
     func testGivenCrashDuringRUMSessionWithActiveView_whenErrorMapperReturnsNull_itSendOriginalError() throws {

--- a/DatadogRUM/Sources/RUMEvent/RUMEventSanitizer.swift
+++ b/DatadogRUM/Sources/RUMEvent/RUMEventSanitizer.swift
@@ -20,66 +20,435 @@ internal protocol RUMSanitizableEvent {
 
 /// Sanitizes `RUMEvent` representation received from the user, so it can match Datadog RUM Events constraints.
 internal struct RUMEventSanitizer {
+    /// Bounds JSON buffer growth from inspectable custom attributes to the maximum RUM event size.
+    static let maxTotalAttributeBytes = 1.MB
+
+    private struct Limits {
+        var remainingCount = AttributesSanitizer.Constraints.maxNumberOfAttributes
+        var remainingAttributeBytes = maxTotalAttributeBytes
+        var numberOfSizeLimitedAttributes = 0
+    }
+
     private let attributesSanitizer = AttributesSanitizer(featureName: "RUM Event")
 
     func sanitize<Event>(event: Event) -> Event where Event: RUMSanitizableEvent {
         var event = event
 
-        // Limit to max number of attributes.
-        // If any attributes need to be removed, we first reduce number of
-        // event attributes, then user info extra attributes.
-        var limit = AttributesSanitizer.Constraints.maxNumberOfAttributes
-        event.usr = sanitize(usr: event.usr, limit: &limit)
-        event.account = sanitize(account: event.account, limit: &limit)
-        event.context = sanitize(context: event.context, limit: &limit)
+        // Limit the total number and estimated content size of attributes. User and account information take
+        // precedence over event context, matching the existing attribute-count policy.
+        var limits = Limits()
+        event.usr = sanitize(event.usr, attributesAt: \.usrInfo, limits: &limits)
+        event.account = sanitize(event.account, attributesAt: \.accountInfo, limits: &limits)
+        event.context = sanitize(event.context, attributesAt: \.contextInfo, limits: &limits)
+
+        if limits.numberOfSizeLimitedAttributes > 0 {
+            DD.logger.warn(
+                """
+                Size of RUM Event attributes exceeds the limit of \(Self.maxTotalAttributeBytes) bytes.
+                \(limits.numberOfSizeLimitedAttributes) attribute(s) will be ignored.
+                """
+            )
+        }
 
         return event
     }
 
-    private func sanitize(usr: RUMUser?, limit: inout Int) -> RUMUser? {
-        guard var usr = usr else {
+    private func sanitize<Container>(
+        _ container: Container?,
+        attributesAt keyPath: WritableKeyPath<Container, [String: Encodable]>,
+        limits: inout Limits
+    ) -> Container? {
+        guard var container else {
             return nil
         }
 
-        // Sanitize attribute names
-        let attributes = attributesSanitizer.sanitizeKeys(for: usr.usrInfo, prefixLevels: 1)
-
-        // Limit to max number of attributes.
-        usr.usrInfo = attributesSanitizer.limitNumberOf(attributes: attributes, to: limit)
-
-        limit -= usr.usrInfo.count
-        return usr
+        container[keyPath: keyPath] = sanitize(
+            attributes: container[keyPath: keyPath],
+            limits: &limits
+        )
+        return container
     }
 
-    private func sanitize(account: RUMAccount?, limit: inout Int) -> RUMAccount? {
-        guard var account = account else {
-            return nil
+    private func sanitize(
+        attributes: [String: Encodable],
+        limits: inout Limits
+    ) -> [String: Encodable] {
+        let sanitizedKeys = attributesSanitizer.sanitizeKeys(for: attributes, prefixLevels: 1)
+        let countLimited = attributesSanitizer.limitNumberOf(
+            attributes: sanitizedKeys,
+            to: limits.remainingCount
+        )
+        let sizeLimited = JSONAttributeSizeLimiter.limit(
+            attributes: countLimited,
+            remainingBytes: &limits.remainingAttributeBytes
+        )
+
+        limits.remainingCount -= sizeLimited.attributes.count
+        limits.numberOfSizeLimitedAttributes += sizeLimited.numberOfRejectedAttributes
+        return sizeLimited.attributes
+    }
+}
+
+/// Limits Foundation-compatible attributes without invoking customer `Encodable` implementations.
+private enum JSONAttributeSizeLimiter {
+    private static let maxNestingDepth = 10
+
+    struct Result {
+        let attributes: [String: Encodable]
+        let numberOfRejectedAttributes: Int
+    }
+
+    private struct Candidate {
+        let jsonObject: Any
+        let requiresSnapshot: Bool
+    }
+
+    private struct Inspection {
+        var remainingBytes: Int
+        var containsMutableValue = false
+
+        mutating func consume(_ bytes: Int) -> Bool {
+            guard bytes >= 0, bytes <= remainingBytes else {
+                return false
+            }
+            remainingBytes -= bytes
+            return true
+        }
+    }
+
+    private enum Preparation {
+        case candidate(Candidate)
+        case rejected
+    }
+
+    private enum JSONValueInspection {
+        case measurable
+        case unsupported
+        case limitExceeded
+    }
+
+    private enum Serialization {
+        case written(numberOfBytes: Int, snapshot: [String: Any]?)
+        case limitExceeded
+        case failed
+    }
+
+    static func limit(
+        attributes: [String: Encodable],
+        remainingBytes: inout Int
+    ) -> Result {
+        guard !attributes.isEmpty else {
+            return Result(attributes: attributes, numberOfRejectedAttributes: 0)
         }
 
-        // Sanitize attribute names
-        let attributes = attributesSanitizer.sanitizeKeys(for: account.accountInfo, prefixLevels: 1)
+        var accepted = attributes
+        var candidates: [String: Candidate] = [:]
+        var jsonObject: [String: Any] = [:]
+        var lowerBoundRemainingBytes = remainingBytes
+        var numberOfRejectedAttributes = 0
 
-        // Limit to max number of attributes.
-        account.accountInfo = attributesSanitizer.limitNumberOf(attributes: attributes, to: limit)
+        for (key, value) in attributes {
+            var inspection = Inspection(remainingBytes: lowerBoundRemainingBytes)
+            guard inspection.consume(key.utf8.count) else {
+                accepted.removeValue(forKey: key)
+                numberOfRejectedAttributes += 1
+                continue
+            }
 
-        limit -= account.accountInfo.count
-        return account
-    }
-
-    private func sanitize(context: RUMEventAttributes?, limit: inout Int) -> RUMEventAttributes? {
-        guard var context = context else {
-            return nil
+            switch prepare(value, inspection: &inspection) {
+            case let .candidate(candidate):
+                lowerBoundRemainingBytes = inspection.remainingBytes
+                candidates[key] = candidate
+                jsonObject[key] = candidate.jsonObject
+            case .rejected:
+                accepted.removeValue(forKey: key)
+                numberOfRejectedAttributes += 1
+            }
         }
 
-        // Sanitize attribute names
-        let attributes = attributesSanitizer.sanitizeKeys(for: context.contextInfo, prefixLevels: 1)
+        if !JSONSerialization.isValidJSONObject(jsonObject) {
+            // Partition Foundation-incompatible values without executing arbitrary `Encodable` implementations.
+            // These values remain in the event, but are intentionally left unverified.
+            for (key, candidate) in candidates where !JSONSerialization.isValidJSONObject([key: candidate.jsonObject]) {
+                candidates.removeValue(forKey: key)
+                jsonObject.removeValue(forKey: key)
+            }
+        }
 
-        // Limit to max number of attributes.
-        context.contextInfo = attributesSanitizer.limitNumberOf(attributes: attributes, to: limit)
+        guard !jsonObject.isEmpty else {
+            return Result(
+                attributes: accepted,
+                numberOfRejectedAttributes: numberOfRejectedAttributes
+            )
+        }
 
-        limit -= context.contextInfo.count
-        return context
+        let requiresSnapshot = candidates.values.contains { $0.requiresSnapshot }
+        switch serialize(
+            jsonObject,
+            byteLimit: remainingBytes,
+            capturesSnapshot: requiresSnapshot
+        ) {
+        case let .written(numberOfBytes, snapshot):
+            remainingBytes -= numberOfBytes
+            applySnapshot(snapshot, for: candidates, to: &accepted)
+
+        case .limitExceeded:
+            // The uncommon oversized path measures attributes independently so only attributes crossing the
+            // remaining budget are rejected. The normal path above performs a single Foundation serialization.
+            for (key, _) in attributes {
+                guard let candidate = candidates[key] else {
+                    continue
+                }
+
+                switch serialize(
+                    [key: candidate.jsonObject],
+                    byteLimit: remainingBytes,
+                    capturesSnapshot: candidate.requiresSnapshot
+                ) {
+                case let .written(numberOfBytes, snapshot):
+                    remainingBytes -= numberOfBytes
+                    if let value = snapshot?[key] {
+                        accepted[key] = AnyEncodable(value)
+                    }
+                case .limitExceeded:
+                    accepted.removeValue(forKey: key)
+                    numberOfRejectedAttributes += 1
+                case .failed:
+                    break
+                }
+            }
+
+        case .failed:
+            // Preserve existing behavior if Foundation rejects a value we expected it to support.
+            break
+        }
+
+        return Result(
+            attributes: accepted,
+            numberOfRejectedAttributes: numberOfRejectedAttributes
+        )
     }
+
+    private static func prepare(_ value: Any, inspection: inout Inspection) -> Preparation {
+        let value = unwrap(value)
+        switch inspectJSONValue(value, depth: 0, inspection: &inspection) {
+        case .measurable:
+            let jsonObject: Any = value is Void ? NSNull() : value
+            return .candidate(
+                Candidate(
+                    jsonObject: jsonObject,
+                    requiresSnapshot: inspection.containsMutableValue
+                )
+            )
+
+        case .unsupported:
+            if value is NSNumber || value is [Any?] || value is [String: Any?] {
+                // Reject invalid numbers and native collections containing unsupported values. Measuring either
+                // would require reproducing `JSONEncoder` or executing customer `Encodable` implementations.
+                return .rejected
+            }
+            return .candidate(
+                Candidate(
+                    jsonObject: value,
+                    requiresSnapshot: inspection.containsMutableValue
+                )
+            )
+
+        case .limitExceeded:
+            return .rejected
+        }
+    }
+
+    private static func unwrap(_ value: Any) -> Any {
+        if let value = value as? AnyEncodable {
+            return unwrap(value.value)
+        }
+        if let value = value as? AnyCodable {
+            return unwrap(value.value)
+        }
+        if let optional = value as? JSONOptional {
+            return optional.jsonValue.map(unwrap) ?? NSNull()
+        }
+        return value
+    }
+
+    /// Applies allocation-safe lower bounds while inspecting a Foundation-compatible JSON value.
+    private static func inspectJSONValue(
+        _ value: Any,
+        depth: Int,
+        inspection: inout Inspection
+    ) -> JSONValueInspection {
+        if let optional = value as? JSONOptional {
+            return inspectJSONValue(
+                optional.jsonValue ?? NSNull(),
+                depth: depth,
+                inspection: &inspection
+            )
+        }
+
+        let isFoundationObject = Swift.type(of: value) is NSObject.Type
+        if isFoundationObject,
+           value is NSMutableString || value is NSMutableData
+            || value is NSMutableArray || value is NSMutableDictionary {
+            inspection.containsMutableValue = true
+        }
+
+        switch value {
+        case is Void, is NSNull:
+            return .measurable
+        case let value as String:
+            return inspection.consume(value.utf8.count) ? .measurable : .limitExceeded
+        case let values as [Any?]:
+            guard depth < maxNestingDepth, inspection.consume(values.count) else {
+                return .limitExceeded
+            }
+            for value in values {
+                switch inspectJSONValue(value as Any, depth: depth + 1, inspection: &inspection) {
+                case .measurable:
+                    continue
+                case .unsupported:
+                    return .unsupported
+                case .limitExceeded:
+                    return .limitExceeded
+                }
+            }
+            return .measurable
+        case let values as [String: Any?]:
+            guard depth < maxNestingDepth, inspection.consume(values.count) else {
+                return .limitExceeded
+            }
+            for (key, value) in values {
+                guard inspection.consume(key.utf8.count) else {
+                    return .limitExceeded
+                }
+                switch inspectJSONValue(value as Any, depth: depth + 1, inspection: &inspection) {
+                case .measurable:
+                    continue
+                case .unsupported:
+                    return .unsupported
+                case .limitExceeded:
+                    return .limitExceeded
+                }
+            }
+            return .measurable
+        case let value as NSNumber:
+            return value.doubleValue.isFinite ? .measurable : .unsupported
+        default:
+            return .unsupported
+        }
+    }
+
+    private static func applySnapshot(
+        _ snapshot: [String: Any]?,
+        for candidates: [String: Candidate],
+        to attributes: inout [String: Encodable]
+    ) {
+        guard let snapshot else {
+            return
+        }
+        for (key, candidate) in candidates where candidate.requiresSnapshot {
+            if let value = snapshot[key] {
+                attributes[key] = AnyEncodable(value)
+            }
+        }
+    }
+
+    private static func serialize(
+        _ jsonObject: Any,
+        byteLimit: Int,
+        capturesSnapshot: Bool
+    ) -> Serialization {
+        let stream = ByteLimitOutputStream(
+            byteLimit: byteLimit,
+            capturesBytes: capturesSnapshot
+        )
+        stream.open()
+        defer { stream.close() }
+
+        var error: NSError?
+        let numberOfBytes = JSONSerialization.writeJSONObject(
+            jsonObject,
+            to: stream,
+            options: [],
+            error: &error
+        )
+
+        if stream.didExceedLimit {
+            return .limitExceeded
+        }
+        guard error == nil, numberOfBytes >= 0 else {
+            return .failed
+        }
+        let snapshot = stream.capturedData.flatMap {
+            try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
+        }
+        return .written(numberOfBytes: stream.numberOfBytesWritten, snapshot: snapshot)
+    }
+}
+
+/// Discards serialized bytes and rejects a write before it crosses the configured limit.
+private final class ByteLimitOutputStream: OutputStream {
+    private let byteLimit: Int
+    private var status: Stream.Status = .notOpen
+    private var data: Data?
+
+    private(set) var numberOfBytesWritten = 0
+    private(set) var didExceedLimit = false
+
+    var capturedData: Data? { data }
+
+    init(byteLimit: Int, capturesBytes: Bool) {
+        self.byteLimit = max(0, byteLimit)
+        if capturesBytes {
+            var data = Data()
+            data.reserveCapacity(min(byteLimit, 4 * 1_024))
+            self.data = data
+        }
+        super.init(toMemory: ())
+    }
+
+    override var hasSpaceAvailable: Bool {
+        status == .open && numberOfBytesWritten < byteLimit
+    }
+
+    override var streamStatus: Stream.Status { status }
+
+    override var streamError: Error? {
+        didExceedLimit
+            ? NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteOutOfSpace.rawValue)
+            : nil
+    }
+
+    override func open() {
+        status = .open
+    }
+
+    override func close() {
+        status = .closed
+    }
+
+    override func write(_ buffer: UnsafePointer<UInt8>, maxLength length: Int) -> Int {
+        guard status == .open else {
+            return -1
+        }
+        guard length <= byteLimit - numberOfBytesWritten else {
+            didExceedLimit = true
+            status = .error
+            return -1
+        }
+
+        data?.append(buffer, count: length)
+        numberOfBytesWritten += length
+        return length
+    }
+}
+
+private protocol JSONOptional {
+    var jsonValue: Any? { get }
+}
+
+extension Optional: JSONOptional {
+    fileprivate var jsonValue: Any? { self }
 }
 
 extension RUMViewEvent: RUMSanitizableEvent {}

--- a/DatadogRUM/Sources/RUMEvent/RUMEventSanitizer.swift
+++ b/DatadogRUM/Sources/RUMEvent/RUMEventSanitizer.swift
@@ -37,8 +37,8 @@ internal struct RUMEventSanitizer {
         // Limit the total number and estimated content size of attributes. User and account information take
         // precedence over event context, matching the existing attribute-count policy.
         var limits = Limits()
-        event.usr = sanitize(event.usr, attributesAt: \.usrInfo, limits: &limits)
-        event.account = sanitize(event.account, attributesAt: \.accountInfo, limits: &limits)
+        event.usr = sanitize(event.usr, limits: &limits)
+        event.account = sanitize(event.account, limits: &limits)
         event.context = sanitize(event.context, attributesAt: \.contextInfo, limits: &limits)
 
         if limits.numberOfSizeLimitedAttributes > 0 {
@@ -67,6 +67,55 @@ internal struct RUMEventSanitizer {
             limits: &limits
         )
         return container
+    }
+
+    /// User's static fields (`id`/`name`/`email`/`anonymousId`) are as customer-controlled as `usrInfo` (both are
+    /// set through `Datadog.setUserInfo`), so they must count against the same shared byte budget.
+    private func sanitize(_ usr: RUMUser?, limits: inout Limits) -> RUMUser? {
+        guard let usr else {
+            return nil
+        }
+
+        var sanitized = RUMUser(
+            anonymousId: sanitize(staticField: usr.anonymousId, limits: &limits),
+            email: sanitize(staticField: usr.email, limits: &limits),
+            id: sanitize(staticField: usr.id, limits: &limits),
+            name: sanitize(staticField: usr.name, limits: &limits),
+            usrInfo: usr.usrInfo
+        )
+        sanitized.usrInfo = sanitize(attributes: usr.usrInfo, limits: &limits)
+        return sanitized
+    }
+
+    /// Account's static fields (`id`/`name`) are as customer-controlled as `accountInfo` (both are set through
+    /// `Datadog.setAccountInfo`), so they must count against the same shared byte budget. `id` is not optional on
+    /// `RUMAccount`, so it can't be dropped like the other static fields - it is still charged against the budget.
+    private func sanitize(_ account: RUMAccount?, limits: inout Limits) -> RUMAccount? {
+        guard let account else {
+            return nil
+        }
+
+        limits.remainingAttributeBytes -= min(account.id.utf8.count, max(limits.remainingAttributeBytes, 0))
+
+        var sanitized = RUMAccount(
+            id: account.id,
+            name: sanitize(staticField: account.name, limits: &limits),
+            accountInfo: account.accountInfo
+        )
+        sanitized.accountInfo = sanitize(attributes: account.accountInfo, limits: &limits)
+        return sanitized
+    }
+
+    private func sanitize(staticField value: String?, limits: inout Limits) -> String? {
+        guard let value else {
+            return nil
+        }
+        guard value.utf8.count <= limits.remainingAttributeBytes else {
+            limits.numberOfSizeLimitedAttributes += 1
+            return nil
+        }
+        limits.remainingAttributeBytes -= value.utf8.count
+        return value
     }
 
     private func sanitize(
@@ -332,10 +381,24 @@ private enum JSONAttributeSizeLimiter {
             }
             return .measurable
         case let value as NSNumber:
-            return value.doubleValue.isFinite ? .measurable : .unsupported
+            guard value.doubleValue.isFinite else {
+                return .unsupported
+            }
+            // Charge the number's own encoded size - a large array of small-but-real numbers must not pass the
+            // check cheaply just because the flat per-element charge above only accounts for structural overhead.
+            return inspection.consume(jsonEncodedByteCount(of: value)) ? .measurable : .limitExceeded
         default:
             return .unsupported
         }
+    }
+
+    /// A coarse (but safe) lower bound of the number of bytes `JSONSerialization` will write for this value,
+    /// without actually encoding it.
+    private static func jsonEncodedByteCount(of value: NSNumber) -> Int {
+        if CFGetTypeID(value) == CFBooleanGetTypeID() {
+            return value.boolValue ? 4 : 5 // "true" / "false"
+        }
+        return "\(value)".utf8.count
     }
 
     private static func applySnapshot(

--- a/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationReporterTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/WatchdogTerminations/WatchdogTerminationReporterTests.swift
@@ -75,4 +75,33 @@ final class WatchdogTerminationReporterTests: XCTestCase {
         XCTAssertEqual(usrInfoCount + accountInfoCount + contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes)
         XCTAssertEqual(contextInfoCount, AttributesSanitizer.Constraints.maxNumberOfAttributes - usrInfoCount - accountInfoCount, "`contextInfo` is removed first, then `account`, when the total exceeds the limit")
     }
+
+    func testSend_sanitizesOversizedRUMErrorAndViewAttributesBeforeWriting() throws {
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        var viewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
+        viewEvent.context = RUMEventAttributes(
+            contextInfo: [
+                "small": "value",
+                "large": String(repeating: "a", count: RUMEventSanitizer.maxTotalAttributeBytes),
+            ]
+        )
+        let reporter = WatchdogTerminationReporter(
+            featureScope: featureScope,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            uuidGenerator: RUMUUIDGeneratorMock()
+        )
+
+        reporter.send(
+            date: currentDate,
+            state: .mockWith(trackingConsent: .granted),
+            viewEvent: viewEvent
+        )
+
+        let sentRUMError = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMErrorEvent.self).first)
+        let sentRUMView = try XCTUnwrap(featureScope.eventsWritten(ofType: RUMViewEvent.self).first)
+        XCTAssertEqual(sentRUMError.context?.contextInfo["small"] as? String, "value")
+        XCTAssertNil(sentRUMError.context?.contextInfo["large"])
+        XCTAssertEqual(sentRUMView.context?.contextInfo["small"] as? String, "value")
+        XCTAssertNil(sentRUMView.context?.contextInfo["large"])
+    }
 }

--- a/DatadogRUM/Tests/RUMEvent/RUMEventSanitizerTests.swift
+++ b/DatadogRUM/Tests/RUMEvent/RUMEventSanitizerTests.swift
@@ -19,53 +19,54 @@ class RUMEventSanitizerTests: XCTestCase {
     private let vitalOperationStepEvent: RUMVitalOperationStepEvent = .mockRandom()
 
     func testWhenAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
-        var event = viewEvent
-        event.context = RUMEventAttributes(contextInfo: [
-            "attribute-one": mockValue(),
-            "attribute-one.two": mockValue(),
-            "attribute-one.two.three": mockValue(),
-            "attribute-one.two.three.four": mockValue(),
-            "attribute-one.two.three.four.five": mockValue(),
-            "attribute-one.two.three.four.five.six": mockValue(),
-            "attribute-one.two.three.four.five.six.seven": mockValue(),
-            "attribute-one.two.three.four.five.six.seven.eight": mockValue(),
-            "attribute-one.two.three.four.five.six.seven.eight.nine": mockValue(),
-            "attribute-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
-            "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
-            "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
-        ])
+        func test<Event>(event: Event) where Event: RUMSanitizableEvent {
+            var event = event
+            event.context?.contextInfo = [
+                "attribute-one": mockValue(),
+                "attribute-one.two": mockValue(),
+                "attribute-one.two.three": mockValue(),
+                "attribute-one.two.three.four": mockValue(),
+                "attribute-one.two.three.four.five": mockValue(),
+                "attribute-one.two.three.four.five.six": mockValue(),
+                "attribute-one.two.three.four.five.six.seven": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+            ]
 
-        event.usr = RUMUser(usrInfo: [
-            "user-info-one": mockValue(),
-            "user-info-one.two": mockValue(),
-            "user-info-one.two.three": mockValue(),
-            "user-info-one.two.three.four": mockValue(),
-            "user-info-one.two.three.four.five": mockValue(),
-            "user-info-one.two.three.four.five.six": mockValue(),
-            "user-info-one.two.three.four.five.six.seven": mockValue(),
-            "user-info-one.two.three.four.five.six.seven.eight": mockValue(),
-            "user-info-one.two.three.four.five.six.seven.eight.nine": mockValue(),
-            "user-info-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
-            "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
-            "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
-        ])
+            event.usr?.usrInfo = [
+                "user-info-one": mockValue(),
+                "user-info-one.two": mockValue(),
+                "user-info-one.two.three": mockValue(),
+                "user-info-one.two.three.four": mockValue(),
+                "user-info-one.two.three.four.five": mockValue(),
+                "user-info-one.two.three.four.five.six": mockValue(),
+                "user-info-one.two.three.four.five.six.seven": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+            ]
 
-        // When
-        let sanitized = RUMEventSanitizer().sanitize(event: event)
+            // When
+            let sanitized = RUMEventSanitizer().sanitize(event: event)
 
-        // Then
-        XCTAssertEqual(sanitized.context?.contextInfo.count, 12)
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
-        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
+            // Then
+            XCTAssertEqual(sanitized.context?.contextInfo.count, 12)
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
 
             XCTAssertEqual(sanitized.usr?.usrInfo.count, 12)
             XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one"])

--- a/DatadogRUM/Tests/RUMEvent/RUMEventSanitizerTests.swift
+++ b/DatadogRUM/Tests/RUMEvent/RUMEventSanitizerTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+import TestUtilities
 import DatadogInternal
 @testable import DatadogRUM
 
@@ -18,54 +19,53 @@ class RUMEventSanitizerTests: XCTestCase {
     private let vitalOperationStepEvent: RUMVitalOperationStepEvent = .mockRandom()
 
     func testWhenAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
-        func test<Event>(event: Event) where Event: RUMSanitizableEvent {
-            var event = event
-            event.context?.contextInfo = [
-                "attribute-one": mockValue(),
-                "attribute-one.two": mockValue(),
-                "attribute-one.two.three": mockValue(),
-                "attribute-one.two.three.four": mockValue(),
-                "attribute-one.two.three.four.five": mockValue(),
-                "attribute-one.two.three.four.five.six": mockValue(),
-                "attribute-one.two.three.four.five.six.seven": mockValue(),
-                "attribute-one.two.three.four.five.six.seven.eight": mockValue(),
-                "attribute-one.two.three.four.five.six.seven.eight.nine": mockValue(),
-                "attribute-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
-                "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
-                "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
-            ]
+        var event = viewEvent
+        event.context = RUMEventAttributes(contextInfo: [
+            "attribute-one": mockValue(),
+            "attribute-one.two": mockValue(),
+            "attribute-one.two.three": mockValue(),
+            "attribute-one.two.three.four": mockValue(),
+            "attribute-one.two.three.four.five": mockValue(),
+            "attribute-one.two.three.four.five.six": mockValue(),
+            "attribute-one.two.three.four.five.six.seven": mockValue(),
+            "attribute-one.two.three.four.five.six.seven.eight": mockValue(),
+            "attribute-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+            "attribute-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+            "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+            "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+        ])
 
-            event.usr?.usrInfo = [
-                "user-info-one": mockValue(),
-                "user-info-one.two": mockValue(),
-                "user-info-one.two.three": mockValue(),
-                "user-info-one.two.three.four": mockValue(),
-                "user-info-one.two.three.four.five": mockValue(),
-                "user-info-one.two.three.four.five.six": mockValue(),
-                "user-info-one.two.three.four.five.six.seven": mockValue(),
-                "user-info-one.two.three.four.five.six.seven.eight": mockValue(),
-                "user-info-one.two.three.four.five.six.seven.eight.nine": mockValue(),
-                "user-info-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
-                "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
-                "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
-            ]
+        event.usr = RUMUser(usrInfo: [
+            "user-info-one": mockValue(),
+            "user-info-one.two": mockValue(),
+            "user-info-one.two.three": mockValue(),
+            "user-info-one.two.three.four": mockValue(),
+            "user-info-one.two.three.four.five": mockValue(),
+            "user-info-one.two.three.four.five.six": mockValue(),
+            "user-info-one.two.three.four.five.six.seven": mockValue(),
+            "user-info-one.two.three.four.five.six.seven.eight": mockValue(),
+            "user-info-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+            "user-info-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+            "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+            "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+        ])
 
-            // When
-            let sanitized = RUMEventSanitizer().sanitize(event: event)
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
 
-            // Then
-            XCTAssertEqual(sanitized.context?.contextInfo.count, 12)
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
-            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
+        // Then
+        XCTAssertEqual(sanitized.context?.contextInfo.count, 12)
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
 
             XCTAssertEqual(sanitized.usr?.usrInfo.count, 12)
             XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one"])
@@ -133,9 +133,307 @@ class RUMEventSanitizerTests: XCTestCase {
         test(event: vitalOperationStepEvent)
     }
 
+    func testWhenTotalSizeOfAttributesExceedsLimit_itPreservesValidAttributesByPriority() throws {
+        // Four accepted attributes total 960 KiB, leaving enough room for the event envelope.
+        let value = String(repeating: "a", count: 240 * 1_024)
+        var event = viewEvent
+        event.usr = RUMUser(
+            usrInfo: [
+                "user-1": value,
+                "user-2": value,
+            ]
+        )
+        event.account = RUMAccount(
+            id: "account-id",
+            accountInfo: [
+                "account-1": value,
+                "account-2": value,
+            ]
+        )
+        event.context = RUMEventAttributes(
+            contextInfo: [
+                "context-1": value,
+                "context-2": value,
+            ]
+        )
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertEqual(sanitized.usr?.usrInfo.count, 2)
+        XCTAssertEqual(sanitized.account?.accountInfo.count, 2)
+        XCTAssertTrue(sanitized.context?.contextInfo.isEmpty == true)
+        XCTAssertLessThan(try JSONEncoder.dd.default().encode(sanitized).count, 1_024 * 1_024)
+    }
+
+    func testWhenInspectableNestedAttributeExceedsSizeLimit_itDropsOnlyThatAttributeAndLogsOneWarning() {
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        let largeAttribute = [
+            "values": [String(repeating: "a", count: RUMEventSanitizer.maxTotalAttributeBytes)]
+        ]
+        var event = viewEvent
+        event.usr = RUMUser(usrInfo: [:])
+        event.account = RUMAccount(id: "account-id", accountInfo: [:])
+        event.context = RUMEventAttributes(
+            contextInfo: [
+                "small": "value",
+                "large": largeAttribute,
+            ]
+        )
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertNotNil(sanitized.context?.contextInfo["small"])
+        XCTAssertNil(sanitized.context?.contextInfo["large"])
+        XCTAssertEqual(dd.logger.warnMessages.count, 1)
+        XCTAssertEqual(
+            dd.logger.warnLog?.message,
+            """
+            Size of RUM Event attributes exceeds the limit of \(RUMEventSanitizer.maxTotalAttributeBytes) bytes.
+            1 attribute(s) will be ignored.
+            """
+        )
+    }
+
+    func testWhenAnyCodableContainsOversizedNativeValue_itDropsTheAttribute() {
+        var event = viewEvent
+        event.usr = RUMUser(usrInfo: [:])
+        event.account = RUMAccount(id: "account-id", accountInfo: [:])
+        event.context = RUMEventAttributes(
+            contextInfo: [
+                "small": "value",
+                "large": AnyCodable([
+                    "value": String(
+                        repeating: "a",
+                        count: RUMEventSanitizer.maxTotalAttributeBytes
+                    )
+                ]),
+            ]
+        )
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertNotNil(sanitized.context?.contextInfo["small"])
+        XCTAssertNil(sanitized.context?.contextInfo["large"])
+    }
+
+    func testWhenNativeCollectionsContainUnsupportedFoundationValues_itDropsTheAttributes() {
+        var event = viewEvent
+        event.context = RUMEventAttributes(
+            contextInfo: [
+                "small": "value",
+                "date": AnyEncodable([Date()] as [Any?]),
+                "data": AnyEncodable([Data([0x00, 0xff, 0x42])] as [Any?]),
+                "url": AnyEncodable([URL(string: "https://example.com")!] as [Any?]),
+            ]
+        )
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertNotNil(sanitized.context?.contextInfo["small"])
+        XCTAssertNil(sanitized.context?.contextInfo["date"])
+        XCTAssertNil(sanitized.context?.contextInfo["data"])
+        XCTAssertNil(sanitized.context?.contextInfo["url"])
+    }
+
+    func testWhenNativeCollectionContainsUnknownEncodable_itDropsWithoutEncoding() {
+        final class EncodingSpy: Encodable {
+            private(set) var numberOfCalls = 0
+
+            func encode(to encoder: Encoder) throws {
+                numberOfCalls += 1
+                var container = encoder.singleValueContainer()
+                try container.encode("value")
+            }
+        }
+
+        let value = EncodingSpy()
+        let collection: [Any?] = [value]
+        var event = viewEvent
+        event.context = RUMEventAttributes(
+            contextInfo: [
+                "small": "value",
+                "unknown": AnyEncodable(collection),
+            ]
+        )
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertNotNil(sanitized.context?.contextInfo["small"])
+        XCTAssertNil(sanitized.context?.contextInfo["unknown"])
+        XCTAssertEqual(value.numberOfCalls, 0)
+    }
+
+    func testWhenAttributeIsMutableObjectiveCCollection_itPreservesAndEncodesTheAttribute() throws {
+        let dd = DD.mockWith(logger: CoreLoggerMock())
+        defer { dd.reset() }
+
+        let mutableArray = NSMutableArray(array: ["value"])
+        let mutableDictionary = NSMutableDictionary(dictionary: ["key": "value"])
+        var event = viewEvent
+        event.context = RUMEventAttributes(
+            contextInfo: [
+                "small": "value",
+                "mutable-array": AnyEncodable(mutableArray),
+                "mutable-dictionary": AnyEncodable(mutableDictionary),
+            ]
+        )
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+        mutableArray.add("later-value")
+        mutableDictionary["later-key"] = "later-value"
+        let encoded = try JSONEncoder.dd.default().encode(sanitized)
+
+        // Then
+        XCTAssertNotNil(sanitized.context?.contextInfo["small"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["mutable-array"])
+        XCTAssertNotNil(sanitized.context?.contextInfo["mutable-dictionary"])
+        XCTAssertEqual(
+            try contextAttribute(named: "mutable-array", in: encoded) as? NSArray,
+            ["value"]
+        )
+        XCTAssertEqual(
+            try contextAttribute(named: "mutable-dictionary", in: encoded) as? NSDictionary,
+            ["key": "value"]
+        )
+        XCTAssertTrue(dd.logger.warnMessages.isEmpty)
+    }
+
+    func testWhenEscapedStringExceedsEncodedSizeLimit_itDropsTheAttribute() {
+        var event = viewEvent
+        event.context = RUMEventAttributes(
+            contextInfo: [
+                "small": "value",
+                // Each quote occupies two bytes in encoded JSON.
+                "large": String(
+                    repeating: "\"",
+                    count: RUMEventSanitizer.maxTotalAttributeBytes / 2
+                ),
+            ]
+        )
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertNotNil(sanitized.context?.contextInfo["small"])
+        XCTAssertNil(sanitized.context?.contextInfo["large"])
+    }
+
+    func testWhenAttributeIsCustomEncodable_itLeavesItUnverifiedAndEncodesCustomerCodeOnlyOnce() throws {
+        final class MirrorCallSpy {
+            var wasCalled = false
+        }
+
+        final class StatefulAttribute: Encodable, CustomReflectable {
+            let mirrorCallSpy: MirrorCallSpy
+            private(set) var numberOfCalls = 0
+            private(set) var observedCodingPath: [String] = []
+
+            init(mirrorCallSpy: MirrorCallSpy) {
+                self.mirrorCallSpy = mirrorCallSpy
+            }
+
+            var customMirror: Mirror {
+                mirrorCallSpy.wasCalled = true
+                return Mirror(self, children: [:])
+            }
+
+            func encode(to encoder: Encoder) throws {
+                numberOfCalls += 1
+                observedCodingPath = encoder.codingPath.map { $0.stringValue }
+
+                var container = encoder.singleValueContainer()
+                if numberOfCalls == 1 {
+                    try container.encode(
+                        String(repeating: "a", count: RUMEventSanitizer.maxTotalAttributeBytes)
+                    )
+                } else {
+                    try container.encode("second-value")
+                }
+            }
+        }
+
+        let mirrorCallSpy = MirrorCallSpy()
+        let attribute = StatefulAttribute(mirrorCallSpy: mirrorCallSpy)
+        var event = viewEvent
+        event.usr = RUMUser(usrInfo: [:])
+        event.account = RUMAccount(id: "account-id", accountInfo: [:])
+        event.context = RUMEventAttributes(contextInfo: ["stateful": attribute])
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+        let encoded = try JSONEncoder.dd.default().encode(sanitized)
+
+        // Then
+        XCTAssertFalse(mirrorCallSpy.wasCalled)
+        XCTAssertEqual(attribute.numberOfCalls, 1)
+        XCTAssertEqual(attribute.observedCodingPath, ["context", "stateful"])
+        XCTAssertEqual(
+            (try contextAttribute(named: "stateful", in: encoded) as? String)?.utf8.count,
+            RUMEventSanitizer.maxTotalAttributeBytes
+        )
+    }
+
+    func testWhenAttributeIsCustomEncodable_itPreservesItsEncodedJSONValue() throws {
+        struct NestedValue: Encodable {
+            let name: String
+            let values: [Int]
+            let flags: [String: Bool]
+            let data: Data
+            let date: Date
+            let url: URL
+            let decimal: Decimal
+        }
+
+        let attribute = NestedValue(
+            name: "value",
+            values: [1, 2, 3],
+            flags: ["enabled": true, "disabled": false],
+            data: Data([0x00, 0xff, 0x42]),
+            date: Date(timeIntervalSince1970: 1_700_000_000),
+            url: URL(string: "path", relativeTo: URL(string: "https://example.com/base/"))!,
+            decimal: Decimal(string: "1234.5678")!
+        )
+        var event = viewEvent
+        event.usr = RUMUser(usrInfo: [:])
+        event.account = RUMAccount(id: "account-id", accountInfo: [:])
+        event.context = RUMEventAttributes(contextInfo: ["nested": attribute])
+
+        let original = try JSONEncoder.dd.default().encode(event)
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+        let encoded = try JSONEncoder.dd.default().encode(sanitized)
+
+        // Then
+        XCTAssertEqual(
+            try contextAttribute(named: "nested", in: encoded) as? NSDictionary,
+            try contextAttribute(named: "nested", in: original) as? NSDictionary
+        )
+    }
+
     // MARK: - Private
 
     private func mockValue() -> String {
         return .mockAny()
+    }
+
+    private func contextAttribute(named name: String, in data: Data) throws -> Any? {
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let context = try XCTUnwrap(object["context"] as? [String: Any])
+        return context[name]
     }
 }

--- a/DatadogRUM/Tests/RUMEvent/RUMEventSanitizerTests.swift
+++ b/DatadogRUM/Tests/RUMEvent/RUMEventSanitizerTests.swift
@@ -168,6 +168,65 @@ class RUMEventSanitizerTests: XCTestCase {
         XCTAssertLessThan(try JSONEncoder.dd.default().encode(sanitized).count, 1_024 * 1_024)
     }
 
+    func testWhenStaticUserOrAccountFieldExceedsSizeLimit_itDropsOnlyThatField() {
+        let oversizedValue = String(repeating: "a", count: RUMEventSanitizer.maxTotalAttributeBytes + 1)
+        var event = viewEvent
+        event.usr = RUMUser(email: oversizedValue, id: "user-id", usrInfo: ["info": "value"])
+        event.account = RUMAccount(id: "account-id", name: oversizedValue, accountInfo: [:])
+        event.context = RUMEventAttributes(contextInfo: [:])
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertNil(sanitized.usr?.email)
+        XCTAssertEqual(sanitized.usr?.id, "user-id")
+        XCTAssertNotNil(sanitized.usr?.usrInfo["info"])
+        XCTAssertEqual(sanitized.account?.id, "account-id", "`id` is not optional on `RUMAccount` so it can never be dropped")
+        XCTAssertNil(sanitized.account?.name)
+    }
+
+    func testWhenStaticUserAndAccountFieldsConsumeBudget_itLeavesLessRoomForOtherAttributes() {
+        // `usr.email` and `account.id` are as customer-controlled as `usrInfo`/`accountInfo`/`contextInfo`, so they
+        // must count against the same 1 MB shared budget - even though `email` is preserved (600 KiB fits) and
+        // `account.id` can never be dropped, both must still shrink the room left for the attributes that follow.
+        let largeValue = String(repeating: "a", count: 600 * 1_024)
+        var event = viewEvent
+        event.usr = RUMUser(email: largeValue, usrInfo: [:])
+        event.account = RUMAccount(id: largeValue, accountInfo: [:])
+        event.context = RUMEventAttributes(contextInfo: ["large": largeValue])
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertEqual(sanitized.usr?.email, largeValue)
+        XCTAssertEqual(sanitized.account?.id, largeValue)
+        XCTAssertTrue(sanitized.context?.contextInfo.isEmpty == true)
+    }
+
+    func testWhenNativeArrayContainsManyLargeNumbers_itIsRejectedWithoutExceedingTheByteBudget() {
+        // Charged by element count alone (1 byte/element), 100k numbers would look like ~100 KB - well within
+        // budget - even though each of these 18-digit numbers actually encodes to ~18 bytes, i.e. ~1.8 MB overall.
+        let numbers: [Any?] = Array(repeating: 123_456_789_012_345_678, count: 100_000)
+        var event = viewEvent
+        event.usr = RUMUser(usrInfo: [:])
+        event.account = RUMAccount(id: "account-id", accountInfo: [:])
+        event.context = RUMEventAttributes(
+            contextInfo: [
+                "small": "value",
+                "numbers": AnyEncodable(numbers),
+            ]
+        )
+
+        // When
+        let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+        // Then
+        XCTAssertNotNil(sanitized.context?.contextInfo["small"])
+        XCTAssertNil(sanitized.context?.contextInfo["numbers"])
+    }
+
     func testWhenInspectableNestedAttributeExceedsSizeLimit_itDropsOnlyThatAttributeAndLogsOneWarning() {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }

--- a/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMFeatureOperationManagerTests.swift
@@ -114,6 +114,20 @@ class RUMFeatureOperationManagerTests: XCTestCase {
         XCTAssertEqual(event.context?.contextInfo.count, AttributesSanitizer.Constraints.maxNumberOfAttributes)
     }
 
+    func testFeatureOperationCommand_sanitizesOversizedContextAttributesBeforeWriting() throws {
+        let attributes = [
+            "small": "value",
+            "large": String(repeating: "a", count: RUMEventSanitizer.maxTotalAttributeBytes),
+        ]
+        let command: RUMOperationStepVitalCommand = .mockWith(attributes: attributes)
+
+        manager.process(command, context: mockContext, writer: mockWriter, activeView: .mockAny())
+
+        let event = try XCTUnwrap(mockWriter.events(ofType: RUMVitalOperationStepEvent.self).first)
+        XCTAssertEqual(event.context?.contextInfo["small"] as? String, "value")
+        XCTAssertNil(event.context?.contextInfo["large"])
+    }
+
     func testFeatureOperationCommand_sendsOperationMessageWithServerTimeOffset() throws {
         // Given
         let featureScope = FeatureScopeMock()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMAppLaunchManagerTests.swift
@@ -120,6 +120,22 @@ final class RUMAppLaunchManagerTests: XCTestCase {
         XCTAssertEqual(event.context?.contextInfo.count, AttributesSanitizer.Constraints.maxNumberOfAttributes)
     }
 
+    func testTTIDCommand_sanitizesOversizedContextAttributesBeforeWriting() throws {
+        let command: RUMTimeToInitialDisplayCommand = .mockWith(
+            time: mockContext.launchInfo.processLaunchDate.addingTimeInterval(1),
+            attributes: [
+                "small": "value",
+                "large": String(repeating: "a", count: RUMEventSanitizer.maxTotalAttributeBytes),
+            ]
+        )
+
+        manager.process(command, context: mockContext, writer: mockWriter)
+
+        let event = try XCTUnwrap(mockWriter.events(ofType: RUMVitalAppLaunchEvent.self).first)
+        XCTAssertEqual(event.context?.contextInfo["small"] as? String, "value")
+        XCTAssertNil(event.context?.contextInfo["large"])
+    }
+
     func testTTIDCommand_appliesServerTimeOffsetToAppLaunchEventAndProfilerMessage() throws {
         // Given
         let featureScope = FeatureScopeMock()


### PR DESCRIPTION
### What and why?

This PR prevents oversized RUM custom attributes from reaching `JSONEncoder`, where Foundation may abort the application while growing its serialization buffer.

Custom attributes from user, account and event context share a 1MB size budget. Attributes that exceed the available budget (256 attributes per event) are discarded while the rest of the event is preserved.

### How?

`RUMEventSanitizer` measures custom attributes that can be represented as native JSON values. For each user, account or context attribute dictionary, supported attributes are first measured together against the remaining shared budget. If that dictionary does not fit, the sanitizer evaluates its attributes separately so that only those exceeding the available space are discarded. A warning is logged when attributes are removed.

Clearly oversized values are discarded before asking Foundation to serialize them. Native collections containing unsupported values are also discarded because their encoded size cannot be determined reliably.

Arbitrary `Encodable` values remain unverified so customer encoding code is not invoked twice. For mutable Foundation collections, the sanitizer preserves the representation that was measured so it cannot change before final encoding.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
