### PR TITLE
[EX-3418] Send the split serial id on exposure events

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 		5B1D02822E8E6D2700AB2391 /* FlagsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D02812E8E6D2300AB2391 /* FlagsError.swift */; };
 		5B1D02862E8EB78800AB2391 /* FlagEvaluationReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D02842E8EB78600AB2391 /* FlagEvaluationReceiver.swift */; };
 		5B1D028E2E8ED10200AB2391 /* FlagAssignmentsResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D028D2E8ED0FF00AB2391 /* FlagAssignmentsResponseTests.swift */; };
+		5B1D02912E8ED10500AB2391 /* ExposureEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D02902E8ED10500AB2391 /* ExposureEventTests.swift */; };
 		5B1D02942E8ED6C000AB2391 /* FlagEvaluationReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1D02932E8ED6BE00AB2391 /* FlagEvaluationReceiverTests.swift */; };
 		5B23A8AB2FF7A8A800024C6F /* MaskSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B23A8AA2FF7A8A800024C6F /* MaskSnapshot.swift */; };
 		5B2835E12FFFF2CA00C6F0E4 /* UILabel+SRWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2835E02FFFF2C300C6F0E4 /* UILabel+SRWireframe.swift */; };
@@ -2190,6 +2191,7 @@
 		5B1D02812E8E6D2300AB2391 /* FlagsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagsError.swift; sourceTree = "<group>"; };
 		5B1D02842E8EB78600AB2391 /* FlagEvaluationReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagEvaluationReceiver.swift; sourceTree = "<group>"; };
 		5B1D028D2E8ED0FF00AB2391 /* FlagAssignmentsResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagAssignmentsResponseTests.swift; sourceTree = "<group>"; };
+		5B1D02902E8ED10500AB2391 /* ExposureEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExposureEventTests.swift; sourceTree = "<group>"; };
 		5B1D02932E8ED6BE00AB2391 /* FlagEvaluationReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagEvaluationReceiverTests.swift; sourceTree = "<group>"; };
 		5B23A8AA2FF7A8A800024C6F /* MaskSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskSnapshot.swift; sourceTree = "<group>"; };
 		5B2835E02FFFF2C300C6F0E4 /* UILabel+SRWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+SRWireframe.swift"; sourceTree = "<group>"; };
@@ -4009,6 +4011,7 @@
 			isa = PBXGroup;
 			children = (
 				5B1D028D2E8ED0FF00AB2391 /* FlagAssignmentsResponseTests.swift */,
+				5B1D02902E8ED10500AB2391 /* ExposureEventTests.swift */,
 				5B16A3692E83E46F0046A863 /* AnyValueTests.swift */,
 			);
 			path = Models;
@@ -8318,6 +8321,7 @@
 				5B4F552F2E853D7700A241C3 /* FlagsClientMocks.swift in Sources */,
 				8DADC3C92E7CCF190060F558 /* FlagsClientTests.swift in Sources */,
 				5B1D028E2E8ED10200AB2391 /* FlagAssignmentsResponseTests.swift in Sources */,
+				5B1D02912E8ED10500AB2391 /* ExposureEventTests.swift in Sources */,
 				5B1D026E2E8D079F00AB2391 /* FallbackFlagsClientTests.swift in Sources */,
 				5B1D027A2E8D6DE700AB2391 /* FlagAssignmentsFetcherTests.swift in Sources */,
 				5B16A3732E8434200046A863 /* ExposureMocks.swift in Sources */,

--- a/DatadogFlags/Sources/Client/ExposureLogger.swift
+++ b/DatadogFlags/Sources/Client/ExposureLogger.swift
@@ -43,7 +43,8 @@ internal final class ExposureLogger: ExposureLogging {
                 targetingKey: evaluationContext.targetingKey,
                 flagKey: flagKey,
                 allocationKey: assignment.allocationKey,
-                variationKey: assignment.variationKey
+                variationKey: assignment.variationKey,
+                serialID: assignment.serialID
             )
 
             guard loggedExposures.track(exposure) else {
@@ -56,6 +57,7 @@ internal final class ExposureLogger: ExposureLogging {
                 allocation: .init(key: assignment.allocationKey),
                 flag: .init(key: flagKey),
                 variant: .init(key: assignment.variationKey),
+                serialID: assignment.serialID,
                 subject: .init(
                     id: evaluationContext.targetingKey,
                     attributes: evaluationContext.attributes

--- a/DatadogFlags/Sources/Client/ExposureTracker.swift
+++ b/DatadogFlags/Sources/Client/ExposureTracker.swift
@@ -12,6 +12,7 @@ internal final class ExposureTracker {
         let flagKey: String
         let allocationKey: String
         let variationKey: String
+        let serialID: Int?
     }
 
     private final class ExposureKey: NSObject {
@@ -42,14 +43,16 @@ internal final class ExposureTracker {
     private final class Assignment {
         let allocationKey: String
         let variationKey: String
+        let serialID: Int?
 
         init(_ exposure: Exposure) {
             self.allocationKey = exposure.allocationKey
             self.variationKey = exposure.variationKey
+            self.serialID = exposure.serialID
         }
 
         func isEqual(to other: Assignment) -> Bool {
-            allocationKey == other.allocationKey && variationKey == other.variationKey
+            allocationKey == other.allocationKey && variationKey == other.variationKey && serialID == other.serialID
         }
     }
 

--- a/DatadogFlags/Sources/Models/ExposureEvent.swift
+++ b/DatadogFlags/Sources/Models/ExposureEvent.swift
@@ -20,5 +20,15 @@ internal struct ExposureEvent: Equatable, Codable {
     let allocation: Identifier
     let flag: Identifier
     let variant: Identifier
+    let serialID: Int?
     let subject: Subject
+
+    enum CodingKeys: String, CodingKey {
+        case timestamp
+        case allocation
+        case flag
+        case variant
+        case serialID = "serial_id"
+        case subject
+    }
 }

--- a/DatadogFlags/Sources/Models/FlagAssignment.swift
+++ b/DatadogFlags/Sources/Models/FlagAssignment.swift
@@ -21,6 +21,7 @@ public struct FlagAssignment: Equatable {
     public var variation: Variation
     public var reason: String
     public var doLog: Bool
+    public var serialID: Int?
 
     func variation<T: FlagValue>(as type: T.Type) -> T? {
         switch self.variation {
@@ -39,12 +40,13 @@ public struct FlagAssignment: Equatable {
         }
     }
 
-    public init(allocationKey: String, variationKey: String, variation: Variation, reason: String, doLog: Bool) {
+    public init(allocationKey: String, variationKey: String, variation: Variation, reason: String, doLog: Bool, serialID: Int? = nil) {
         self.allocationKey = allocationKey
         self.variationKey = variationKey
         self.variation = variation
         self.reason = reason
         self.doLog = doLog
+        self.serialID = serialID
     }
 }
 
@@ -56,6 +58,7 @@ extension FlagAssignment: Codable {
         case variationValue
         case reason
         case doLog
+        case serialID = "serialId"
     }
 
     public init(from decoder: any Decoder) throws {
@@ -65,6 +68,7 @@ extension FlagAssignment: Codable {
         self.variationKey = try container.decode(String.self, forKey: .variationKey)
         self.reason = try container.decode(String.self, forKey: .reason)
         self.doLog = try container.decode(Bool.self, forKey: .doLog)
+        self.serialID = try container.decodeIfPresent(Int.self, forKey: .serialID)
 
         let variationType = try container.decode(String.self, forKey: .variationType)
 
@@ -99,6 +103,7 @@ extension FlagAssignment: Codable {
         try container.encode(variationKey, forKey: .variationKey)
         try container.encode(reason, forKey: .reason)
         try container.encode(doLog, forKey: .doLog)
+        try container.encodeIfPresent(serialID, forKey: .serialID)
 
         switch variation {
         case .boolean(let value):

--- a/DatadogFlags/Sources/Models/FlagAssignment.swift
+++ b/DatadogFlags/Sources/Models/FlagAssignment.swift
@@ -68,7 +68,8 @@ extension FlagAssignment: Codable {
         self.variationKey = try container.decode(String.self, forKey: .variationKey)
         self.reason = try container.decode(String.self, forKey: .reason)
         self.doLog = try container.decode(Bool.self, forKey: .doLog)
-        self.serialID = try container.decodeIfPresent(Int.self, forKey: .serialID)
+        // A malformed serial id decodes as absent so it cannot fail the whole response.
+        self.serialID = try? container.decodeIfPresent(Int.self, forKey: .serialID)
 
         let variationType = try container.decode(String.self, forKey: .variationType)
 

--- a/DatadogFlags/Tests/Client/ExposureLoggerTests.swift
+++ b/DatadogFlags/Tests/Client/ExposureLoggerTests.swift
@@ -49,9 +49,77 @@ final class ExposureLoggerTests: XCTestCase {
                     allocation: .init(key: "allocation-123"),
                     flag: .init(key: "some-flag"),
                     variant: .init(key: "variation-123"),
+                    serialID: nil,
                     subject: .init(id: .mockAny(), attributes: .mockAny())
                 )
             ]
+        )
+    }
+
+    func testLogExposureWithSerialID() {
+        // Given
+        let logger = ExposureLogger(
+            dateProvider: DateProviderMock(now: .mockAny()),
+            featureScope: featureScope
+        )
+
+        // When
+        logger.logExposure(
+            for: "some-flag",
+            assignment: .init(
+                allocationKey: "allocation-123",
+                variationKey: "variation-123",
+                variation: .mockAnyBoolean(),
+                reason: .mockAny(),
+                doLog: true,
+                serialID: 0
+            ),
+            evaluationContext: .mockAny()
+        )
+
+        // Then
+        XCTAssertEqual(
+            featureScope.exposureEventsWritten,
+            [
+                .init(
+                    timestamp: Date.mockAny().timeIntervalSince1970.dd.toInt64Milliseconds,
+                    allocation: .init(key: "allocation-123"),
+                    flag: .init(key: "some-flag"),
+                    variant: .init(key: "variation-123"),
+                    serialID: 0,
+                    subject: .init(id: .mockAny(), attributes: .mockAny())
+                )
+            ]
+        )
+    }
+
+    func testLogExposureSerialIDAppearing() {
+        // Given
+        let logger = ExposureLogger(
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope
+        )
+        let assignment1 = FlagAssignment.mockAnyBoolean()
+        var assignment2 = assignment1
+        assignment2.serialID = 0
+
+        // When
+        logger.logExposure(
+            for: .mockAny(),
+            assignment: assignment1,
+            evaluationContext: .mockAny()
+        )
+        logger.logExposure(
+            for: .mockAny(),
+            assignment: assignment2,
+            evaluationContext: .mockAny()
+        )
+
+        // Then
+        XCTAssertEqual(
+            featureScope.exposureEventsWritten.map(\.serialID),
+            [nil, 0],
+            "A serial id appearing on an otherwise unchanged assignment should not be deduplicated"
         )
     }
 

--- a/DatadogFlags/Tests/Client/ExposureMocks.swift
+++ b/DatadogFlags/Tests/Client/ExposureMocks.swift
@@ -18,6 +18,7 @@ extension ExposureEvent: AnyMockable, RandomMockable {
             allocation: .mockAny(),
             flag: .mockAny(),
             variant: .mockAny(),
+            serialID: nil,
             subject: .mockAny()
         )
     }
@@ -28,6 +29,7 @@ extension ExposureEvent: AnyMockable, RandomMockable {
             allocation: .mockRandom(),
             flag: .mockRandom(),
             variant: .mockRandom(),
+            serialID: .mockRandom(),
             subject: .mockRandom()
         )
     }

--- a/DatadogFlags/Tests/Client/ExposureTrackerTests.swift
+++ b/DatadogFlags/Tests/Client/ExposureTrackerTests.swift
@@ -17,7 +17,8 @@ final class ExposureTrackerTests: XCTestCase {
             targetingKey: "subject-1",
             flagKey: "flag-1",
             allocationKey: "allocation-a",
-            variationKey: "variation-a"
+            variationKey: "variation-a",
+            serialID: nil
         )
 
         // When
@@ -36,13 +37,15 @@ final class ExposureTrackerTests: XCTestCase {
             targetingKey: "subject-1",
             flagKey: "flag-1",
             allocationKey: "allocation-a",
-            variationKey: "variation-a"
+            variationKey: "variation-a",
+            serialID: nil
         )
         let exposureB = ExposureTracker.Exposure(
             targetingKey: "subject-1",
             flagKey: "flag-1",
             allocationKey: "allocation-b",
-            variationKey: "variation-b"
+            variationKey: "variation-b",
+            serialID: nil
         )
 
         // When
@@ -54,6 +57,62 @@ final class ExposureTrackerTests: XCTestCase {
         XCTAssertTrue(firstTrack)
         XCTAssertTrue(secondTrack)
         XCTAssertTrue(thirdTrack)
+    }
+
+    func testItTracksSerialIDAppearingOnAnUnchangedAssignment() {
+        // Given
+        let tracker = ExposureTracker()
+        let withoutSerialID = ExposureTracker.Exposure(
+            targetingKey: "subject-1",
+            flagKey: "flag-1",
+            allocationKey: "allocation-a",
+            variationKey: "variation-a",
+            serialID: nil
+        )
+        let withSerialID = ExposureTracker.Exposure(
+            targetingKey: "subject-1",
+            flagKey: "flag-1",
+            allocationKey: "allocation-a",
+            variationKey: "variation-a",
+            serialID: 0
+        )
+
+        // When
+        let firstTrack = tracker.track(withoutSerialID)
+        let secondTrack = tracker.track(withSerialID)
+        let thirdTrack = tracker.track(withSerialID)
+
+        // Then
+        XCTAssertTrue(firstTrack)
+        XCTAssertTrue(secondTrack)
+        XCTAssertFalse(thirdTrack)
+    }
+
+    func testItTracksSerialIDChangingOnAnUnchangedAssignment() {
+        // Given
+        let tracker = ExposureTracker()
+        let exposureA = ExposureTracker.Exposure(
+            targetingKey: "subject-1",
+            flagKey: "flag-1",
+            allocationKey: "allocation-a",
+            variationKey: "variation-a",
+            serialID: 340_132
+        )
+        let exposureB = ExposureTracker.Exposure(
+            targetingKey: "subject-1",
+            flagKey: "flag-1",
+            allocationKey: "allocation-a",
+            variationKey: "variation-a",
+            serialID: 340_133
+        )
+
+        // When
+        let firstTrack = tracker.track(exposureA)
+        let secondTrack = tracker.track(exposureB)
+
+        // Then
+        XCTAssertTrue(firstTrack)
+        XCTAssertTrue(secondTrack)
     }
 
     func testItTracksTwoSubjectsAcrossManyFlags() {
@@ -71,7 +130,8 @@ final class ExposureTrackerTests: XCTestCase {
                             targetingKey: targetingKey,
                             flagKey: flagKey,
                             allocationKey: "allocation-a",
-                            variationKey: "variation-a"
+                            variationKey: "variation-a",
+                            serialID: nil
                         )
                     )
                 )
@@ -86,7 +146,8 @@ final class ExposureTrackerTests: XCTestCase {
                             targetingKey: targetingKey,
                             flagKey: flagKey,
                             allocationKey: "allocation-a",
-                            variationKey: "variation-a"
+                            variationKey: "variation-a",
+                            serialID: nil
                         )
                     )
                 )

--- a/DatadogFlags/Tests/Models/ExposureEventTests.swift
+++ b/DatadogFlags/Tests/Models/ExposureEventTests.swift
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+
+@_spi(Internal)
+@testable import DatadogFlags
+
+final class ExposureEventTests: XCTestCase {
+    private func event(serialID: Int?) -> ExposureEvent {
+        ExposureEvent(
+            timestamp: 1_731_939_805_123,
+            allocation: .init(key: "allocation-123"),
+            flag: .init(key: "some-flag"),
+            variant: .init(key: "variation-123"),
+            serialID: serialID,
+            subject: .init(id: "subject-1", attributes: [:])
+        )
+    }
+
+    func testEncodingSerialIDAsSnakeCase() throws {
+        // When
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(event(serialID: 0))) as? [String: Any]
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(json)["serial_id"] as? Int, 0)
+    }
+
+    func testEncodingOmitsAbsentSerialID() throws {
+        // When
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(event(serialID: nil))) as? [String: Any]
+
+        // Then
+        XCTAssertFalse(try XCTUnwrap(json).keys.contains("serial_id"))
+    }
+}

--- a/DatadogFlags/Tests/Models/FlagAssignmentsResponseTests.swift
+++ b/DatadogFlags/Tests/Models/FlagAssignmentsResponseTests.swift
@@ -283,12 +283,60 @@ final class FlagAssignmentsResponseTests: XCTestCase {
         let withValue = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(#", "serialId": 340132"#))
         let withNull = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(#", "serialId": null"#))
         let withoutKey = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(""))
+        let withString = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(#", "serialId": "abc""#))
+        let withFraction = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(#", "serialId": 3.7"#))
 
         // Then
         XCTAssertEqual(withZero.serialID, 0)
         XCTAssertEqual(withValue.serialID, 340_132)
         XCTAssertNil(withNull.serialID, "An explicit null must decode as an absent serial id")
         XCTAssertNil(withoutKey.serialID)
+        XCTAssertNil(withString.serialID, "A malformed serial id must decode as absent")
+        XCTAssertNil(withFraction.serialID, "A malformed serial id must decode as absent")
+        XCTAssertEqual(withString.variation, .string("red"), "The rest of the flag must still decode")
+    }
+
+    func testDecodingMalformedSerialIDDoesNotFailSiblingFlags() throws {
+        // Given
+        let json = """
+        {
+          "data": {
+            "id": "test_subject",
+            "type": "precomputed-assignments",
+            "attributes": {
+              "flags": {
+                "broken-serial-id-flag": {
+                  "allocationKey": "allocation-123",
+                  "variationKey": "variation-123",
+                  "variationType": "string",
+                  "variationValue": "red",
+                  "doLog": true,
+                  "reason": "TARGETING_MATCH",
+                  "serialId": "not-an-integer"
+                },
+                "healthy-flag": {
+                  "allocationKey": "allocation-124",
+                  "variationKey": "variation-124",
+                  "variationType": "boolean",
+                  "variationValue": true,
+                  "doLog": true,
+                  "reason": "TARGETING_MATCH",
+                  "serialId": 0
+                }
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        // When
+        let response = try JSONDecoder().decode(FlagAssignmentsResponse.self, from: json)
+
+        // Then
+        XCTAssertEqual(response.flags.count, 2)
+        XCTAssertNil(try XCTUnwrap(response.flags["broken-serial-id-flag"]).serialID)
+        XCTAssertEqual(try XCTUnwrap(response.flags["healthy-flag"]).serialID, 0)
+        XCTAssertEqual(response.failedFlags, [:])
     }
 
     func testEncodingSerialID() throws {

--- a/DatadogFlags/Tests/Models/FlagAssignmentsResponseTests.swift
+++ b/DatadogFlags/Tests/Models/FlagAssignmentsResponseTests.swift
@@ -263,6 +263,56 @@ final class FlagAssignmentsResponseTests: XCTestCase {
         XCTAssertTrue(anotherBrokenFlagError.contains("ANOTHER_NEW_TYPE"), "Error should mention the unknown variant type")
     }
 
+    func testDecodingSerialID() throws {
+        // Given
+        let withSerialIDEntry = { (entry: String) in
+            """
+            {
+              "allocationKey": "allocation-123",
+              "variationKey": "variation-123",
+              "variationType": "string",
+              "variationValue": "red",
+              "doLog": true,
+              "reason": "TARGETING_MATCH"\(entry)
+            }
+            """.data(using: .utf8)!
+        }
+
+        // When
+        let withZero = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(#", "serialId": 0"#))
+        let withValue = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(#", "serialId": 340132"#))
+        let withNull = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(#", "serialId": null"#))
+        let withoutKey = try JSONDecoder().decode(FlagAssignment.self, from: withSerialIDEntry(""))
+
+        // Then
+        XCTAssertEqual(withZero.serialID, 0)
+        XCTAssertEqual(withValue.serialID, 340_132)
+        XCTAssertNil(withNull.serialID, "An explicit null must decode as an absent serial id")
+        XCTAssertNil(withoutKey.serialID)
+    }
+
+    func testEncodingSerialID() throws {
+        // Given
+        let assignment = FlagAssignment(
+            allocationKey: "allocation-123",
+            variationKey: "variation-123",
+            variation: .string("red"),
+            reason: "TARGETING_MATCH",
+            doLog: true,
+            serialID: 0
+        )
+        var withoutSerialID = assignment
+        withoutSerialID.serialID = nil
+
+        // When
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(assignment)) as? [String: Any]
+        let encodedWithoutSerialID = try JSONSerialization.jsonObject(with: JSONEncoder().encode(withoutSerialID)) as? [String: Any]
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(encoded)["serialId"] as? Int, 0)
+        XCTAssertFalse(try XCTUnwrap(encodedWithoutSerialID).keys.contains("serialId"))
+    }
+
     func testDecodingFlagAssignmentWithUnknownVariationType() throws {
         // Given
         let json = """

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1644,7 +1644,8 @@ public struct FlagAssignment: Equatable
     public var variation: Variation
     public var reason: String
     public var doLog: Bool
-    public init(allocationKey: String, variationKey: String, variation: Variation, reason: String, doLog: Bool)
+    public var serialID: Int?
+    public init(allocationKey: String, variationKey: String, variation: Variation, reason: String, doLog: Bool, serialID: Int? = nil)
     public init(from decoder: any Decoder) throws
     public func encode(to encoder: any Encoder) throws
 public enum FlagEvaluationError: Error


### PR DESCRIPTION
### What and why?

Exposure events sent by `DatadogFlags` carry no serial id. The exposures intake uses the serial id to find the holdout that an allocation comes from. The flag configuration rewrites a holdout into a usual allocation before an SDK receives it, so the serial id is the only link back to the holdout.

The precompute service already sends the value in the `serialId` field of each flag. This adds a top-level `serial_id` to the exposure event, matching `DataDog/openfeature-js-client#368` for the web SDK, which reads the same precompute response.

JIRA: EX-3418

### How?

| File | Change |
|---|---|
| `Models/FlagAssignment.swift` | Optional `serialID`, decoded from `serialId` and re-encoded |
| `Models/ExposureEvent.swift` | Optional `serialID`, encoded as `serial_id` |
| `Client/ExposureLogger.swift` | Sets the field from the precomputed assignment |
| `Client/ExposureTracker.swift` | Adds the serial id to the deduplication comparison |

The server sends an explicit null when an assignment has no serial id, so decoding accepts null as well as an absent key, and encoding omits the key rather than writing null. The model is re-encoded for on-disk persistence through `FlagsData`, so the value survives a cold start.

Serial ids start at zero for each organization, which makes zero the most common value. Presence is therefore tested rather than truthiness, and the tests pin zero.

The deduplication cache keys on the flag and subject and compares the allocation and variant. The serial id joins that comparison. Without it, a serial id that appears or changes while the allocation and variant stay the same sends no exposure, and the server metric `ffe.ufc.vac_miss` shows this transition happens in production. The consequence is a small number of extra exposures for assignments whose serial id arrives on a later configuration refresh.

The value is passed through unchanged. The flag configuration layer owns validation.

`FlagAssignment` is `@_spi(Internal)`, so this adds no public API. The new initializer parameter is defaulted, so existing call sites are unaffected.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — not user facing
- [ ] Add Objective-C interface for public APIs — SPI only, `api-surface-objc` unchanged
- [x] Run `make api-surface` when adding new APIs
