### PR TITLE
Prepare feature branch for merging into develop.

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		095AE9592F7D4E9F00C332AE /* SamplingDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095AE9522F7D4E9F00C332AE /* SamplingDecision.swift */; };
 		095AE95A2F7D4E9F00C332AE /* SamplerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095AE9532F7D4E9F00C332AE /* SamplerProvider.swift */; };
 		09977EB62FB4DB6300AC9361 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09977EB52FB4DB6300AC9361 /* Feature.swift */; };
-		099CD2993029FF52003F8C74 /* NotificationCenters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099CD2983029FF52003F8C74 /* NotificationCenters.swift */; };
+		099CD2993029FF52003F8C74 /* NotificationCenterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099CD2983029FF52003F8C74 /* NotificationCenterProvider.swift */; };
 		09A936A02F0EB989000B6379 /* SamplingMechanismType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A9369A2F0EB989000B6379 /* SamplingMechanismType.swift */; };
 		09A936A12F0EB989000B6379 /* SamplingPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A9369B2F0EB989000B6379 /* SamplingPriority.swift */; };
 		09A936A22F0EB989000B6379 /* SpanContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A9369C2F0EB989000B6379 /* SpanContext.swift */; };
@@ -1925,7 +1925,7 @@
 		095AE9532F7D4E9F00C332AE /* SamplerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplerProvider.swift; sourceTree = "<group>"; };
 		095AE9542F7D4E9F00C332AE /* TracerSamplerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracerSamplerProvider.swift; sourceTree = "<group>"; };
 		09977EB52FB4DB6300AC9361 /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
-		099CD2983029FF52003F8C74 /* NotificationCenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenters.swift; sourceTree = "<group>"; };
+		099CD2983029FF52003F8C74 /* NotificationCenterProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterProvider.swift; sourceTree = "<group>"; };
 		09A9369A2F0EB989000B6379 /* SamplingMechanismType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplingMechanismType.swift; sourceTree = "<group>"; };
 		09A9369B2F0EB989000B6379 /* SamplingPriority.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplingPriority.swift; sourceTree = "<group>"; };
 		09A9369C2F0EB989000B6379 /* SpanContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanContext.swift; sourceTree = "<group>"; };
@@ -6533,7 +6533,7 @@
 				D23039AD298D5234001A1FA3 /* DD.swift */,
 				091E808D2FF289FC00457606 /* DDPlatformTypes.swift */,
 				09977EB52FB4DB6300AC9361 /* Feature.swift */,
-				099CD2983029FF52003F8C74 /* NotificationCenters.swift */,
+				099CD2983029FF52003F8C74 /* NotificationCenterProvider.swift */,
 				3C08F9CF2C2D652D002B0FF2 /* Storage.swift */,
 				D23039CA298D5235001A1FA3 /* Attributes */,
 				6167E6FB2B81EBD100C3CA2D /* BacktraceReporting */,
@@ -9216,7 +9216,7 @@
 				3C0D5DD72A543B3B00446CF9 /* Event.swift in Sources */,
 				D2D7482B2DC1214100C61353 /* LogEventAttributes.swift in Sources */,
 				3CBDE68A2AA0C47300F6A7B6 /* URLSessionTask+Tracking.swift in Sources */,
-				099CD2993029FF52003F8C74 /* NotificationCenters.swift in Sources */,
+				099CD2993029FF52003F8C74 /* NotificationCenterProvider.swift in Sources */,
 				D270CDDD2B46E3DB0002EACD /* URLSessionDataDelegateSwizzler.swift in Sources */,
 				1166C59E2F76D840008E34BC /* TTIDMessage.swift in Sources */,
 				D22F06D929DAFD500026CC3C /* TimeInterval+Convenience.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		09C2D45430063F3E00BD5CF1 /* MacOSApplicationStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C2D45330063F3E00BD5CF1 /* MacOSApplicationStateProvider.swift */; };
 		09D2859B3029CCCF00CA8AE5 /* NSWorkspace+AppStateUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2859A3029CCBB00CA8AE5 /* NSWorkspace+AppStateUtilities.swift */; };
 		09D2859D3029CD3100CA8AE5 /* NSRunningApplication+AppStateUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2859C3029CD3100CA8AE5 /* NSRunningApplication+AppStateUtilities.swift */; };
+		09E5009E30333743003E67A6 /* DDPlatformTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E5009D30333743003E67A6 /* DDPlatformTypes.swift */; };
+		09E500A030333D0D003E67A6 /* DDCoreTestPlatformTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E5009F30333D0D003E67A6 /* DDCoreTestPlatformTypes.swift */; };
+		09E500A130333D0D003E67A6 /* DDCoreTestPlatformTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E5009F30333D0D003E67A6 /* DDCoreTestPlatformTypes.swift */; };
 		09EC863F2FD30D4B00F40087 /* OTTagValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EC863E2FD30D4B00F40087 /* OTTagValue.swift */; };
 		09F1DC8E302B1D0100BE2471 /* AppStateProvider_macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F1DC8D302B1D0100BE2471 /* AppStateProvider_macOS.swift */; };
 		09F1DC90302B1D4800BE2471 /* AppStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F1DC8F302B1D4800BE2471 /* AppStateProvider.swift */; };
@@ -273,10 +276,10 @@
 		1434A4662B7F8D880072E3BB /* DebugOTelTracingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1434A4652B7F8D880072E3BB /* DebugOTelTracingViewController.swift */; };
 		144CDB9AFBDFF0B7EB10B4A3 /* EvaluationAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA681535D980BA99B12659B /* EvaluationAggregatorTests.swift */; };
 		17EFC9D8185942399E05BDB4 /* OcclusionMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2ED47E396E4030BF5D0469 /* OcclusionMapTests.swift */; };
+		1D6C3C99D788AF6D8ED50979 /* DisallowList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */; };
 		261255872E2167E40015042B /* BaggageHeaderMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255862E2167E40015042B /* BaggageHeaderMerger.swift */; };
 		2612558B2E2167F10015042B /* BaggageHeaderMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */; };
 		261255952E2167F10015042B /* HeaderProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255932E2167F10015042B /* HeaderProcessorTests.swift */; };
-		479539F3F9AC61238ACF3D6C /* DisallowListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B9C6954A07274919E80B5E /* DisallowListTests.swift */; };
 		265496D42D81C5B10094B6E2 /* RUMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265496D22D81C5AE0094B6E2 /* RUMAccount.swift */; };
 		266BFA5E2D6F4E31003041A5 /* AccountInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266BFA5D2D6F4E2A003041A5 /* AccountInfoPublisherTests.swift */; };
 		2671348E2D688AD60048CB54 /* AccountInfoPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2671348C2D688ACD0048CB54 /* AccountInfoPublisher.swift */; };
@@ -342,6 +345,7 @@
 		3CFF4FA42C0E0FE8006F191D /* WatchdogTerminationCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF4FA32C0E0FE5006F191D /* WatchdogTerminationCheckerTests.swift */; };
 		3CFF5D492B555F4F00FC483A /* OTelTracerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CFF5D482B555F4F00FC483A /* OTelTracerProvider.swift */; };
 		4062CCAEB02C9EEF6761F4F8 /* HeatmapIdentifierStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E553EF33633FBFBB288899 /* HeatmapIdentifierStore.swift */; };
+		479539F3F9AC61238ACF3D6C /* DisallowListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B9C6954A07274919E80B5E /* DisallowListTests.swift */; };
 		49274906288048B500ECD49B /* InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalProxyTests.swift */; };
 		49D8C0B72AC5D2160075E427 /* RUM+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B62AC5D2160075E427 /* RUM+Internal.swift */; };
 		49D8C0BD2AC5F2BB0075E427 /* Logs+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D8C0B92AC5F21F0075E427 /* Logs+Internal.swift */; };
@@ -1232,7 +1236,6 @@
 		D29D1CCE2F6067AB0085574B /* UIScrollViewSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001012A000003000A0001 /* UIScrollViewSwizzler.swift */; };
 		D29D1CCF2F6067BF0085574B /* UIScrollViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001012A000005000A0001 /* UIScrollViewHandler.swift */; };
 		D29D1CD02F6067D20085574B /* HeaderProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261255902E2167E40015042B /* HeaderProcessor.swift */; };
-		1D6C3C99D788AF6D8ED50979 /* DisallowList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */; };
 		D29D1CD12F6068820085574B /* DataStoreAsyncMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119F75F32F438C2100845833 /* DataStoreAsyncMock.swift */; };
 		D29D3A272F3E2D5C00863C5C /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; };
 		D29D3A282F3E2D5C00863C5C /* DatadogFlags.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8C2ED2E784B3C00B1DA80 /* DatadogFlags.framework */; };
@@ -1930,6 +1933,8 @@
 		09C2D45330063F3E00BD5CF1 /* MacOSApplicationStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSApplicationStateProvider.swift; sourceTree = "<group>"; };
 		09D2859A3029CCBB00CA8AE5 /* NSWorkspace+AppStateUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWorkspace+AppStateUtilities.swift"; sourceTree = "<group>"; };
 		09D2859C3029CD3100CA8AE5 /* NSRunningApplication+AppStateUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRunningApplication+AppStateUtilities.swift"; sourceTree = "<group>"; };
+		09E5009D30333743003E67A6 /* DDPlatformTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDPlatformTypes.swift; sourceTree = "<group>"; };
+		09E5009F30333D0D003E67A6 /* DDCoreTestPlatformTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCoreTestPlatformTypes.swift; sourceTree = "<group>"; };
 		09EC863E2FD30D4B00F40087 /* OTTagValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTTagValue.swift; sourceTree = "<group>"; };
 		09F1DC8D302B1D0100BE2471 /* AppStateProvider_macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateProvider_macOS.swift; sourceTree = "<group>"; };
 		09F1DC8F302B1D4800BE2471 /* AppStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateProvider.swift; sourceTree = "<group>"; };
@@ -2127,13 +2132,12 @@
 		11F59BC02EAE2180009F8579 /* LaunchInfoPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchInfoPublisher.swift; sourceTree = "<group>"; };
 		1434A4652B7F8D880072E3BB /* DebugOTelTracingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugOTelTracingViewController.swift; sourceTree = "<group>"; };
 		1A9F4D5BEEE5E977A58E2034 /* HeatmapIdentifierRegistryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapIdentifierRegistryFeature.swift; sourceTree = "<group>"; };
+		1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisallowList.swift; sourceTree = "<group>"; };
 		1E03E4DD559B4F63BD5A292E /* ProfilingConditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingConditionsTests.swift; sourceTree = "<group>"; };
 		261255862E2167E40015042B /* BaggageHeaderMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggageHeaderMerger.swift; sourceTree = "<group>"; };
 		261255892E2167F10015042B /* BaggageHeaderMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggageHeaderMergerTests.swift; sourceTree = "<group>"; };
 		261255902E2167E40015042B /* HeaderProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderProcessor.swift; sourceTree = "<group>"; };
-		1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisallowList.swift; sourceTree = "<group>"; };
 		261255932E2167F10015042B /* HeaderProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderProcessorTests.swift; sourceTree = "<group>"; };
-		66B9C6954A07274919E80B5E /* DisallowListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisallowListTests.swift; sourceTree = "<group>"; };
 		265496D22D81C5AE0094B6E2 /* RUMAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAccount.swift; sourceTree = "<group>"; };
 		266BFA5D2D6F4E2A003041A5 /* AccountInfoPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoPublisherTests.swift; sourceTree = "<group>"; };
 		2671348C2D688ACD0048CB54 /* AccountInfoPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfoPublisher.swift; sourceTree = "<group>"; };
@@ -2766,6 +2770,7 @@
 		61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutputTests.swift; sourceTree = "<group>"; };
 		61FF9A4425AC5DEA001058CC /* ViewIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewIdentifier.swift; sourceTree = "<group>"; };
 		6482FB0D2EE885C20042234B /* FlagsClientInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsClientInternal.swift; sourceTree = "<group>"; };
+		66B9C6954A07274919E80B5E /* DisallowListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisallowListTests.swift; sourceTree = "<group>"; };
 		6FE4202BC457504AC37A51D6 /* HeatmapIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapIdentifier.swift; sourceTree = "<group>"; };
 		759200012FD2000100000001 /* CALayerSnapshotImageSnapshotRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayerSnapshotImageSnapshotRequestTests.swift; sourceTree = "<group>"; };
 		759200032FD2000100000001 /* CALayerSnapshot+ImageSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayerSnapshot+ImageSnapshot.swift"; sourceTree = "<group>"; };
@@ -3635,6 +3640,7 @@
 				1182F9C32DA2F827007FE71A /* TestsDirectory.swift */,
 				1182F9C42DA2F827007FE71A /* UIKitHelpers.swift */,
 				1182F9C52DA2F827007FE71A /* XCTestCase.swift */,
+				09E5009D30333743003E67A6 /* DDPlatformTypes.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -3946,28 +3952,12 @@
 			path = HeaderCapture;
 			sourceTree = "<group>";
 		};
-		F36014A6B87B685CB54DD26F /* DisallowList */ = {
-			isa = PBXGroup;
-			children = (
-				1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */,
-			);
-			path = DisallowList;
-			sourceTree = "<group>";
-		};
 		261255972E2167F10015042B /* HeaderCapture */ = {
 			isa = PBXGroup;
 			children = (
 				261255932E2167F10015042B /* HeaderProcessorTests.swift */,
 			);
 			path = HeaderCapture;
-			sourceTree = "<group>";
-		};
-		F5627932F2D7852661CA308B /* DisallowList */ = {
-			isa = PBXGroup;
-			children = (
-				66B9C6954A07274919E80B5E /* DisallowListTests.swift */,
-			);
-			path = DisallowList;
 			sourceTree = "<group>";
 		};
 		3C4CF9932C47BE10006DE1C0 /* MemoryWarnings */ = {
@@ -4994,6 +4984,7 @@
 				3CCCA5C62ABAF5230029D7BD /* DDURLSessionInstrumentationConfigurationTests.swift */,
 				61D03BDE273404BB00367DE0 /* RUM */,
 				F603F1282CAEA4E90088E6B7 /* DDInternalLoggerTests.swift */,
+				09E5009F30333D0D003E67A6 /* DDCoreTestPlatformTypes.swift */,
 			);
 			path = Objc;
 			sourceTree = "<group>";
@@ -7288,6 +7279,22 @@
 			path = Heatmaps;
 			sourceTree = "<group>";
 		};
+		F36014A6B87B685CB54DD26F /* DisallowList */ = {
+			isa = PBXGroup;
+			children = (
+				1B1CAD82E7949DB6D771DF05 /* DisallowList.swift */,
+			);
+			path = DisallowList;
+			sourceTree = "<group>";
+		};
+		F5627932F2D7852661CA308B /* DisallowList */ = {
+			isa = PBXGroup;
+			children = (
+				66B9C6954A07274919E80B5E /* DisallowListTests.swift */,
+			);
+			path = DisallowList;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -8511,6 +8518,7 @@
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,
 				618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */,
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
+				09E500A030333D0D003E67A6 /* DDCoreTestPlatformTypes.swift in Sources */,
 				61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */,
 				D2EFA875286E011900F1FAA6 /* DatadogContextProviderTests.swift in Sources */,
 				61363D9F24D99BAA0084CD6F /* DDErrorTests.swift in Sources */,
@@ -9246,6 +9254,7 @@
 				1182FA2E2DA2F827007FE71A /* CoreTelephonyMocks.swift in Sources */,
 				1182FA302DA2F827007FE71A /* HostsSanitizerMock.swift in Sources */,
 				1182FA312DA2F827007FE71A /* Encoding.swift in Sources */,
+				09E5009E30333743003E67A6 /* DDPlatformTypes.swift in Sources */,
 				11B8F33C2F588DE300747321 /* VitalMock.swift in Sources */,
 				1182FA322DA2F827007FE71A /* BinaryImageMocks.swift in Sources */,
 				1182FA332DA2F827007FE71A /* JSONDataMatcher.swift in Sources */,
@@ -9266,6 +9275,7 @@
 				1182FA3F2DA2F827007FE71A /* NetworkInstrumentationMocks.swift in Sources */,
 				1182FA402DA2F827007FE71A /* KronosClockMock.swift in Sources */,
 				1182FA412DA2F827007FE71A /* QueueMocks.swift in Sources */,
+				09E500A130333D0D003E67A6 /* DDCoreTestPlatformTypes.swift in Sources */,
 				1182FA422DA2F827007FE71A /* LogMatcher.swift in Sources */,
 				1182FA432DA2F827007FE71A /* ModuleName.swift in Sources */,
 				1182FA442DA2F827007FE71A /* DDAssert.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
+++ b/Datadog/IntegrationUnitTests/AppRunner/AppRunner.swift
@@ -124,14 +124,14 @@ internal class AppRunner {
 
     /// Cleans up and resets the test environment.
     func tearDown() {
-        appStateObservers.forEach { notificationCenters.removeObserver($0) }
+        appStateObservers.forEach { notificationCenterProvider.removeObserver($0) }
         appStateObservers = []
 
         DeleteTemporaryDirectory()
 
         appDirectory = nil
         processInfo = nil
-        notificationCenters = nil
+        notificationCenterProvider = nil
         dateProvider = nil
         appStateProvider = nil
         appLaunchHandler = nil
@@ -141,7 +141,7 @@ internal class AppRunner {
     // swiftlint:disable implicitly_unwrapped_optional
     private var appDirectory: (() -> Directory)!
     private var processInfo: ProcessInfoMock!
-    private var notificationCenters: NotificationCenters!
+    private var notificationCenterProvider: NotificationCenterProvider!
     private var dateProvider: DateProviderMock!
     private var appStateProvider: AppStateProviderMock!
     private var appLaunchHandler: AppLaunchHandlerMock!
@@ -158,7 +158,7 @@ internal class AppRunner {
     func launch(_ launchType: ProcessLaunchType) {
         appDirectory = { Directory(url: temporaryDirectory) }
         processInfo = ProcessInfoMock(environment: launchType.processInfoEnvironment)
-        notificationCenters = Self.makeTestNotificationCenters()
+        notificationCenterProvider = Self.makeTestNotificationCenterProvider()
         dateProvider = DateProviderMock(now: launchType.processLaunchDate)
         appStateProvider = AppStateProviderMock(state: launchType.initialAppState)
         appLaunchHandler = AppLaunchHandlerMock(
@@ -169,7 +169,7 @@ internal class AppRunner {
         )
 
         appStateObservers = [
-            notificationCenters.applicationCenter.addObserver(forName: ApplicationNotifications.didBecomeActive, object: nil, queue: .main) { [weak self] _ in
+            notificationCenterProvider.applicationCenter.addObserver(forName: ApplicationNotifications.didBecomeActive, object: nil, queue: .main) { [weak self] _ in
                 guard let self else {
                     return
                 }
@@ -181,17 +181,17 @@ internal class AppRunner {
                     self.appLaunchHandler.simulateDidBecomeActive(date: self.dateProvider.now)
                 }
             },
-            notificationCenters.applicationCenter.addObserver(forName: ApplicationNotifications.willResignActive, object: nil, queue: .main) { [weak self] _ in
+            notificationCenterProvider.applicationCenter.addObserver(forName: ApplicationNotifications.willResignActive, object: nil, queue: .main) { [weak self] _ in
                 runOnMainThreadSync {
                     self?.appStateProvider.current = .inactive
                 }
             },
-            notificationCenters.applicationCenter.addObserver(forName: ApplicationNotifications.didEnterBackground, object: nil, queue: .main) { [weak self] _ in
+            notificationCenterProvider.applicationCenter.addObserver(forName: ApplicationNotifications.didEnterBackground, object: nil, queue: .main) { [weak self] _ in
                 runOnMainThreadSync {
                     self?.appStateProvider.current = .background
                 }
             },
-            notificationCenters.applicationCenter.addObserver(forName: ApplicationNotifications.willEnterForeground, object: nil, queue: .main) { [weak self] _ in
+            notificationCenterProvider.applicationCenter.addObserver(forName: ApplicationNotifications.willEnterForeground, object: nil, queue: .main) { [weak self] _ in
                 runOnMainThreadSync {
                     self?.appStateProvider.current = .inactive
                 }
@@ -199,11 +199,11 @@ internal class AppRunner {
         ]
     }
 
-    private static func makeTestNotificationCenters() -> NotificationCenters {
+    private static func makeTestNotificationCenterProvider() -> NotificationCenterProvider {
         #if os(macOS)
-        NotificationCenters(applicationCenter: NotificationCenter(), workspaceCenter: NotificationCenter())
+        NotificationCenterProvider(applicationCenter: NotificationCenter(), workspaceCenter: NotificationCenter())
         #else
-        NotificationCenters(applicationCenter: NotificationCenter())
+        NotificationCenterProvider(applicationCenter: NotificationCenter())
         #endif
     }
 
@@ -211,18 +211,18 @@ internal class AppRunner {
     func transitionToActive() {
         precondition(currentState != .active, "The app is already ACTIVE")
         if currentState != .inactive { // apps do not send "will enter foreground" when in INACTIVE
-            notificationCenters.applicationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
+            notificationCenterProvider.applicationCenter.post(name: ApplicationNotifications.willEnterForeground, object: nil)
         }
-        notificationCenters.applicationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+        notificationCenterProvider.applicationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
     }
 
     /// Simulates transition to the background state.
     func transitionToBackground() {
         precondition(currentState != .background, "The app is already in BACKGROUND")
         if currentState != .inactive { // apps do not send "will resign active" when in INACTIVE
-            notificationCenters.applicationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
+            notificationCenterProvider.applicationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
         }
-        notificationCenters.applicationCenter.post(name: ApplicationNotifications.didEnterBackground, object: nil)
+        notificationCenterProvider.applicationCenter.post(name: ApplicationNotifications.didEnterBackground, object: nil)
     }
 
     /// Returns the current simulated app state.
@@ -276,7 +276,7 @@ internal class AppRunner {
         config.systemDirectory = appDirectory
         config.processInfo = processInfo
         config.dateProvider = dateProvider
-        config.notificationCenters = notificationCenters
+        config.notificationCenterProvider = notificationCenterProvider
         config.appLaunchHandler = appLaunchHandler
         config.appStateProvider = appStateProvider
         config.serverDateProvider = ServerDateProviderMock()
@@ -300,7 +300,7 @@ internal class AppRunner {
         var config = RUM.Configuration(applicationID: "mock-application-id")
         config.dateProvider = dateProvider
         config.mediaTimeProvider = MediaTimeProviderMock(current: 0)
-        config.notificationCenter = notificationCenters.applicationCenter
+        config.notificationCenter = notificationCenterProvider.applicationCenter
         #if !os(watchOS)
         config.frameInfoProviderFactory = { [weak self] in
             let frameInfoProvider = FrameInfoProviderMock(target: $0, selector: $1)
@@ -329,7 +329,7 @@ internal class AppRunner {
     }
 }
 
-fileprivate extension NotificationCenters {
+fileprivate extension NotificationCenterProvider {
     func removeObserver(_ observer: Any) {
         #if os(macOS)
         applicationCenter.removeObserver(observer)

--- a/DatadogCore/Sources/Core/DatadogCore.swift
+++ b/DatadogCore/Sources/Core/DatadogCore.swift
@@ -513,7 +513,7 @@ extension DatadogContextProvider {
         processInfo: ProcessInfo,
         dateProvider: DateProvider,
         serverDateProvider: ServerDateProvider,
-        notificationCenters: NotificationCenters,
+        notificationCenterProvider: NotificationCenterProvider,
         appLaunchHandler: AppLaunchHandling,
         appStateProvider: AppStateProvider
     ) {
@@ -561,37 +561,37 @@ extension DatadogContextProvider {
         subscribe(
             \.batteryStatus,
              to: BatteryStatusPublisher(
-                notificationCenter: notificationCenters.applicationCenter,
+                notificationCenter: notificationCenterProvider.applicationCenter,
                 device: .current
              )
         )
         subscribe(
             \.isLowPowerModeEnabled,
              to: LowPowerModePublisher(
-                notificationCenter: notificationCenters.applicationCenter,
+                notificationCenter: notificationCenterProvider.applicationCenter,
                 processInfo: processInfo
              )
         )
         #endif
 
         #if os(iOS)
-        subscribe(\.brightnessLevel, to: BrightnessLevelPublisher(notificationCenter: notificationCenters.applicationCenter))
+        subscribe(\.brightnessLevel, to: BrightnessLevelPublisher(notificationCenter: notificationCenterProvider.applicationCenter))
         #endif
 
-        subscribe(\.localeInfo, to: LocaleInfoPublisher(initialLocale: locale, notificationCenter: notificationCenters.applicationCenter))
+        subscribe(\.localeInfo, to: LocaleInfoPublisher(initialLocale: locale, notificationCenter: notificationCenterProvider.applicationCenter))
 
         #if os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
         let applicationStatePublisher = ApplicationStatePublisher(
             appStateHistory: appStateHistory,
-            notificationCenter: notificationCenters.applicationCenter,
+            notificationCenter: notificationCenterProvider.applicationCenter,
             dateProvider: dateProvider
         )
         self.subscribe(\.applicationStateHistory, to: applicationStatePublisher)
         #elseif os(macOS)
         let applicationStatePublisher = ApplicationStatePublisher(
             appStateHistory: appStateHistory,
-            applicationNotificationCenter: notificationCenters.applicationCenter,
-            workspaceNotificationCenter: notificationCenters.workspaceCenter,
+            applicationNotificationCenter: notificationCenterProvider.applicationCenter,
+            workspaceNotificationCenter: notificationCenterProvider.workspaceCenter,
             applicationStateProvider: DefaultMacOSApplicationStateProvider(),
             dateProvider: dateProvider
         )

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -253,6 +253,10 @@ public enum Datadog {
         consolePrint("⚠️ Catalyst is not officially supported by Datadog SDK: some features may NOT be functional!", .warn)
         #endif
 
+        #if os(macOS)
+        consolePrint("⚠️ macOS is not officially supported by Datadog SDK: some features may NOT be functional!", .warn)
+        #endif
+
         do {
             // To safely instrument the application lifecycle observer and other providers,
             // SDK initialization must occur on the main thread. This enforcement is also present

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -452,7 +452,7 @@ extension DatadogCore {
                 processInfo: configuration.processInfo,
                 dateProvider: configuration.dateProvider,
                 serverDateProvider: configuration.serverDateProvider,
-                notificationCenters: configuration.notificationCenters,
+                notificationCenterProvider: configuration.notificationCenterProvider,
                 appLaunchHandler: configuration.appLaunchHandler,
                 appStateProvider: configuration.appStateProvider
             ),

--- a/DatadogCore/Sources/DatadogConfiguration.swift
+++ b/DatadogCore/Sources/DatadogConfiguration.swift
@@ -220,8 +220,8 @@ extension Datadog {
             URLSessionClient(proxyConfiguration: proxyConfiguration)
         }
 
-        /// The default notification center used for subscribing to app lifecycle events and system notifications.
-        internal var notificationCenters: NotificationCenters = .default
+        /// Provides notification centers used for subscribing to app lifecycle events and system notifications.
+        internal var notificationCenterProvider: NotificationCenterProvider = .default
 
         /// The default app launch handler for tracking application startup time.
         internal var appLaunchHandler: AppLaunchHandling = AppLaunchHandler.shared

--- a/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogConfigurationTests.swift
@@ -357,7 +357,12 @@ class DatadogConfigurationTests: XCTestCase {
                 trackingConsent: .mockRandom()
             )
             defer { Datadog.flushAndDeinitialize() }
+            #if os(macOS)
+            // Temporary, will be removed when we're ready!
+            XCTAssertEqual(printFunction.printedMessage, "⚠️ macOS is not officially supported by Datadog SDK: some features may NOT be functional!")
+            #else
             XCTAssertNil(printFunction.printedMessage)
+            #endif
         }
 
         func verify(invalidEnv env: String) {

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalCPUReaderTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalCPUReaderTests.swift
@@ -10,11 +10,11 @@ import DatadogInternal
 
 class VitalCPUReaderTest: XCTestCase {
     #if os(macOS)
-    let testNotificationCenters = NotificationCenters(applicationCenter: NotificationCenter(), workspaceCenter: NotificationCenter())
+    let testNotificationCenterProvider = NotificationCenterProvider(applicationCenter: NotificationCenter(), workspaceCenter: NotificationCenter())
     #else
-    let testNotificationCenters = NotificationCenters(applicationCenter: NotificationCenter())
+    let testNotificationCenterProvider = NotificationCenterProvider(applicationCenter: NotificationCenter())
     #endif
-    lazy var cpuReader = VitalCPUReader(notificationCenters: testNotificationCenters)
+    lazy var cpuReader = VitalCPUReader(notificationCenterProvider: testNotificationCenterProvider)
 
     func testWhenCPUUnderHeavyLoadItMeasuresHigherCPUTicks() throws {
         let repetitions = 3
@@ -45,16 +45,16 @@ class VitalCPUReaderTest: XCTestCase {
     func testWhenInactiveAppStateItIgnoresCPUTicks() throws {
         let baseline = try XCTUnwrap(cpuReader.readVitalData())
         #if os(macOS)
-        testNotificationCenters.workspaceCenter.post(name: WorkspaceNotifications.willSleep, object: nil)
+        testNotificationCenterProvider.workspaceCenter.post(name: WorkspaceNotifications.willSleep, object: nil)
         #else
-        testNotificationCenters.applicationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
+        testNotificationCenterProvider.applicationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
         #endif
         heavyLoad()
         let measurementWhenInactive = try XCTUnwrap(cpuReader.readVitalData())
         #if os(macOS)
-        testNotificationCenters.workspaceCenter.post(name: WorkspaceNotifications.didWake, object: nil)
+        testNotificationCenterProvider.workspaceCenter.post(name: WorkspaceNotifications.didWake, object: nil)
         #else
-        testNotificationCenters.applicationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
+        testNotificationCenterProvider.applicationCenter.post(name: ApplicationNotifications.didBecomeActive, object: nil)
         #endif
         heavyLoad()
         let measurementWhenActive = try XCTUnwrap(cpuReader.readVitalData())
@@ -70,7 +70,7 @@ class VitalCPUReaderTest: XCTestCase {
         let tickWhenResigningActive = UInt32.max - 10
         let tickAfterRollover: UInt32 = 20
         let cpuReader = VitalCPUReaderMock(
-            notificationCenters: testNotificationCenters,
+            notificationCenterProvider: testNotificationCenterProvider,
             mockTicks: [
                 tickWhenResigningActive,
                 tickAfterRollover
@@ -78,9 +78,9 @@ class VitalCPUReaderTest: XCTestCase {
         )
 
         #if os(macOS)
-        testNotificationCenters.workspaceCenter.post(name: WorkspaceNotifications.willSleep, object: nil)
+        testNotificationCenterProvider.workspaceCenter.post(name: WorkspaceNotifications.willSleep, object: nil)
         #else
-        testNotificationCenters.applicationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
+        testNotificationCenterProvider.applicationCenter.post(name: ApplicationNotifications.willResignActive, object: nil)
         #endif
 
         let measurementWhenInactive = try XCTUnwrap(cpuReader.readVitalData())
@@ -91,7 +91,7 @@ class VitalCPUReaderTest: XCTestCase {
         let tickBeforeRollover = UInt32.max - 10
         let tickAfterRollover: UInt32 = 20
         let cpuReader = VitalCPUReaderMock(
-            notificationCenters: testNotificationCenters,
+            notificationCenterProvider: testNotificationCenterProvider,
             mockTicks: [
                 tickBeforeRollover,
                 tickAfterRollover
@@ -124,9 +124,9 @@ class VitalCPUReaderTest: XCTestCase {
 private class VitalCPUReaderMock: VitalCPUReader {
     private var mockTicks: [UInt32]
 
-    init(notificationCenters: NotificationCenters, mockTicks: [UInt32]) {
+    init(notificationCenterProvider: NotificationCenterProvider, mockTicks: [UInt32]) {
         self.mockTicks = mockTicks
-        super.init(notificationCenters: notificationCenters)
+        super.init(notificationCenterProvider: notificationCenterProvider)
     }
 
     override func readRawUtilizedTicks() -> UInt32? {

--- a/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
@@ -107,7 +107,7 @@ class VitalInfoSamplerTests: XCTestCase {
 
             // in real-world scenarios, sampling will be started from background threads
             sampler = VitalInfoSampler(
-                cpuReader: VitalCPUReader(notificationCenters: .default),
+                cpuReader: VitalCPUReader(notificationCenterProvider: .default),
                 memoryReader: VitalMemoryReader(),
                 refreshRateReader: refreshRateReader,
                 frequency: 0.1

--- a/DatadogCore/Tests/Objc/DDCoreTestPlatformTypes.swift
+++ b/DatadogCore/Tests/Objc/DDCoreTestPlatformTypes.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+@_spi(objc)
+@testable import DatadogRUM
+
+#if os(macOS)
+typealias objc_ViewsPredicate = objc_AppKitRUMViewsPredicate
+typealias objc_DefaultViewsPredicate = objc_DefaultAppKitRUMViewsPredicate
+typealias ViewsPredicate = AppKitRUMViewsPredicateBridge
+#elseif !os(watchOS)
+typealias objc_ViewsPredicate = objc_UIKitRUMViewsPredicate
+typealias objc_DefaultViewsPredicate = objc_DefaultUIKitRUMViewsPredicate
+typealias ViewsPredicate = UIKitRUMViewsPredicateBridge
+#endif

--- a/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
@@ -16,7 +16,7 @@ import DatadogInternal
 
 class UIKitRUMViewsPredicateBridgeTests: XCTestCase {
     func testItForwardsCallToObjcPredicate() {
-        class MockPredicate: objc_UIKitRUMViewsPredicate {
+        class MockPredicate: objc_ViewsPredicate {
             var didCallRUMView = false
             func rumView(for viewController: DDViewController) -> objc_RUMView? {
                 didCallRUMView = true
@@ -26,7 +26,7 @@ class UIKitRUMViewsPredicateBridgeTests: XCTestCase {
 
         let objcPredicate = MockPredicate()
 
-        let predicateBridge = UIKitRUMViewsPredicateBridge(objcPredicate: objcPredicate)
+        let predicateBridge = ViewsPredicate(objcPredicate: objcPredicate)
         _ = predicateBridge.rumView(for: mockView)
 
         XCTAssertTrue(objcPredicate.didCallRUMView)

--- a/DatadogCore/Tests/Objc/DDUIKitRUMViewsPredicateTests.swift
+++ b/DatadogCore/Tests/Objc/DDUIKitRUMViewsPredicateTests.swift
@@ -18,7 +18,7 @@ import SwiftUI
 class DDUIKitRUMViewsPredicateTests: XCTestCase {
     func testGivenDefaultPredicate_whenAskingForCustomSwiftViewController_itNamesTheViewByItsClassName() {
         // Given
-        let predicate = objc_DefaultUIKitRUMViewsPredicate()
+        let predicate = objc_DefaultViewsPredicate()
 
         // When
         let customViewController = createMockView(viewControllerClassName: "CustomSwiftViewController")
@@ -31,7 +31,7 @@ class DDUIKitRUMViewsPredicateTests: XCTestCase {
 
     func testGivenDefaultPredicate_whenAskingForCustomObjcViewController_itNamesTheViewByItsClassName() {
         // Given
-        let predicate = objc_DefaultUIKitRUMViewsPredicate()
+        let predicate = objc_DefaultViewsPredicate()
 
         // When
         let customViewController = CustomObjcViewController()
@@ -44,7 +44,7 @@ class DDUIKitRUMViewsPredicateTests: XCTestCase {
 
     func testGivenDefaultPredicate_whenAskingUIKitViewController_itReturnsNoView() {
         // Given
-        let predicate = objc_DefaultUIKitRUMViewsPredicate()
+        let predicate = objc_DefaultViewsPredicate()
 
         // When
         let uiKitViewController = DDViewController()
@@ -60,7 +60,7 @@ class DDUIKitRUMViewsPredicateTests: XCTestCase {
             return
         }
         // Given
-        let predicate = objc_DefaultUIKitRUMViewsPredicate()
+        let predicate = objc_DefaultViewsPredicate()
 
         // When
         let swiftUIHostingController = DDHostingController<EmptyView>(rootView: EmptyView())

--- a/DatadogInternal/Sources/DDPlatformTypes.swift
+++ b/DatadogInternal/Sources/DDPlatformTypes.swift
@@ -10,10 +10,10 @@ import Foundation
 import UIKit
 
 // MARK: - Application
-public typealias DDApplication = UIApplication
+internal typealias DDApplication = UIApplication
 #elseif canImport(AppKit)
 import AppKit
 
 // MARK: - Application
-public typealias DDApplication = NSApplication
+internal typealias DDApplication = NSApplication
 #endif

--- a/DatadogInternal/Sources/NotificationCenterProvider.swift
+++ b/DatadogInternal/Sources/NotificationCenterProvider.swift
@@ -8,21 +8,23 @@ import Foundation
 
 #if os(macOS)
 import AppKit
+#endif
 
-/// Wraps the necessary notification centers used by Core.
-public struct NotificationCenters {
+/// Provides notification centers used by Core.
+public struct NotificationCenterProvider {
     /// Notification centre where application notifications are published.
     ///
     /// Usually `NotificationCenter.default`.
     public let applicationCenter: NotificationCenter
 
+    #if os(macOS)
     /// Notification centre where workspace notifications are published.
     ///
     /// Usually `NSWorkspace.shared.notificationCenter`.
     public let workspaceCenter: NotificationCenter
 
-    /// A `NotificationCenters` instance with the default values used in production.
-    public static var `default`: NotificationCenters {
+    /// A `NotificationCenterProvider` instance with the default values used in production.
+    public static var `default`: NotificationCenterProvider {
         .init(applicationCenter: .default, workspaceCenter: NSWorkspace.shared.notificationCenter)
     }
 
@@ -30,22 +32,14 @@ public struct NotificationCenters {
         self.applicationCenter = applicationCenter
         self.workspaceCenter = workspaceCenter
     }
-}
-#else
-/// Wraps the necessary notification centers used by Core.
-public struct NotificationCenters {
-    /// Notification centre where application notifications are published.
-    ///
-    /// Usually `NotificationCenter.default`.
-    public let applicationCenter: NotificationCenter
-
-    /// A `NotificationCenters` instance with the default values used in production.
-    public static var `default`: NotificationCenters {
+    #else
+    /// A `NotificationCenterProvider` instance with the default values used in production.
+    public static var `default`: NotificationCenterProvider {
         .init(applicationCenter: .default)
     }
 
     public init(applicationCenter: NotificationCenter) {
         self.applicationCenter = applicationCenter
     }
+    #endif
 }
-#endif

--- a/DatadogInternal/Sources/Utils/UIKitExtensions.swift
+++ b/DatadogInternal/Sources/Utils/UIKitExtensions.swift
@@ -4,19 +4,35 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(macOS)
 import Foundation
+import UIKit
 
-extension DatadogExtension where ExtendedType == DDApplication {
+extension DatadogExtension where ExtendedType == UIApplication {
     /// `UIApplication.shared` does not compile in some environments (e.g. notification service app extension), resulting with:
     /// _"shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead"_.
     ///
     /// As a workaround, this `managedShared` utility provides a key-path access to the `UIApplication.shared` to make the compiler pass.
-    public static var managedShared: DDApplication? {
+    public static var managedShared: UIApplication? {
         return DDApplication
-            .value(forKeyPath: #keyPath(DDApplication.shared)) as? DDApplication // swiftlint:disable:this unsafe_uiapplication_shared
+            .value(forKeyPath: #keyPath(UIApplication.shared)) as? UIApplication // swiftlint:disable:this unsafe_uiapplication_shared
     }
 }
 
-extension DDApplication: DatadogExtended { }
+extension UIApplication: DatadogExtended { }
+#elseif os(macOS)
+import Foundation
+import AppKit
+
+extension DatadogExtension where ExtendedType == NSApplication {
+    /// On macOS, simply return `NSApplication.shared`.
+    ///
+    /// AppKit does not have the same problem as UIKit in extensions, so this is not really needed. However, the API exists to maintain
+    /// compatibility with SDK code that calls `managedShared`.
+    public static var managedShared: NSApplication? {
+        NSApplication.shared
+    }
+}
+
+extension NSApplication: DatadogExtended { }
 #endif

--- a/DatadogRUM/Sources/DDPlatformTypes.swift
+++ b/DatadogRUM/Sources/DDPlatformTypes.swift
@@ -19,47 +19,47 @@ import UIKit
 internal typealias DDApplication = UIApplication
 
 // MARK: - Views
-public typealias DDView = UIView
-public typealias DDControl = UIControl
-public typealias DDLabel = UILabel
-public typealias DDButton = UIButton
-public typealias DDScrollView = UIScrollView
-public typealias DDStackView = UIStackView
-public typealias DDSegmentedControl = UISegmentedControl
-public typealias DDWindow = UIWindow
+internal typealias DDView = UIView
+internal typealias DDControl = UIControl
+internal typealias DDLabel = UILabel
+internal typealias DDButton = UIButton
+internal typealias DDScrollView = UIScrollView
+internal typealias DDStackView = UIStackView
+internal typealias DDSegmentedControl = UISegmentedControl
+internal typealias DDWindow = UIWindow
 #if !os(visionOS)
-public typealias DDScreen = UIScreen
+internal typealias DDScreen = UIScreen
 #endif
 
 // MARK: - View Controllers
-public typealias DDViewController = UIViewController
-public typealias DDNavigationController = UINavigationController
-public typealias DDTabBarController = UITabBarController
+internal typealias DDViewController = UIViewController
+internal typealias DDNavigationController = UINavigationController
+internal typealias DDTabBarController = UITabBarController
 
 // MARK: - Events
-public typealias DDEvent = UIEvent
-public typealias DDTouch = UITouch
+internal typealias DDEvent = UIEvent
+internal typealias DDTouch = UITouch
 
 // MARK: - Collection / Table Cells
-public typealias DDTableViewCell = UITableViewCell
-public typealias DDCollectionViewCell = UICollectionViewCell
+internal typealias DDTableViewCell = UITableViewCell
+internal typealias DDCollectionViewCell = UICollectionViewCell
 
 // MARK: - Accessibility
-public typealias DDAccessibility = UIAccessibility
+internal typealias DDAccessibility = UIAccessibility
 
-public typealias DDKitRUMActionsPredicate = UIKitRUMActionsPredicate
-public typealias DDKitRUMViewsPredicate = UIKitRUMViewsPredicate
+internal typealias DDKitRUMActionsPredicate = UIKitRUMActionsPredicate
+internal typealias DDKitRUMViewsPredicate = UIKitRUMViewsPredicate
 #endif
 
 // MARK: - Appearance
-public typealias DDColor = UIColor
-public typealias DDFont = UIFont
+internal typealias DDColor = UIColor
+internal typealias DDFont = UIFont
 
 #if canImport(SwiftUI) && (os(iOS) || os(tvOS) || os(visionOS))
 import SwiftUI
 
 @available(iOS 13.0, tvOS 13.0, *)
-public typealias DDHostingController = UIHostingController
+internal typealias DDHostingController = UIHostingController
 #endif
 
 #elseif canImport(AppKit)
@@ -69,45 +69,45 @@ import AppKit
 internal typealias DDApplication = NSApplication
 
 // MARK: - Views
-public typealias DDView = NSView
-public typealias DDControl = NSControl
+internal typealias DDView = NSView
+internal typealias DDControl = NSControl
 /// Closest AppKit equivalent; configure with `isEditable = false` / `isBezeled = false` for label behaviour.
-public typealias DDLabel = NSTextField
-public typealias DDButton = NSButton
-public typealias DDScrollView = NSScrollView
-public typealias DDStackView = NSStackView
-public typealias DDSegmentedControl = NSSegmentedControl
-public typealias DDWindow = NSWindow
-public typealias DDScreen = NSScreen
+internal typealias DDLabel = NSTextField
+internal typealias DDButton = NSButton
+internal typealias DDScrollView = NSScrollView
+internal typealias DDStackView = NSStackView
+internal typealias DDSegmentedControl = NSSegmentedControl
+internal typealias DDWindow = NSWindow
+internal typealias DDScreen = NSScreen
 
 // MARK: - View Controllers
-public typealias DDViewController = NSViewController
+internal typealias DDViewController = NSViewController
 /// No direct AppKit equivalent — aliased to `NSViewController` for compilation purposes.
-public typealias DDNavigationController = NSViewController
+internal typealias DDNavigationController = NSViewController
 /// No direct AppKit equivalent — aliased to `NSViewController` for compilation purposes.
-public typealias DDTabBarController = NSViewController
+internal typealias DDTabBarController = NSViewController
 
 // MARK: - Events
 /// `NSEvent` covers all input events on macOS (mouse, keyboard, scroll, etc.).
-public typealias DDEvent = NSEvent
+internal typealias DDEvent = NSEvent
 /// `NSTouch` represents trackpad touches on macOS; semantically different from `UITouch`.
-public typealias DDTouch = NSTouch
+internal typealias DDTouch = NSTouch
 
 // MARK: - Appearance
-public typealias DDColor = NSColor
-public typealias DDFont = NSFont
+internal typealias DDColor = NSColor
+internal typealias DDFont = NSFont
 
 // MARK: - Collection / Table Cells
 /// Closest AppKit equivalent to `UITableViewCell` — an `NSView`-based cell.
-public typealias DDTableViewCell = NSTableCellView
+internal typealias DDTableViewCell = NSTableCellView
 /// `NSCollectionViewItem` is the AppKit equivalent; note it is an `NSViewController` subclass.
-public typealias DDCollectionViewCell = NSCollectionViewItem
+internal typealias DDCollectionViewCell = NSCollectionViewItem
 
 // MARK: - Accessibility
 /// Stub namespace matching `UIAccessibility` API surface used in DatadogRUM.
 /// AppKit exposes accessibility via `NSAccessibility` (a protocol) and top-level functions;
 /// this enum provides a compilation target — actual macOS values are not supported.
-public typealias DDAccessibility = NSAccessibility
+internal typealias DDAccessibility = NSAccessibility
 
 // MARK: - Application lifecycle notifications
 /// Maps `UIApplication.didEnterBackgroundNotification` → `NSApplication.didResignActiveNotification`.
@@ -117,13 +117,13 @@ extension NSApplication {
 }
 
 // MARK: - SDK specific
-public typealias DDKitRUMActionsPredicate = AppKitRUMActionsPredicate
-public typealias DDKitRUMViewsPredicate = AppKitRUMViewsPredicate
+internal typealias DDKitRUMActionsPredicate = AppKitRUMActionsPredicate
+internal typealias DDKitRUMViewsPredicate = AppKitRUMViewsPredicate
 
 #if canImport(SwiftUI)
 import SwiftUI
 
-public typealias DDHostingController = NSHostingController
+internal typealias DDHostingController = NSHostingController
 #endif
 
 #endif

--- a/DatadogRUM/Sources/DDPlatformTypes.swift
+++ b/DatadogRUM/Sources/DDPlatformTypes.swift
@@ -15,6 +15,9 @@
 import UIKit
 #if !os(watchOS)
 
+// MARK: - Application
+internal typealias DDApplication = UIApplication
+
 // MARK: - Views
 public typealias DDView = UIView
 public typealias DDControl = UIControl
@@ -61,6 +64,9 @@ public typealias DDHostingController = UIHostingController
 
 #elseif canImport(AppKit)
 import AppKit
+
+// MARK: - Application
+internal typealias DDApplication = NSApplication
 
 // MARK: - Views
 public typealias DDView = NSView

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -156,7 +156,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             vitalsReaders: configuration.vitalsUpdateFrequency.map {
                 VitalsReaders(
                     frequency: $0.timeInterval,
-                    notificationCenters: .default,
+                    notificationCenterProvider: .default,
                     telemetry: core.telemetry,
                 )
             },

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -217,7 +217,48 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         firstFrameReader.publish(to: monitor)
         dependencies.renderLoopObserver?.register(firstFrameReader)
 
-        #if !os(watchOS)
+        #if os(macOS)
+        let heatmapIdentifierStore = HeatmapIdentifierStore()
+        //try core.register(heatmapIdentifierRegistry: heatmapIdentifierStore)
+
+        self.instrumentation = RUMInstrumentation(
+            featureScope: featureScope,
+            uiKitRUMViewsPredicate: configuration.appKitViewsPredicate,
+            uiKitRUMActionsPredicate: configuration.appKitActionsPredicate,
+            swiftUIRUMViewsPredicate: configuration.swiftUIViewsPredicate,
+            swiftUIRUMActionsPredicate: configuration.swiftUIActionsPredicate,
+            trackScrollAndSwipeActions: configuration.featureFlags[.trackScrollAndSwipeActions, default: true],
+            longTaskThreshold: configuration.longTaskThreshold,
+            appHangThreshold: configuration.appHangThreshold,
+            mainQueue: configuration.mainQueue,
+            dateProvider: configuration.dateProvider,
+            backtraceReporter: core.backtraceReporter,
+            fatalErrorContext: dependencies.fatalErrorContext,
+            processID: configuration.processID,
+            notificationCenter: configuration.notificationCenter,
+            bundleType: bundleType,
+            watchdogTermination: watchdogTermination,
+            memoryWarningMonitor: nil,
+            uuidGenerator: configuration.uuidGenerator,
+            heatmapIdentifierRegistry: heatmapIdentifierStore
+        )
+        #elseif os(watchOS)
+        self.instrumentation = RUMInstrumentation(
+            featureScope: featureScope,
+            longTaskThreshold: configuration.longTaskThreshold,
+            appHangThreshold: configuration.appHangThreshold,
+            mainQueue: configuration.mainQueue,
+            dateProvider: configuration.dateProvider,
+            backtraceReporter: core.backtraceReporter,
+            fatalErrorContext: dependencies.fatalErrorContext,
+            processID: configuration.processID,
+            notificationCenter: configuration.notificationCenter,
+            bundleType: bundleType,
+            watchdogTermination: watchdogTermination,
+            memoryWarningMonitor: nil,
+            uuidGenerator: configuration.uuidGenerator
+        )
+        #else
         var memoryWarningMonitor: MemoryWarningMonitor?
         if configuration.trackMemoryWarnings {
             let memoryWarningReporter = MemoryWarningReporter()
@@ -250,22 +291,6 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
             memoryWarningMonitor: memoryWarningMonitor,
             uuidGenerator: configuration.uuidGenerator,
             heatmapIdentifierRegistry: heatmapIdentifierStore
-        )
-        #else
-        self.instrumentation = RUMInstrumentation(
-            featureScope: featureScope,
-            longTaskThreshold: configuration.longTaskThreshold,
-            appHangThreshold: configuration.appHangThreshold,
-            mainQueue: configuration.mainQueue,
-            dateProvider: configuration.dateProvider,
-            backtraceReporter: core.backtraceReporter,
-            fatalErrorContext: dependencies.fatalErrorContext,
-            processID: configuration.processID,
-            notificationCenter: configuration.notificationCenter,
-            bundleType: bundleType,
-            watchdogTermination: watchdogTermination,
-            memoryWarningMonitor: nil,
-            uuidGenerator: configuration.uuidGenerator
         )
         #endif
         self.requestBuilder = RequestBuilder(
@@ -331,8 +356,8 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         #if !os(watchOS)
         let swiftUIViewTrackingEnabled = configuration.swiftUIViewsPredicate != nil
         let swiftUIActionTrackingEnabled = configuration.swiftUIActionsPredicate != nil
-        let trackNativeViews = configuration.uiKitViewsPredicate != nil
-        let trackUserInteractions = configuration.uiKitActionsPredicate != nil
+        let trackNativeViews = configuration.ddKitViewsPredicate != nil
+        let trackUserInteractions = configuration.ddKitActionsPredicate != nil
         #else
         let swiftUIViewTrackingEnabled = false
         let swiftUIActionTrackingEnabled = false

--- a/DatadogRUM/Sources/Instrumentation/Actions/AppKit/AppKitRUMUserActionsPredicate.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/AppKit/AppKitRUMUserActionsPredicate.swift
@@ -16,7 +16,7 @@ public protocol AppKitRUMActionsPredicate {
     /// The predicate deciding if the RUM Action should be recorded.
     /// - Parameter targetView: an instance of the `UIView` which received the action.
     /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
-    func rumAction(targetView: DDView) -> RUMAction?
+    func rumAction(targetView: NSView) -> RUMAction?
 
     func rumAction(targetMenuItem: NSMenuItem) -> RUMAction?
 }
@@ -49,7 +49,7 @@ public struct DefaultAppKitRUMActionsPredicate {
 
 // MARK: DefaultAppKitRUMActionsPredicate
 extension DefaultAppKitRUMActionsPredicate: AppKitRUMActionsPredicate {
-    public func rumAction(targetView: DDView) -> RUMAction? {
+    public func rumAction(targetView: NSView) -> RUMAction? {
         return RUMAction(
             name: targetName(for: targetView),
             attributes: [:]

--- a/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIKitRUMUserActionsPredicate.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIKitRUMUserActionsPredicate.swift
@@ -22,7 +22,7 @@ public protocol UITouchRUMActionsPredicate {
     /// The predicate deciding if the RUM Action should be recorded.
     /// - Parameter targetView: an instance of the `UIView` which received the action.
     /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
-    func rumAction(targetView: DDView) -> RUMAction?
+    func rumAction(targetView: UIView) -> RUMAction?
 }
 
 /// The predicate for tvOS interactions deciding if a given RUM Action should be recorded.
@@ -35,7 +35,7 @@ public protocol UIPressRUMActionsPredicate {
     ///   - type: the `UIPress.PressType` which received the action.
     ///   - targetView: an instance of the `DDView` which received the action.
     /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
-    func rumAction(press type: UIPress.PressType, targetView: DDView) -> RUMAction?
+    func rumAction(press type: UIPress.PressType, targetView: UIView) -> RUMAction?
 }
 
 /// Default implementation of `UIKitRUMActionsPredicate`.
@@ -62,7 +62,7 @@ public struct DefaultUIKitRUMActionsPredicate {
 
 // MARK: iOS DefaultUIKitRUMActionsPredicate
 extension DefaultUIKitRUMActionsPredicate: UITouchRUMActionsPredicate {
-    public func rumAction(targetView: DDView) -> RUMAction? {
+    public func rumAction(targetView: UIView) -> RUMAction? {
         return RUMAction(
             name: targetName(for: targetView),
             attributes: [:]
@@ -72,7 +72,7 @@ extension DefaultUIKitRUMActionsPredicate: UITouchRUMActionsPredicate {
 
 // MARK: tvOS DefaultUIKitRUMActionsPredicate
 extension DefaultUIKitRUMActionsPredicate: UIPressRUMActionsPredicate {
-    public func rumAction(press type: UIPress.PressType, targetView: DDView) -> RUMAction? {
+    public func rumAction(press type: UIPress.PressType, targetView: UIView) -> RUMAction? {
         var name: String
 
         switch type {

--- a/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIKitRUMUserActionsPredicate.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIKitRUMUserActionsPredicate.swift
@@ -33,7 +33,7 @@ public protocol UIPressRUMActionsPredicate {
     /// The predicate deciding if the RUM Action should be recorded.
     /// - Parameters:
     ///   - type: the `UIPress.PressType` which received the action.
-    ///   - targetView: an instance of the `DDView` which received the action.
+    ///   - targetView: an instance of the `UIView` which received the action.
     /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
     func rumAction(press type: UIPress.PressType, targetView: UIView) -> RUMAction?
 }
@@ -43,8 +43,8 @@ public protocol UIPressRUMActionsPredicate {
 public struct DefaultUIKitRUMActionsPredicate {
     public init () {}
 
-    /// Builds the RUM Action's `target` name for given `DDView`.
-    private func targetName(for view: DDView) -> String {
+    /// Builds the RUM Action's `target` name for given `UIView`.
+    private func targetName(for view: UIView) -> String {
         let className = NSStringFromClass(type(of: view))
 
         if let accessibilityIdentifier = view.accessibilityIdentifier {

--- a/DatadogRUM/Sources/Instrumentation/MemoryWarnings/MemoryWarningMonitor.swift
+++ b/DatadogRUM/Sources/Instrumentation/MemoryWarnings/MemoryWarningMonitor.swift
@@ -8,8 +8,6 @@ import Foundation
 import DatadogInternal
 #if canImport(UIKit)
 import UIKit
-#elseif canImport(AppKit)
-import AppKit
 #endif
 
 /// Tracks the memory warnings history and publishes it to the subscribers.
@@ -25,12 +23,12 @@ internal final class MemoryWarningMonitor {
         self.reporter = memoryWarningReporter
     }
 
-    /// Starts monitoring memory warnings by subscribing to `DDApplication.didReceiveMemoryWarningNotification`.
+    /// Starts monitoring memory warnings by subscribing to `UIApplication.didReceiveMemoryWarningNotification`.
     func start() {
-        #if os(watchOS)
-        consolePrint("Memory warnings instrumentation is not available on watchOS.", .warn)
+        #if os(watchOS) || os(macOS)
+        consolePrint("Memory warnings instrumentation is not available on watchOS nor macOS.", .warn)
         #elseif canImport(UIKit)
-        notificationCenter.addObserver(self, selector: #selector(didReceiveMemoryWarning), name: DDApplication.didReceiveMemoryWarningNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(didReceiveMemoryWarning), name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
         #endif
     }
 

--- a/DatadogRUM/Sources/Instrumentation/Views/AppKit/AppKitRUMViewsPredicate.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/AppKit/AppKitRUMViewsPredicate.swift
@@ -21,7 +21,7 @@ public protocol AppKitRUMViewsPredicate {
     ///
     /// - Parameter viewController: The view controller that has appeared in the UI.
     /// - Returns: RUM view parameters if the view controller should be tracked, or `nil` to ignore it.
-    func rumView(for viewController: DDViewController) -> RUMView?
+    func rumView(for viewController: NSViewController) -> RUMView?
 }
 
 /// Default implementation of `UIKitRUMViewsPredicate`.
@@ -31,7 +31,7 @@ public protocol AppKitRUMViewsPredicate {
 public struct DefaultAppKitRUMViewsPredicate: AppKitRUMViewsPredicate {
     public init () {}
 
-    public func rumView(for viewController: DDViewController) -> RUMView? {
+    public func rumView(for viewController: NSViewController) -> RUMView? {
         guard !Bundle(for: type(of: viewController)).dd.isAppKit || viewController.isUIAlertController else {
             // Part of our heuristic for (auto) tracking view controllers is to ignore
             // container view controllers coming from `UIKit` if they are not subclassed.

--- a/DatadogRUM/Sources/Instrumentation/Views/UIKit/UIKitRUMViewsPredicate.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/UIKit/UIKitRUMViewsPredicate.swift
@@ -21,7 +21,7 @@ public protocol UIKitRUMViewsPredicate {
     ///
     /// - Parameter viewController: The view controller that has appeared in the UI.
     /// - Returns: RUM view parameters if the view controller should be tracked, or `nil` to ignore it.
-    func rumView(for viewController: DDViewController) -> RUMView?
+    func rumView(for viewController: UIViewController) -> RUMView?
 }
 
 /// Default implementation of `UIKitRUMViewsPredicate`.
@@ -31,7 +31,7 @@ public protocol UIKitRUMViewsPredicate {
 public struct DefaultUIKitRUMViewsPredicate: UIKitRUMViewsPredicate {
     public init () {}
 
-    public func rumView(for viewController: DDViewController) -> RUMView? {
+    public func rumView(for viewController: UIViewController) -> RUMView? {
         guard !Bundle(for: type(of: viewController)).dd.isUIKit || viewController.isUIAlertController else {
             // Part of our heuristic for (auto) tracking view controllers is to ignore
             // container view controllers coming from `UIKit` if they are not subclassed.

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -696,7 +696,12 @@ public class objc_RUMConfiguration: NSObject {
     }
     #endif
 
-    #if canImport(UIKit)
+    #if os(macOS)
+    public var appKitActionsPredicate: objc_AppKitRUMActionsPredicate? {
+        set { swiftConfig.appKitActionsPredicate = newValue.map { AppKitRUMActionsPredicateBridge(objcPredicate: $0) } }
+        get { (swiftConfig.appKitActionsPredicate as? AppKitRUMActionsPredicateBridge)?.objcPredicate as? objc_AppKitRUMActionsPredicate  }
+    }
+    #elseif canImport(UIKit)
     public var uiKitActionsPredicate: objc_UIKitRUMActionsPredicate? {
         set { swiftConfig.uiKitActionsPredicate = newValue.map { UIKitRUMActionsPredicateBridge(objcPredicate: $0) } }
         get { (swiftConfig.uiKitActionsPredicate as? UIKitRUMActionsPredicateBridge)?.objcPredicate as? objc_UIKitRUMActionsPredicate  }

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -13,14 +13,189 @@ import AppKit
 @_spi(objc)
 import DatadogInternal
 
-#if !os(watchOS)
-internal struct UIKitRUMViewsPredicateBridge: DDKitRUMViewsPredicate {
+#if os(macOS)
+internal struct AppKitRUMViewsPredicateBridge: AppKitRUMViewsPredicate {
+    let objcPredicate: objc_AppKitRUMViewsPredicate
+
+    func rumView(for viewController: NSViewController) -> RUMView? {
+        return objcPredicate.rumView(for: viewController)?.swiftView
+    }
+}
+
+@objc(DDAppKitRUMViewsPredicate)
+@_spi(objc)
+public protocol objc_AppKitRUMViewsPredicate: AnyObject {
+    /// The predicate deciding if the RUM View should be started or ended for given instance of the `NSViewController`.
+    /// - Parameter viewController: an instance of the view controller noticed by the SDK.
+    /// - Returns: RUM View parameters if received view controller should start/end the RUM View, `nil` otherwise.
+    func rumView(for viewController: NSViewController) -> objc_RUMView?
+}
+
+@objc(DDDefaultAppKitRUMViewsPredicate)
+@objcMembers
+@_spi(objc)
+public class objc_DefaultAppKitRUMViewsPredicate: NSObject, objc_AppKitRUMViewsPredicate {
+    private let swiftPredicate = DefaultAppKitRUMViewsPredicate()
+
+    public func rumView(for viewController: NSViewController) -> objc_RUMView? {
+        return swiftPredicate.rumView(for: viewController).map {
+            objc_RUMView(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
+        }
+    }
+}
+
+@objc(DDDefaultAppKitRUMActionsPredicate)
+@objcMembers
+@_spi(objc)
+public class objc_DefaultAppKitRUMActionsPredicate: NSObject, objc_AppKitRUMActionsPredicate {
+    let swiftPredicate = DefaultAppKitRUMActionsPredicate()
+    public func rumAction(targetView: NSView) -> objc_RUMAction? {
+        swiftPredicate.rumAction(targetView: targetView).map {
+            objc_RUMAction(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
+        }
+    }
+
+    public func rumAction(targetMenuItem: NSMenuItem) -> objc_RUMAction? {
+        swiftPredicate.rumAction(targetMenuItem: targetMenuItem).map {
+            objc_RUMAction(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
+        }
+    }
+}
+
+@objc(DDAppKitRUMActionsPredicate)
+@_spi(objc)
+public protocol objc_AppKitRUMActionsPredicate: AnyObject {
+    /// The predicate deciding if the RUM Action should be recorded.
+    /// - Parameter targetView: an instance of the `NSView` which received the action.
+    /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
+    func rumAction(targetView: NSView) -> objc_RUMAction?
+
+    func rumAction(targetMenuItem: NSMenuItem) -> objc_RUMAction?
+}
+
+internal struct AppKitRUMActionsPredicateBridge: AppKitRUMActionsPredicate {
+    let objcPredicate: objc_AppKitRUMActionsPredicate
+
+    func rumAction(targetView: NSView) -> RUMAction? {
+        return objcPredicate.rumAction(targetView: targetView)?.swiftAction
+    }
+
+    func rumAction(targetMenuItem: NSMenuItem) -> RUMAction? {
+        return objcPredicate.rumAction(targetMenuItem: targetMenuItem)?.swiftAction
+    }
+}
+
+#elseif !os(watchOS)
+internal struct UIKitRUMViewsPredicateBridge: UIKitRUMViewsPredicate {
     let objcPredicate: objc_UIKitRUMViewsPredicate
 
     func rumView(for viewController: DDViewController) -> RUMView? {
         return objcPredicate.rumView(for: viewController)?.swiftView
     }
 }
+
+@objc(DDUIKitRUMViewsPredicate)
+@_spi(objc)
+public protocol objc_UIKitRUMViewsPredicate: AnyObject {
+    /// The predicate deciding if the RUM View should be started or ended for given instance of the `DDViewController`.
+    /// - Parameter viewController: an instance of the view controller noticed by the SDK.
+    /// - Returns: RUM View parameters if received view controller should start/end the RUM View, `nil` otherwise.
+    func rumView(for viewController: UIViewController) -> objc_RUMView?
+}
+
+@objc(DDDefaultUIKitRUMViewsPredicate)
+@objcMembers
+@_spi(objc)
+public class objc_DefaultUIKitRUMViewsPredicate: NSObject, objc_UIKitRUMViewsPredicate {
+    private let swiftPredicate = DefaultUIKitRUMViewsPredicate()
+
+    public func rumView(for viewController: UIViewController) -> objc_RUMView? {
+        return swiftPredicate.rumView(for: viewController).map {
+            objc_RUMView(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
+        }
+    }
+}
+
+#if canImport(UIKit)
+@objc(DDDefaultUIKitRUMActionsPredicate)
+@objcMembers
+@_spi(objc)
+public class objc_DefaultUIKitRUMActionsPredicate: NSObject, objc_UIKitRUMActionsPredicate {
+    let swiftPredicate = DefaultUIKitRUMActionsPredicate()
+    #if os(tvOS)
+    public func rumAction(press type: UIPress.PressType, targetView: UIView) -> objc_RUMAction? {
+        swiftPredicate.rumAction(press: type, targetView: targetView).map {
+            objc_RUMAction(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
+        }
+    }
+    #else
+    public func rumAction(targetView: UIView) -> objc_RUMAction? {
+        swiftPredicate.rumAction(targetView: targetView).map {
+            objc_RUMAction(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
+        }
+    }
+    #endif
+}
+
+internal struct UIKitRUMActionsPredicateBridge: UITouchRUMActionsPredicate & UIPressRUMActionsPredicate {
+    let objcPredicate: AnyObject?
+
+    init(objcPredicate: objc_UITouchRUMActionsPredicate) {
+        self.objcPredicate = objcPredicate
+    }
+
+    init(objcPredicate: objc_UIPressRUMActionsPredicate) {
+        self.objcPredicate = objcPredicate
+    }
+
+    func rumAction(targetView: UIView) -> RUMAction? {
+        guard let objcPredicate = objcPredicate as? objc_UITouchRUMActionsPredicate else {
+            return nil
+        }
+        return objcPredicate.rumAction(targetView: targetView)?.swiftAction
+    }
+
+    func rumAction(press type: UIPress.PressType, targetView: UIView) -> RUMAction? {
+        guard let objcPredicate = objcPredicate as? objc_UIPressRUMActionsPredicate else {
+            return nil
+        }
+        return objcPredicate.rumAction(press: type, targetView: targetView)?.swiftAction
+    }
+}
+#endif
+
+#if os(tvOS)
+@objc(DDUIKitRUMActionsPredicate)
+@_spi(objc)
+public protocol objc_UIKitRUMActionsPredicate: objc_UIPressRUMActionsPredicate {}
+#else
+@objc(DDUIKitRUMActionsPredicate)
+@_spi(objc)
+public protocol objc_UIKitRUMActionsPredicate: objc_UITouchRUMActionsPredicate {}
+#endif
+
+@objc(DDUITouchRUMActionsPredicate)
+@_spi(objc)
+public protocol objc_UITouchRUMActionsPredicate: AnyObject {
+    /// The predicate deciding if the RUM Action should be recorded.
+    /// - Parameter targetView: an instance of the `UIView` which received the action.
+    /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
+    func rumAction(targetView: UIView) -> objc_RUMAction?
+}
+
+#if canImport(UIKit)
+@objc(DDUIPressRUMActionsPredicate)
+@_spi(objc)
+public protocol objc_UIPressRUMActionsPredicate: AnyObject {
+    /// The predicate deciding if the RUM Action should be recorded.
+    /// - Parameters:
+    ///   - type: the `UIPress.PressType` which received the action.
+    ///   - targetView: an instance of the `UIView` which received the action.
+    /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
+    func rumAction(press type: UIPress.PressType, targetView: UIView) -> objc_RUMAction?
+}
+#endif
+#endif
 
 @objc(DDRUMView)
 @objcMembers
@@ -43,80 +218,6 @@ public class objc_RUMView: NSObject {
     }
 }
 
-@objc(DDUIKitRUMViewsPredicate)
-@_spi(objc)
-public protocol objc_UIKitRUMViewsPredicate: AnyObject {
-    /// The predicate deciding if the RUM View should be started or ended for given instance of the `DDViewController`.
-    /// - Parameter viewController: an instance of the view controller noticed by the SDK.
-    /// - Returns: RUM View parameters if received view controller should start/end the RUM View, `nil` otherwise.
-    func rumView(for viewController: DDViewController) -> objc_RUMView?
-}
-
-@objc(DDDefaultUIKitRUMViewsPredicate)
-@objcMembers
-@_spi(objc)
-public class objc_DefaultUIKitRUMViewsPredicate: NSObject, objc_UIKitRUMViewsPredicate {
-    #if os(macOS)
-    private let swiftPredicate = DefaultAppKitRUMViewsPredicate()
-    #else
-    private let swiftPredicate = DefaultUIKitRUMViewsPredicate()
-    #endif
-
-    public func rumView(for viewController: DDViewController) -> objc_RUMView? {
-        return swiftPredicate.rumView(for: viewController).map {
-            objc_RUMView(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
-        }
-    }
-}
-
-#if canImport(UIKit)
-@objc(DDDefaultUIKitRUMActionsPredicate)
-@objcMembers
-@_spi(objc)
-public class objc_DefaultUIKitRUMActionsPredicate: NSObject, objc_UIKitRUMActionsPredicate {
-    let swiftPredicate = DefaultUIKitRUMActionsPredicate()
-    #if os(tvOS)
-    public func rumAction(press type: UIPress.PressType, targetView: UIView) -> objc_RUMAction? {
-        swiftPredicate.rumAction(press: type, targetView: targetView).map {
-            objc_RUMAction(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
-        }
-    }
-    #else
-    public func rumAction(targetView: DDView) -> objc_RUMAction? {
-        swiftPredicate.rumAction(targetView: targetView).map {
-            objc_RUMAction(name: $0.name, attributes: $0.attributes.dd.objCAttributes)
-        }
-    }
-    #endif
-}
-
-internal struct UIKitRUMActionsPredicateBridge: UITouchRUMActionsPredicate & UIPressRUMActionsPredicate {
-    let objcPredicate: AnyObject?
-
-    init(objcPredicate: objc_UITouchRUMActionsPredicate) {
-        self.objcPredicate = objcPredicate
-    }
-
-    init(objcPredicate: objc_UIPressRUMActionsPredicate) {
-        self.objcPredicate = objcPredicate
-    }
-
-    func rumAction(targetView: DDView) -> RUMAction? {
-        guard let objcPredicate = objcPredicate as? objc_UITouchRUMActionsPredicate else {
-            return nil
-        }
-        return objcPredicate.rumAction(targetView: targetView)?.swiftAction
-    }
-
-    func rumAction(press type: UIPress.PressType, targetView: DDView) -> RUMAction? {
-        guard let objcPredicate = objcPredicate as? objc_UIPressRUMActionsPredicate else {
-            return nil
-        }
-        return objcPredicate.rumAction(press: type, targetView: targetView)?.swiftAction
-    }
-}
-#endif
-
 @objc(DDRUMAction)
 @objcMembers
 @_spi(objc)
@@ -137,39 +238,6 @@ public class objc_RUMAction: NSObject {
         )
     }
 }
-
-#if os(tvOS)
-@objc(DDUIKitRUMActionsPredicate)
-@_spi(objc)
-public protocol objc_UIKitRUMActionsPredicate: objc_UIPressRUMActionsPredicate {}
-#else
-@objc(DDUIKitRUMActionsPredicate)
-@_spi(objc)
-public protocol objc_UIKitRUMActionsPredicate: objc_UITouchRUMActionsPredicate {}
-#endif
-
-@objc(DDUITouchRUMActionsPredicate)
-@_spi(objc)
-public protocol objc_UITouchRUMActionsPredicate: AnyObject {
-    /// The predicate deciding if the RUM Action should be recorded.
-    /// - Parameter targetView: an instance of the `UIView` which received the action.
-    /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
-    func rumAction(targetView: DDView) -> objc_RUMAction?
-}
-
-#if canImport(UIKit)
-@objc(DDUIPressRUMActionsPredicate)
-@_spi(objc)
-public protocol objc_UIPressRUMActionsPredicate: AnyObject {
-    /// The predicate deciding if the RUM Action should be recorded.
-    /// - Parameters:
-    ///   - type: the `UIPress.PressType` which received the action.
-    ///   - targetView: an instance of the `UIView` which received the action.
-    /// - Returns: RUM Action if it should be recorded, `nil` otherwise.
-    func rumAction(press type: UIPress.PressType, targetView: DDView) -> objc_RUMAction?
-}
-#endif
-#endif
 
 // MARK: - NetworkSettledResourcePredicate
 
@@ -615,10 +683,18 @@ public class objc_RUMConfiguration: NSObject {
     }
 
     #if !os(watchOS)
+
+    #if os(macOS)
+    public var appKitViewsPredicate: objc_AppKitRUMViewsPredicate? {
+        set { swiftConfig.appKitViewsPredicate = newValue.map { AppKitRUMViewsPredicateBridge(objcPredicate: $0) } }
+        get { (swiftConfig.appKitViewsPredicate as? AppKitRUMViewsPredicateBridge)?.objcPredicate  }
+    }
+    #else
     public var uiKitViewsPredicate: objc_UIKitRUMViewsPredicate? {
         set { swiftConfig.uiKitViewsPredicate = newValue.map { UIKitRUMViewsPredicateBridge(objcPredicate: $0) } }
         get { (swiftConfig.uiKitViewsPredicate as? UIKitRUMViewsPredicateBridge)?.objcPredicate  }
     }
+    #endif
 
     #if canImport(UIKit)
     public var uiKitActionsPredicate: objc_UIKitRUMActionsPredicate? {
@@ -806,9 +882,9 @@ public class objc_RUMMonitor: NSObject {
         swiftRUMMonitor.removeViewAttributes(forKeys: keys)
     }
 
-    #if !os(watchOS)
+    #if os(macOS)
     public func startView(
-        viewController: DDViewController,
+        viewController: NSViewController,
         name: String?,
         attributes: [String: Any]
     ) {
@@ -816,7 +892,22 @@ public class objc_RUMMonitor: NSObject {
     }
 
     public func stopView(
-        viewController: DDViewController,
+        viewController: NSViewController,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.stopView(viewController: viewController, attributes: attributes.dd.swiftAttributes)
+    }
+    #elseif !os(watchOS)
+    public func startView(
+        viewController: UIViewController,
+        name: String?,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.startView(viewController: viewController, name: name, attributes: attributes.dd.swiftAttributes)
+    }
+
+    public func stopView(
+        viewController: UIViewController,
         attributes: [String: Any]
     ) {
         swiftRUMMonitor.stopView(viewController: viewController, attributes: attributes.dd.swiftAttributes)

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -88,7 +88,7 @@ extension RUM {
         /// You can use `DefaultAppKitRUMActionsPredicate` or create your own predicate by
         /// implementing `AppKitRUMActionsPredicate`.
         ///
-        /// Default: `nil` - which means automatic RUM action tracking for AppKit is not enabled by default. instead.
+        /// Default: `nil` - which means automatic RUM action tracking for AppKit is not enabled by default.
         public var appKitActionsPredicate: AppKitRUMActionsPredicate?
         #elseif !os(watchOS)
         /// The predicate for automatically tracking `UIViewControllers` as RUM views.

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -88,7 +88,7 @@ extension RUM {
         /// You can use `DefaultAppKitRUMActionsPredicate` or create your own predicate by
         /// implementing `AppKitRUMActionsPredicate`.
         ///
-        /// Default: `nil` - which means automatic RUM action tracking for UIKit is not enabled by default. instead.
+        /// Default: `nil` - which means automatic RUM action tracking for AppKit is not enabled by default. instead.
         public var appKitActionsPredicate: AppKitRUMActionsPredicate?
         #elseif !os(watchOS)
         /// The predicate for automatically tracking `UIViewControllers` as RUM views.
@@ -668,8 +668,8 @@ extension RUM.Configuration {
     public init(
         applicationID: String,
         sessionSampleRate: SampleRate = .maxSampleRate,
-        uiKitViewsPredicate: AppKitRUMViewsPredicate? = nil,
-        uiKitActionsPredicate: AppKitRUMActionsPredicate? = nil,
+        appKitViewsPredicate: AppKitRUMViewsPredicate? = nil,
+        appKitActionsPredicate: AppKitRUMActionsPredicate? = nil,
         swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,
         swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,
         urlSessionTracking: URLSessionTracking? = nil,
@@ -697,8 +697,8 @@ extension RUM.Configuration {
     ) {
         self.applicationID = applicationID
         self.sessionSampleRate = sessionSampleRate
-        self.appKitViewsPredicate = uiKitViewsPredicate
-        self.appKitActionsPredicate = uiKitActionsPredicate
+        self.appKitViewsPredicate = appKitViewsPredicate
+        self.appKitActionsPredicate = appKitActionsPredicate
         self.swiftUIViewsPredicate = swiftUIViewsPredicate
         self.swiftUIActionsPredicate = swiftUIActionsPredicate
         self.urlSessionTracking = urlSessionTracking

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -66,7 +66,31 @@ extension RUM {
         /// Default: `100.0`.
         public var sessionSampleRate: Float
 
-        #if !os(watchOS)
+        #if os(macOS)
+        /// The predicate for automatically tracking `NSViewControllers` as RUM views.
+        ///
+        /// RUM will query this predicate for each `NSViewController` presented in the app. The predicate implementation
+        /// should return RUM view parameters if the given controller should start a view, or `nil` to ignore it.
+        ///
+        /// You can use `DefaultAppKitRUMViewsPredicate` or create your own predicate by implementing `AppKitRUMViewsPredicate`.
+        ///
+        /// Note: Automatic RUM views tracking involves swizzling the `NSViewController` lifecycle methods.
+        ///
+        /// Default: `nil` - which means automatic RUM view tracking for AppKit is not enabled by default.
+        public var appKitViewsPredicate: AppKitRUMViewsPredicate?
+
+        /// The predicate for automatically tracking `NSEvents` as RUM actions.
+        ///
+        /// RUM will query this predicate for each `NSView` and `NSMenuItem` that the user interacts with. The predicate
+        /// implementation should return RUM action parameters if the given interaction should be accepted, or `nil` to ignore it.
+        /// Touch events on the keyboard are ignored for privacy reasons.
+        ///
+        /// You can use `DefaultAppKitRUMActionsPredicate` or create your own predicate by
+        /// implementing `AppKitRUMActionsPredicate`.
+        ///
+        /// Default: `nil` - which means automatic RUM action tracking for UIKit is not enabled by default. instead.
+        public var appKitActionsPredicate: AppKitRUMActionsPredicate?
+        #elseif !os(watchOS)
         /// The predicate for automatically tracking `UIViewControllers` as RUM views.
         ///
         /// RUM will query this predicate for each `UIViewController` presented in the app. The predicate implementation
@@ -79,10 +103,8 @@ extension RUM {
         /// Default: `nil` - which means automatic RUM view tracking for UIKit is not enabled by default.
         ///
         /// - Important: This feature is unavailable on watchOS. Use manual view tracking with `startView(key:name:attributes:)` instead.
-        public var uiKitViewsPredicate: DDKitRUMViewsPredicate?
-        #endif
+        public var uiKitViewsPredicate: UIKitRUMViewsPredicate?
 
-        #if !os(watchOS)
         /// The predicate for automatically tracking `UITouch` events as RUM actions.
         ///
         /// RUM will query this predicate for each `UIView` that the user interacts with. The predicate implementation
@@ -97,7 +119,25 @@ extension RUM {
         /// Default: `nil` - which means automatic RUM action tracking for UIKit is not enabled by default.
         ///
         /// - Important: This feature is unavailable on watchOS. Use manual action tracking with `addAction(type:name:attributes:)` instead.
-        public var uiKitActionsPredicate: DDKitRUMActionsPredicate?
+        public var uiKitActionsPredicate: UIKitRUMActionsPredicate?
+        #endif
+
+        #if !os(watchOS)
+        internal var ddKitActionsPredicate: DDKitRUMActionsPredicate? {
+            #if os(macOS)
+            return appKitActionsPredicate
+            #else
+            return uiKitActionsPredicate
+            #endif
+        }
+
+        internal var ddKitViewsPredicate: DDKitRUMViewsPredicate? {
+            #if os(macOS)
+            return appKitViewsPredicate
+            #else
+            return uiKitViewsPredicate
+            #endif
+        }
         #endif
 
         #if !os(watchOS)
@@ -574,12 +614,122 @@ extension RUM.Configuration {
     ///   Use manual tracking APIs instead:
     ///   - `RUMMonitor.shared().startView(key:name:attributes:)` for view tracking
     ///   - `RUMMonitor.shared().addAction(type:name:attributes:)` for action tracking
-    #if !os(watchOS)
+    #if os(watchOS)
     public init(
         applicationID: String,
         sessionSampleRate: SampleRate = .maxSampleRate,
-        uiKitViewsPredicate: DDKitRUMViewsPredicate? = nil,
-        uiKitActionsPredicate: DDKitRUMActionsPredicate? = nil,
+        urlSessionTracking: URLSessionTracking? = nil,
+        trackFrustrations: Bool = true,
+        trackBackgroundEvents: Bool = false,
+        longTaskThreshold: TimeInterval? = 0.1,
+        appHangThreshold: TimeInterval? = nil,
+        trackWatchdogTerminations: Bool = false,
+        vitalsUpdateFrequency: VitalsFrequency? = .average,
+        networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),
+        nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),
+        viewEventMapper: RUM.ViewEventMapper? = nil,
+        resourceEventMapper: RUM.ResourceEventMapper? = nil,
+        actionEventMapper: RUM.ActionEventMapper? = nil,
+        errorEventMapper: RUM.ErrorEventMapper? = nil,
+        longTaskEventMapper: RUM.LongTaskEventMapper? = nil,
+        onSessionStart: RUM.SessionListener? = nil,
+        customEndpoint: URL? = nil,
+        trackAnonymousUser: Bool = true,
+        trackSlowFrames: Bool = true,
+        telemetrySampleRate: SampleRate = 20,
+        collectAccessibility: Bool = false,
+        featureFlags: FeatureFlags = .defaults
+    ) {
+        self.applicationID = applicationID
+        self.sessionSampleRate = sessionSampleRate
+        self.urlSessionTracking = urlSessionTracking
+        self.trackFrustrations = trackFrustrations
+        self.trackBackgroundEvents = trackBackgroundEvents
+        self.longTaskThreshold = longTaskThreshold
+        self.appHangThreshold = appHangThreshold
+        self.vitalsUpdateFrequency = vitalsUpdateFrequency
+        self.networkSettledResourcePredicate = networkSettledResourcePredicate
+        self.nextViewActionPredicate = nextViewActionPredicate
+        self.viewEventMapper = viewEventMapper
+        self.resourceEventMapper = resourceEventMapper
+        self.actionEventMapper = actionEventMapper
+        self.errorEventMapper = errorEventMapper
+        self.longTaskEventMapper = longTaskEventMapper
+        self.onSessionStart = onSessionStart
+        self.customEndpoint = customEndpoint
+        self.trackAnonymousUser = trackAnonymousUser
+        self.trackWatchdogTerminations = trackWatchdogTerminations
+        self.trackSlowFrames = trackSlowFrames
+        self.telemetrySampleRate = telemetrySampleRate
+        self.collectAccessibility = collectAccessibility
+        self.featureFlags = featureFlags
+    }
+    #elseif os(macOS)
+    public init(
+        applicationID: String,
+        sessionSampleRate: SampleRate = .maxSampleRate,
+        uiKitViewsPredicate: AppKitRUMViewsPredicate? = nil,
+        uiKitActionsPredicate: AppKitRUMActionsPredicate? = nil,
+        swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,
+        swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,
+        urlSessionTracking: URLSessionTracking? = nil,
+        trackFrustrations: Bool = true,
+        trackBackgroundEvents: Bool = false,
+        longTaskThreshold: TimeInterval? = 0.1,
+        appHangThreshold: TimeInterval? = nil,
+        trackWatchdogTerminations: Bool = false,
+        vitalsUpdateFrequency: VitalsFrequency? = .average,
+        networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),
+        nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),
+        viewEventMapper: RUM.ViewEventMapper? = nil,
+        resourceEventMapper: RUM.ResourceEventMapper? = nil,
+        actionEventMapper: RUM.ActionEventMapper? = nil,
+        errorEventMapper: RUM.ErrorEventMapper? = nil,
+        longTaskEventMapper: RUM.LongTaskEventMapper? = nil,
+        onSessionStart: RUM.SessionListener? = nil,
+        customEndpoint: URL? = nil,
+        trackAnonymousUser: Bool = true,
+        trackMemoryWarnings: Bool = true,
+        trackSlowFrames: Bool = true,
+        telemetrySampleRate: SampleRate = 20,
+        collectAccessibility: Bool = false,
+        featureFlags: FeatureFlags = .defaults
+    ) {
+        self.applicationID = applicationID
+        self.sessionSampleRate = sessionSampleRate
+        self.appKitViewsPredicate = uiKitViewsPredicate
+        self.appKitActionsPredicate = uiKitActionsPredicate
+        self.swiftUIViewsPredicate = swiftUIViewsPredicate
+        self.swiftUIActionsPredicate = swiftUIActionsPredicate
+        self.urlSessionTracking = urlSessionTracking
+        self.trackFrustrations = trackFrustrations
+        self.trackBackgroundEvents = trackBackgroundEvents
+        self.longTaskThreshold = longTaskThreshold
+        self.appHangThreshold = appHangThreshold
+        self.vitalsUpdateFrequency = vitalsUpdateFrequency
+        self.networkSettledResourcePredicate = networkSettledResourcePredicate
+        self.nextViewActionPredicate = nextViewActionPredicate
+        self.viewEventMapper = viewEventMapper
+        self.resourceEventMapper = resourceEventMapper
+        self.actionEventMapper = actionEventMapper
+        self.errorEventMapper = errorEventMapper
+        self.longTaskEventMapper = longTaskEventMapper
+        self.onSessionStart = onSessionStart
+        self.customEndpoint = customEndpoint
+        self.trackAnonymousUser = trackAnonymousUser
+        self.trackWatchdogTerminations = trackWatchdogTerminations
+        self.trackMemoryWarnings = trackMemoryWarnings
+        self.trackSlowFrames = trackSlowFrames
+        self.telemetrySampleRate = telemetrySampleRate
+        self.collectAccessibility = collectAccessibility
+        self.featureFlags = featureFlags
+    }
+    #else // iOS, everything else
+    public init(
+        applicationID: String,
+        sessionSampleRate: SampleRate = .maxSampleRate,
+        uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,
+        uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,
         swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,
         swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,
         urlSessionTracking: URLSessionTracking? = nil,
@@ -629,56 +779,6 @@ extension RUM.Configuration {
         self.trackAnonymousUser = trackAnonymousUser
         self.trackWatchdogTerminations = trackWatchdogTerminations
         self.trackMemoryWarnings = trackMemoryWarnings
-        self.trackSlowFrames = trackSlowFrames
-        self.telemetrySampleRate = telemetrySampleRate
-        self.collectAccessibility = collectAccessibility
-        self.featureFlags = featureFlags
-    }
-    #else
-    public init(
-        applicationID: String,
-        sessionSampleRate: SampleRate = .maxSampleRate,
-        urlSessionTracking: URLSessionTracking? = nil,
-        trackFrustrations: Bool = true,
-        trackBackgroundEvents: Bool = false,
-        longTaskThreshold: TimeInterval? = 0.1,
-        appHangThreshold: TimeInterval? = nil,
-        trackWatchdogTerminations: Bool = false,
-        vitalsUpdateFrequency: VitalsFrequency? = .average,
-        networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),
-        nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),
-        viewEventMapper: RUM.ViewEventMapper? = nil,
-        resourceEventMapper: RUM.ResourceEventMapper? = nil,
-        actionEventMapper: RUM.ActionEventMapper? = nil,
-        errorEventMapper: RUM.ErrorEventMapper? = nil,
-        longTaskEventMapper: RUM.LongTaskEventMapper? = nil,
-        onSessionStart: RUM.SessionListener? = nil,
-        customEndpoint: URL? = nil,
-        trackAnonymousUser: Bool = true,
-        trackSlowFrames: Bool = true,
-        telemetrySampleRate: SampleRate = 20,
-        collectAccessibility: Bool = false,
-        featureFlags: FeatureFlags = .defaults
-    ) {
-        self.applicationID = applicationID
-        self.sessionSampleRate = sessionSampleRate
-        self.urlSessionTracking = urlSessionTracking
-        self.trackFrustrations = trackFrustrations
-        self.trackBackgroundEvents = trackBackgroundEvents
-        self.longTaskThreshold = longTaskThreshold
-        self.appHangThreshold = appHangThreshold
-        self.vitalsUpdateFrequency = vitalsUpdateFrequency
-        self.networkSettledResourcePredicate = networkSettledResourcePredicate
-        self.nextViewActionPredicate = nextViewActionPredicate
-        self.viewEventMapper = viewEventMapper
-        self.resourceEventMapper = resourceEventMapper
-        self.actionEventMapper = actionEventMapper
-        self.errorEventMapper = errorEventMapper
-        self.longTaskEventMapper = longTaskEventMapper
-        self.onSessionStart = onSessionStart
-        self.customEndpoint = customEndpoint
-        self.trackAnonymousUser = trackAnonymousUser
-        self.trackWatchdogTerminations = trackWatchdogTerminations
         self.trackSlowFrames = trackSlowFrames
         self.telemetrySampleRate = telemetrySampleRate
         self.collectAccessibility = collectAccessibility

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -16,11 +16,11 @@ internal struct VitalsReaders {
 
     init(
         frequency: TimeInterval,
-        notificationCenters: NotificationCenters,
+        notificationCenterProvider: NotificationCenterProvider,
         telemetry: Telemetry = NOPTelemetry()
     ) {
         self.frequency = frequency
-        self.cpu = VitalCPUReader(notificationCenters: notificationCenters, telemetry: telemetry)
+        self.cpu = VitalCPUReader(notificationCenterProvider: notificationCenterProvider, telemetry: telemetry)
         self.memory = VitalMemoryReader()
         self.refreshRate = VitalRefreshRateReader()
     }

--- a/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol+Convenience.swift
@@ -24,14 +24,14 @@ import DatadogInternal
 public extension RUMMonitorProtocol {
     // MARK: - views
 
-    #if !os(watchOS)
+    #if os(macOS)
     /// Starts RUM view.
     /// - Parameters:
-    ///   - viewController: the instance of `DDViewController` representing this view.
+    ///   - viewController: the instance of `NSViewController` representing this view.
     ///   - name: the name of the view. If not provided, the `viewController` class name will be used.
     ///   - attributes: custom attributes to attach to this view.
     func startView(
-        viewController: DDViewController,
+        viewController: NSViewController,
         name: String? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
@@ -40,10 +40,34 @@ public extension RUMMonitorProtocol {
 
     /// Stops RUM view.
     /// - Parameters:
-    ///   - viewController: the instance of `DDViewController` representing this view.
+    ///   - viewController: the instance of `NSViewController` representing this view.
     ///   - attributes: custom attributes to attach to this view.
     func stopView(
-        viewController: DDViewController,
+        viewController: NSViewController,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        stopView(viewController: viewController, attributes: attributes)
+    }
+    #elseif !os(watchOS)
+    /// Starts RUM view.
+    /// - Parameters:
+    ///   - viewController: the instance of `UIViewController` representing this view.
+    ///   - name: the name of the view. If not provided, the `viewController` class name will be used.
+    ///   - attributes: custom attributes to attach to this view.
+    func startView(
+        viewController: UIViewController,
+        name: String? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        startView(viewController: viewController, name: name, attributes: attributes)
+    }
+
+    /// Stops RUM view.
+    /// - Parameters:
+    ///   - viewController: the instance of `UIViewController` representing this view.
+    ///   - attributes: custom attributes to attach to this view.
+    func stopView(
+        viewController: UIViewController,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
         stopView(viewController: viewController, attributes: attributes)

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -422,7 +422,7 @@ public protocol RUMMonitorViewProtocol: AnyObject {
     #if os(macOS)
     /// Starts RUM view.
     /// - Parameters:
-    ///   - viewController: the instance of `DDViewController` representing this view.
+    ///   - viewController: the instance of `NSViewController` representing this view.
     ///   - name: the name of the view. If not provided, the `viewController` class name will be used.
     ///   - attributes: custom attributes to attach to this view.
     func startView(
@@ -433,7 +433,7 @@ public protocol RUMMonitorViewProtocol: AnyObject {
 
     /// Stops RUM view.
     /// - Parameters:
-    ///   - viewController: the instance of `DDViewController` representing this view.
+    ///   - viewController: the instance of `NSViewController` representing this view.
     ///   - attributes: custom attributes to attach to this view.
     func stopView(
         viewController: NSViewController,
@@ -442,7 +442,7 @@ public protocol RUMMonitorViewProtocol: AnyObject {
     #elseif !os(watchOS)
     /// Starts RUM view.
     /// - Parameters:
-    ///   - viewController: the instance of `DDViewController` representing this view.
+    ///   - viewController: the instance of `UIViewController` representing this view.
     ///   - name: the name of the view. If not provided, the `viewController` class name will be used.
     ///   - attributes: custom attributes to attach to this view.
     func startView(
@@ -453,7 +453,7 @@ public protocol RUMMonitorViewProtocol: AnyObject {
 
     /// Stops RUM view.
     /// - Parameters:
-    ///   - viewController: the instance of `DDViewController` representing this view.
+    ///   - viewController: the instance of `UIViewController` representing this view.
     ///   - attributes: custom attributes to attach to this view.
     func stopView(
         viewController: UIViewController,

--- a/DatadogRUM/Sources/RUMMonitorProtocol.swift
+++ b/DatadogRUM/Sources/RUMMonitorProtocol.swift
@@ -419,14 +419,14 @@ public protocol RUMMonitorViewProtocol: AnyObject {
     /// - Parameter keys: array of attribute keys that will be removed.
     func removeViewAttributes(forKeys keys: [AttributeKey])
 
-    #if !os(watchOS)
+    #if os(macOS)
     /// Starts RUM view.
     /// - Parameters:
     ///   - viewController: the instance of `DDViewController` representing this view.
     ///   - name: the name of the view. If not provided, the `viewController` class name will be used.
     ///   - attributes: custom attributes to attach to this view.
     func startView(
-        viewController: DDViewController,
+        viewController: NSViewController,
         name: String?,
         attributes: [AttributeKey: AttributeValue]
     )
@@ -436,7 +436,27 @@ public protocol RUMMonitorViewProtocol: AnyObject {
     ///   - viewController: the instance of `DDViewController` representing this view.
     ///   - attributes: custom attributes to attach to this view.
     func stopView(
-        viewController: DDViewController,
+        viewController: NSViewController,
+        attributes: [AttributeKey: AttributeValue]
+    )
+    #elseif !os(watchOS)
+    /// Starts RUM view.
+    /// - Parameters:
+    ///   - viewController: the instance of `DDViewController` representing this view.
+    ///   - name: the name of the view. If not provided, the `viewController` class name will be used.
+    ///   - attributes: custom attributes to attach to this view.
+    func startView(
+        viewController: UIViewController,
+        name: String?,
+        attributes: [AttributeKey: AttributeValue]
+    )
+
+    /// Stops RUM view.
+    /// - Parameters:
+    ///   - viewController: the instance of `DDViewController` representing this view.
+    ///   - attributes: custom attributes to attach to this view.
+    func stopView(
+        viewController: UIViewController,
         attributes: [AttributeKey: AttributeValue]
     )
     #endif

--- a/DatadogRUM/Sources/RUMVitals/VitalCPUReader.swift
+++ b/DatadogRUM/Sources/RUMVitals/VitalCPUReader.swift
@@ -25,16 +25,16 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
     private let telemetry: Telemetry
 
     init(
-        notificationCenters: NotificationCenters,
+        notificationCenterProvider: NotificationCenterProvider,
         telemetry: Telemetry = NOPTelemetry()
     ) {
         self.telemetry = telemetry
         #if os(macOS)
-        notificationCenters.workspaceCenter.addObserver(self, selector: #selector(appWillResignActive), name: WorkspaceNotifications.willSleep, object: nil)
-        notificationCenters.workspaceCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: WorkspaceNotifications.didWake, object: nil)
+        notificationCenterProvider.workspaceCenter.addObserver(self, selector: #selector(appWillResignActive), name: WorkspaceNotifications.willSleep, object: nil)
+        notificationCenterProvider.workspaceCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: WorkspaceNotifications.didWake, object: nil)
         #else
-        notificationCenters.applicationCenter.addObserver(self, selector: #selector(appWillResignActive), name: ApplicationNotifications.willResignActive, object: nil)
-        notificationCenters.applicationCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: ApplicationNotifications.didBecomeActive, object: nil)
+        notificationCenterProvider.applicationCenter.addObserver(self, selector: #selector(appWillResignActive), name: ApplicationNotifications.willResignActive, object: nil)
+        notificationCenterProvider.applicationCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: ApplicationNotifications.didBecomeActive, object: nil)
         #endif
     }
 

--- a/TestUtilities/Sources/Helpers/DDPlatformTypes.swift
+++ b/TestUtilities/Sources/Helpers/DDPlatformTypes.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+
+public typealias DDColor = UIColor
+#if !os(watchOS)
+public typealias DDView = UIView
+#endif
+#elseif canImport(AppKit)
+import AppKit
+
+public typealias DDColor = NSColor
+public typealias DDView = NSView
+#endif

--- a/TestUtilities/Sources/Helpers/UIKitHelpers.swift
+++ b/TestUtilities/Sources/Helpers/UIKitHelpers.swift
@@ -12,15 +12,6 @@ import AppKit
 import UIKit
 #endif
 
-/// The library name for UIKit framework as it will appear in unsymbolicated stack trace.
-///
-/// This name may differ between OS runtimes.
-public var uiKitLibraryName: String {
-    let uiKitBundleURL = Bundle(for: DDViewController.self).bundleURL
-    let uiKitFrameworkName = uiKitBundleURL.lastPathComponent // 'UIKitCore.framework' on iOS 12+; 'UIKit.framework' on iOS 11
-    return String(uiKitFrameworkName.dropLast(".framework".count))
-}
-
 extension DDView {
     /// Obtains a list of all the subviews, recursively, including `self`, that match a given predicate.
     ///

--- a/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/RUMFeatureMocks.swift
@@ -154,8 +154,8 @@ extension RUM.Configuration: AnyMockable, RandomMockable {
     public static func mockWith(
         applicationID: String = .mockAny(),
         sessionSampleRate: SampleRate = .maxSampleRate,
-        uiKitViewsPredicate: DDKitRUMViewsPredicate? = DefaultAppKitRUMViewsPredicate(),
-        uiKitActionsPredicate: DDKitRUMActionsPredicate? = DefaultAppKitRUMActionsPredicate(),
+        appKitViewsPredicate: DDKitRUMViewsPredicate? = DefaultAppKitRUMViewsPredicate(),
+        appKitActionsPredicate: DDKitRUMActionsPredicate? = DefaultAppKitRUMActionsPredicate(),
         swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = DefaultSwiftUIRUMViewsPredicate(),
         urlSessionTracking: URLSessionTracking? = nil,
         trackFrustrations: Bool = .mockAny(),
@@ -181,8 +181,8 @@ extension RUM.Configuration: AnyMockable, RandomMockable {
         .init(
             applicationID: applicationID,
             sessionSampleRate: sessionSampleRate,
-            uiKitViewsPredicate: uiKitViewsPredicate,
-            uiKitActionsPredicate: uiKitActionsPredicate,
+            appKitViewsPredicate: appKitViewsPredicate,
+            appKitActionsPredicate: appKitActionsPredicate,
             swiftUIViewsPredicate: swiftUIViewsPredicate,
             urlSessionTracking: urlSessionTracking,
             trackFrustrations: trackFrustrations,

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3838,25 +3838,25 @@ public protocol objc_SwiftUIRUMActionsPredicate: AnyObject
 public class objc_DefaultSwiftUIRUMActionsPredicate: NSObject, objc_SwiftUIRUMActionsPredicate
     public init(isLegacyDetectionEnabled: Bool)
     public func rumAction(with componentName: String) -> objc_RUMAction?
+public protocol objc_UIKitRUMViewsPredicate: AnyObject
+    func rumView(for viewController: UIViewController) -> objc_RUMView?
+public class objc_DefaultUIKitRUMViewsPredicate: NSObject, objc_UIKitRUMViewsPredicate
+    public func rumView(for viewController: UIViewController) -> objc_RUMView?
+public class objc_DefaultUIKitRUMActionsPredicate: NSObject, objc_UIKitRUMActionsPredicate
+    public func rumAction(targetView: UIView) -> objc_RUMAction?
+public protocol objc_UIKitRUMActionsPredicate: objc_UITouchRUMActionsPredicate
+public protocol objc_UITouchRUMActionsPredicate: AnyObject
+    func rumAction(targetView: UIView) -> objc_RUMAction?
+public protocol objc_UIPressRUMActionsPredicate: AnyObject
+    func rumAction(press type: UIPress.PressType, targetView: UIView) -> objc_RUMAction?
 public class objc_RUMView: NSObject
     public var name: String
     public var attributes: [String: Any]
     public init(name: String, attributes: [String: Any])
-public protocol objc_UIKitRUMViewsPredicate: AnyObject
-    func rumView(for viewController: DDViewController) -> objc_RUMView?
-public class objc_DefaultUIKitRUMViewsPredicate: NSObject, objc_UIKitRUMViewsPredicate
-    public func rumView(for viewController: DDViewController) -> objc_RUMView?
-public class objc_DefaultUIKitRUMActionsPredicate: NSObject, objc_UIKitRUMActionsPredicate
-    public func rumAction(targetView: DDView) -> objc_RUMAction?
 public class objc_RUMAction: NSObject
     public var name: String
     public var attributes: [String: Any]
     public init(name: String, attributes: [String: Any])
-public protocol objc_UIKitRUMActionsPredicate: objc_UITouchRUMActionsPredicate
-public protocol objc_UITouchRUMActionsPredicate: AnyObject
-    func rumAction(targetView: DDView) -> objc_RUMAction?
-public protocol objc_UIPressRUMActionsPredicate: AnyObject
-    func rumAction(press type: UIPress.PressType, targetView: DDView) -> objc_RUMAction?
 public class objc_TNSResourceParams: NSObject
     public let url: String
     public let timeSinceViewStart: TimeInterval
@@ -3984,8 +3984,8 @@ public class objc_RUMMonitor: NSObject
     public func addViewAttributes(_ attributes: [String: Any])
     public func removeViewAttribute(forKey key: String)
     public func removeViewAttributes(forKeys keys: [String])
-    public func startView(viewController: DDViewController,name: String?,attributes: [String: Any])
-    public func stopView(viewController: DDViewController,attributes: [String: Any])
+    public func startView(viewController: UIViewController,name: String?,attributes: [String: Any])
+    public func stopView(viewController: UIViewController,attributes: [String: Any])
     public func startView(key: String,name: String?,attributes: [String: Any])
     public func stopView(key: String,attributes: [String: Any])
     public func addViewLoadingTime(overwrite: Bool)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -336,28 +336,6 @@ public class Tracer
 # API surface for DatadogRUM:
 # ----------------------------------
 
-public typealias DDView = UIView
-public typealias DDControl = UIControl
-public typealias DDLabel = UILabel
-public typealias DDButton = UIButton
-public typealias DDScrollView = UIScrollView
-public typealias DDStackView = UIStackView
-public typealias DDSegmentedControl = UISegmentedControl
-public typealias DDWindow = UIWindow
-public typealias DDScreen = UIScreen
-public typealias DDViewController = UIViewController
-public typealias DDNavigationController = UINavigationController
-public typealias DDTabBarController = UITabBarController
-public typealias DDEvent = UIEvent
-public typealias DDTouch = UITouch
-public typealias DDTableViewCell = UITableViewCell
-public typealias DDCollectionViewCell = UICollectionViewCell
-public typealias DDAccessibility = UIAccessibility
-public typealias DDKitRUMActionsPredicate = UIKitRUMActionsPredicate
-public typealias DDKitRUMViewsPredicate = UIKitRUMViewsPredicate
-public typealias DDColor = UIColor
-public typealias DDFont = UIFont
-public typealias DDHostingController = UIHostingController
 public struct RUMAction
     public var name: String
     public var attributes: [AttributeKey: AttributeValue]
@@ -372,15 +350,15 @@ public struct DefaultSwiftUIRUMActionsPredicate
     public func rumAction(with componentName: String) -> RUMAction?
 public typealias UIKitRUMActionsPredicate = UITouchRUMActionsPredicate
 public protocol UITouchRUMActionsPredicate
-    func rumAction(targetView: DDView) -> RUMAction?
+    func rumAction(targetView: UIView) -> RUMAction?
 public protocol UIPressRUMActionsPredicate
-    func rumAction(press type: UIPress.PressType, targetView: DDView) -> RUMAction?
+    func rumAction(press type: UIPress.PressType, targetView: UIView) -> RUMAction?
 public struct DefaultUIKitRUMActionsPredicate
     public init ()
 [?] extension DefaultUIKitRUMActionsPredicate: UITouchRUMActionsPredicate
-    public func rumAction(targetView: DDView) -> RUMAction?
+    public func rumAction(targetView: UIView) -> RUMAction?
 [?] extension DefaultUIKitRUMActionsPredicate: UIPressRUMActionsPredicate
-    public func rumAction(press type: UIPress.PressType, targetView: DDView) -> RUMAction?
+    public func rumAction(press type: UIPress.PressType, targetView: UIView) -> RUMAction?
 public struct RUMView
     public var name: String
     public var path: String?
@@ -395,10 +373,10 @@ public struct DefaultSwiftUIRUMViewsPredicate: SwiftUIRUMViewsPredicate
 public extension SwiftUI.View
     func trackRUMView(name: String,attributes: [AttributeKey: AttributeValue] = [:],in core: DatadogCoreProtocol = CoreRegistry.default) -> some View
 public protocol UIKitRUMViewsPredicate
-    func rumView(for viewController: DDViewController) -> RUMView?
+    func rumView(for viewController: UIViewController) -> RUMView?
 public struct DefaultUIKitRUMViewsPredicate: UIKitRUMViewsPredicate
     public init ()
-    public func rumView(for viewController: DDViewController) -> RUMView?
+    public func rumView(for viewController: UIViewController) -> RUMView?
 [?] extension InternalExtension where ExtendedType == RUM
     public static func isEnabled(in core: DatadogCoreProtocol = CoreRegistry.default) -> Bool
     public static func enableURLSessionTracking(with configuration: RUM.Configuration.URLSessionTracking,in core: DatadogCoreProtocol = CoreRegistry.default) throws
@@ -418,8 +396,8 @@ public enum RUM
     public struct Configuration
         public let applicationID: String
         public var sessionSampleRate: Float
-        public var uiKitViewsPredicate: DDKitRUMViewsPredicate?
-        public var uiKitActionsPredicate: DDKitRUMActionsPredicate?
+        public var uiKitViewsPredicate: UIKitRUMViewsPredicate?
+        public var uiKitActionsPredicate: UIKitRUMActionsPredicate?
         public var swiftUIViewsPredicate: SwiftUIRUMViewsPredicate?
         public var swiftUIActionsPredicate: SwiftUIRUMActionsPredicate?
         public var urlSessionTracking: URLSessionTracking?
@@ -466,7 +444,7 @@ public enum RUM
         case matchHeaders([String])
     public init(firstPartyHostsTracing: RUM.Configuration.URLSessionTracking.FirstPartyHostsTracing? = nil,resourceAttributesProvider: RUM.ResourceAttributesProvider? = nil,trackResourceHeaders: TrackResourceHeaders = .disabled,disallowList: [String] = [])
 [?] extension RUM.Configuration
-    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: DDKitRUMViewsPredicate? = nil,uiKitActionsPredicate: DDKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,featureFlags: FeatureFlags = .defaults)
+    public init(applicationID: String,sessionSampleRate: SampleRate = .maxSampleRate,uiKitViewsPredicate: UIKitRUMViewsPredicate? = nil,uiKitActionsPredicate: UIKitRUMActionsPredicate? = nil,swiftUIViewsPredicate: SwiftUIRUMViewsPredicate? = nil,swiftUIActionsPredicate: SwiftUIRUMActionsPredicate? = nil,urlSessionTracking: URLSessionTracking? = nil,trackFrustrations: Bool = true,trackBackgroundEvents: Bool = false,longTaskThreshold: TimeInterval? = 0.1,appHangThreshold: TimeInterval? = nil,trackWatchdogTerminations: Bool = false,vitalsUpdateFrequency: VitalsFrequency? = .average,networkSettledResourcePredicate: NetworkSettledResourcePredicate = TimeBasedTNSResourcePredicate(),nextViewActionPredicate: NextViewActionPredicate? = TimeBasedINVActionPredicate(),viewEventMapper: RUM.ViewEventMapper? = nil,resourceEventMapper: RUM.ResourceEventMapper? = nil,actionEventMapper: RUM.ActionEventMapper? = nil,errorEventMapper: RUM.ErrorEventMapper? = nil,longTaskEventMapper: RUM.LongTaskEventMapper? = nil,onSessionStart: RUM.SessionListener? = nil,customEndpoint: URL? = nil,trackAnonymousUser: Bool = true,trackMemoryWarnings: Bool = true,trackSlowFrames: Bool = true,telemetrySampleRate: SampleRate = 20,collectAccessibility: Bool = false,featureFlags: FeatureFlags = .defaults)
 [?] extension InternalExtension where ExtendedType == RUM.Configuration
     public var configurationTelemetrySampleRate: Float
 [?] extension RUM.Configuration
@@ -501,8 +479,8 @@ public struct TimeBasedINVActionPredicate: NextViewActionPredicate
 public class RUMMonitor
     public static func shared(in core: DatadogCoreProtocol = CoreRegistry.default) -> RUMMonitorProtocol
 public extension RUMMonitorProtocol
-    func startView(viewController: DDViewController,name: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
-    func stopView(viewController: DDViewController,attributes: [AttributeKey: AttributeValue] = [:])
+    func startView(viewController: UIViewController,name: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
+    func stopView(viewController: UIViewController,attributes: [AttributeKey: AttributeValue] = [:])
     func startView(key: String,name: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
     func stopView(key: String,attributes: [AttributeKey: AttributeValue] = [:])
     func addError(message: String,type: String? = nil,stack: String? = nil,source: RUMErrorSource = .custom,attributes: [AttributeKey: AttributeValue] = [:],file: StaticString? = #fileID,line: UInt? = #line)
@@ -582,8 +560,8 @@ public protocol RUMMonitorViewProtocol: AnyObject
     func addViewAttributes(_ attributes: [AttributeKey: AttributeValue])
     func removeViewAttribute(forKey key: AttributeKey)
     func removeViewAttributes(forKeys keys: [AttributeKey])
-    func startView(viewController: DDViewController,name: String?,attributes: [AttributeKey: AttributeValue])
-    func stopView(viewController: DDViewController,attributes: [AttributeKey: AttributeValue])
+    func startView(viewController: UIViewController,name: String?,attributes: [AttributeKey: AttributeValue])
+    func stopView(viewController: UIViewController,attributes: [AttributeKey: AttributeValue])
     func startView(key: String,name: String?,attributes: [AttributeKey: AttributeValue])
     func stopView(key: String,attributes: [AttributeKey: AttributeValue])
     func addTiming(name: String)


### PR DESCRIPTION
### What and why?

Prepares `feature/macos` to be merged into `develop`. macOS support is not yet functional, but SDKs that depend on this one for macOS desktop support can start building on top of us. See RUM-18090 (internal) for more details.

### How?

- Restores the "macOS not supported" message, we are not ready yet!
- Makes all the platform type aliases internal instead of public (with the consequent changes in the API). There is no point in polluting the public API with this.
- Addresses improving ergonomics of `NotificationCenters` (now `NotificationCenterProvider`) based on a [past review](https://github.com/DataDog/dd-sdk-ios/pull/3107#discussion_r3782578129).

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
