### PR TITLE
RUM-18197 Fix timeseries clock monotonicity and hasReplay accumulation

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1182,6 +1182,7 @@
 		D29A9F8629DD85BB005C54A4 /* SessionReplayDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615950ED291C058F00470E0C /* SessionReplayDependency.swift */; };
 		D29A9F8729DD85BB005C54A4 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
 		D29A9F8829DD85BB005C54A4 /* ErrorMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D215ED6A29D2E1080046B721 /* ErrorMessageReceiver.swift */; };
+		3FFF03CB7F99425AA2C13764 /* HasReplayMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F35629D12B41C7BD33C5F7 /* HasReplayMessageReceiver.swift */; };
 		D29A9F8C29DD861C005C54A4 /* ValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611529A425E3DD51004F740E /* ValuePublisher.swift */; };
 		D29A9F8D29DD8665005C54A4 /* UIKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */; };
 		D29A9F8E29DD8665005C54A4 /* SwiftUIExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FCA238271D896E0020286F /* SwiftUIExtensions.swift */; };
@@ -1204,6 +1205,7 @@
 		D29A9FB829DDB483005C54A4 /* RUMViewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */; };
 		D29A9FB929DDB483005C54A4 /* RUMEventsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E81F625A743600084B751 /* RUMEventsMapperTests.swift */; };
 		D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26ED28AFB65B005DD405 /* ErrorMessageReceiverTests.swift */; };
+		4BDA9ACABD194508802E4600 /* HasReplayMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5720D67B13FE4984A00AE45A /* HasReplayMessageReceiverTests.swift */; };
 		D29A9FBC29DDB483005C54A4 /* RUMResourceScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB424C864680082C633 /* RUMResourceScopeTests.swift */; };
 		D29A9FBD29DDB483005C54A4 /* RUMSessionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */; };
 		D29A9FBE29DDB483005C54A4 /* RUMEventBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */; };
@@ -2930,6 +2932,7 @@
 		D214DAA429E072D7004D0AE8 /* MessageBus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBus.swift; sourceTree = "<group>"; };
 		D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryReceiver.swift; sourceTree = "<group>"; };
 		D215ED6A29D2E1080046B721 /* ErrorMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageReceiver.swift; sourceTree = "<group>"; };
+		E6F35629D12B41C7BD33C5F7 /* HasReplayMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasReplayMessageReceiver.swift; sourceTree = "<group>"; };
 		D215F0932F6D5DE000E86466 /* ThirdPartyDelegateProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyDelegateProxy.swift; sourceTree = "<group>"; };
 		D2160C9429C0DE5600FAA9A5 /* FirstPartyHosts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirstPartyHosts.swift; sourceTree = "<group>"; };
 		D2160C9629C0DE5600FAA9A5 /* TracingHeaderType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TracingHeaderType.swift; sourceTree = "<group>"; };
@@ -2954,6 +2957,7 @@
 		D21C26D028A64599005DD405 /* MessageBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusTests.swift; sourceTree = "<group>"; };
 		D21C26EA28AFA11E005DD405 /* LogMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D21C26ED28AFB65B005DD405 /* ErrorMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageReceiverTests.swift; sourceTree = "<group>"; };
+		5720D67B13FE4984A00AE45A /* HasReplayMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasReplayMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D22442C42CA301DA002E71E4 /* UIColor+SessionReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SessionReplay.swift"; sourceTree = "<group>"; };
 		D224430C29E95D6600274EC7 /* CrashReportReceiverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportReceiverTests.swift; sourceTree = "<group>"; };
 		D22689C22EB12D3D00875E44 /* KSCrashPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KSCrashPlugin.swift; sourceTree = "<group>"; };
@@ -5325,6 +5329,7 @@
 				D2CBC26A294383F200134409 /* WebViewEventReceiver.swift */,
 				D236BE2729520FED00676E67 /* CrashReportReceiver.swift */,
 				D215ED6A29D2E1080046B721 /* ErrorMessageReceiver.swift */,
+				E6F35629D12B41C7BD33C5F7 /* HasReplayMessageReceiver.swift */,
 				D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */,
 				61DCC84D2C071DCD00CB59E5 /* TelemetryInterceptor.swift */,
 				D2D748222DC0FF7E00C61353 /* FatalErrorContextNotifier.swift */,
@@ -6623,6 +6628,7 @@
 				A7E6EA832D314A9900997201 /* AnonymousIdentifierManagerTests.swift */,
 				615950EA291C029700470E0C /* SessionReplayDependencyTests.swift */,
 				D21C26ED28AFB65B005DD405 /* ErrorMessageReceiverTests.swift */,
+				5720D67B13FE4984A00AE45A /* HasReplayMessageReceiverTests.swift */,
 				9E53889B2773C4B300A7DC42 /* WebViewEventReceiverTests.swift */,
 				D248ED4728081B9B00B315B4 /* TelemetryReceiverTests.swift */,
 				61C453492C0A0BBF00CC4C17 /* TelemetryInterceptorTests.swift */,
@@ -9406,6 +9412,7 @@
 				118ACA3C2EEED247004E7F20 /* AppLaunchMetricController.swift in Sources */,
 				118ACA3D2EEED247004E7F20 /* AppLaunchMetric.swift in Sources */,
 				D29A9F8829DD85BB005C54A4 /* ErrorMessageReceiver.swift in Sources */,
+				3FFF03CB7F99425AA2C13764 /* HasReplayMessageReceiver.swift in Sources */,
 				96F70D452DD793C400D3736B /* RUMAction.swift in Sources */,
 				D29A9F8729DD85BB005C54A4 /* SwiftUIActionModifier.swift in Sources */,
 				D29A9F5D29DD85BB005C54A4 /* RUMCommandSubscriber.swift in Sources */,
@@ -9515,6 +9522,7 @@
 				61181CDC2BF35BC000632A7A /* FatalErrorContextNotifierTests.swift in Sources */,
 				61C713BC2A3C95AD00FA735A /* RUMInstrumentationTests.swift in Sources */,
 				D29A9FBB29DDB483005C54A4 /* ErrorMessageReceiverTests.swift in Sources */,
+				4BDA9ACABD194508802E4600 /* HasReplayMessageReceiverTests.swift in Sources */,
 				A1B2C3E72F92000100ABCDEF /* ProfilingContextRUMTests.swift in Sources */,
 				61C713C02A3C9DAD00FA735A /* RequestBuilderTests.swift in Sources */,
 				D29A9F9F29DDB483005C54A4 /* RUMApplicationScopeTests.swift in Sources */,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -313,7 +313,6 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
                 featureScope: featureScope,
                 monitor: monitor
             ),
-            HasReplayMessageReceiver(monitor: monitor),
             FlagEvaluationReceiver(monitor: monitor),
             WebViewEventReceiver(
                 featureScope: featureScope,
@@ -342,6 +341,10 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
 
         if let watchdogTermination = watchdogTermination {
             messageReceivers.append(watchdogTermination)
+        }
+
+        if timeseriesCollector != nil {
+            messageReceivers.append(HasReplayMessageReceiver(monitor: monitor))
         }
 
         self.messageReceiver = CombinedFeatureMessageReceiver(messageReceivers)

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -313,6 +313,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
                 featureScope: featureScope,
                 monitor: monitor
             ),
+            HasReplayMessageReceiver(monitor: monitor),
             FlagEvaluationReceiver(monitor: monitor),
             WebViewEventReceiver(
                 featureScope: featureScope,

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -154,7 +154,8 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
                 ciTest: ciTest,
                 syntheticsTest: syntheticsTest,
                 sessionSampleRate: Double(sessionSampleRate),
-                now: { configuration.dateProvider.now }
+                now: { configuration.dateProvider.now },
+                mediaTimeProvider: configuration.mediaTimeProvider
             )
         }
 

--- a/DatadogRUM/Sources/Integrations/HasReplayMessageReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/HasReplayMessageReceiver.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+/// Observes `DatadogContext.hasReplay` through the core's context message bus so `Monitor` stays current
+/// even when Session Replay starts/stops with no `RUMCommand` processed around the same time.
+internal struct HasReplayMessageReceiver: FeatureMessageReceiver {
+    let monitor: Monitor
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard case let .context(context) = message else {
+            return false
+        }
+
+        monitor.update(hasReplay: context.hasReplay)
+
+        return false
+    }
+}

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -171,10 +171,18 @@ internal class Monitor: RUMCommandSubscriber {
             }
 
             let transformedCommand = self.transform(command: command)
+            let previousSessionID = self.sessionActivitySnapshot.sessionID
 
             _ = self.applicationScope.process(command: transformedCommand, context: context, writer: writer)
 
-            self.update(hasReplay: context.hasReplay)
+            if self.applicationScope.dependencies.timeseriesCollector != nil {
+                let currentSessionID = self.applicationScope.activeSession?.sessionUUID.toRUMDataFormat
+                // If a session boundary was just crossed, `context.hasReplay` still reflects the previous
+                // session's Session Replay decision (SR hasn't recomputed it for the new session yet), so
+                // carrying it over would leak stale replay state into the new session.
+                let didStartNewSession = previousSessionID != nil && currentSessionID != previousSessionID
+                self.update(hasReplay: didStartNewSession ? nil : context.hasReplay)
+            }
 
             if let debugging = self.debugging {
                 debugging.debug(applicationScope: self.applicationScope)

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -138,6 +138,13 @@ internal class Monitor: RUMCommandSubscriber {
     @ReadWriteLock
     private var hasReplaySnapshot: Bool? = nil
 
+    /// Updates the replay state snapshot exposed through `RUMActiveContextReader`. Called both from
+    /// `process(command:)` and from `HasReplayMessageReceiver`, since Session Replay toggles `hasReplay`
+    /// through the core context bus, not through a `RUMCommand`.
+    func update(hasReplay: Bool?) {
+        hasReplaySnapshot = hasReplay
+    }
+
     private let fatalErrorContext: FatalErrorContextNotifying
     private let rumUUIDGenerator: RUMUUIDGenerator
     private let telemetry: Telemetry
@@ -167,7 +174,7 @@ internal class Monitor: RUMCommandSubscriber {
 
             _ = self.applicationScope.process(command: transformedCommand, context: context, writer: writer)
 
-            self.hasReplaySnapshot = context.hasReplay
+            self.update(hasReplay: context.hasReplay)
 
             if let debugging = self.debugging {
                 debugging.debug(applicationScope: self.applicationScope)

--- a/DatadogRUM/Sources/RUMMonitor/Monitor.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Monitor.swift
@@ -106,6 +106,9 @@ internal protocol RUMActiveContextReader: AnyObject {
     var globalAttributes: [AttributeKey: AttributeValue] { get }
     /// The currently active view, if any. Conformers must guarantee this is safe to read from any thread.
     var activeView: (id: String?, path: String?, name: String?) { get }
+    /// The most recently observed `DatadogContext.hasReplay` value, or `nil` if no command has been
+    /// processed yet. Conformers must guarantee this is safe to read from any thread.
+    var hasReplay: Bool? { get }
     /// Whether the session identified by `sessionID` has expired (exceeded its max duration or inactivity
     /// timeout) as of `date`, evaluated against a live, single source of truth instead of a shadow copy of
     /// that state. Returns `false` if `sessionID` doesn't match the currently active session (e.g. a session
@@ -131,6 +134,9 @@ internal class Monitor: RUMCommandSubscriber {
 
     @ReadWriteLock
     private var sessionActivitySnapshot: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?) = (nil, nil, nil)
+
+    @ReadWriteLock
+    private var hasReplaySnapshot: Bool? = nil
 
     private let fatalErrorContext: FatalErrorContextNotifying
     private let rumUUIDGenerator: RUMUUIDGenerator
@@ -160,6 +166,8 @@ internal class Monitor: RUMCommandSubscriber {
             let transformedCommand = self.transform(command: command)
 
             _ = self.applicationScope.process(command: transformedCommand, context: context, writer: writer)
+
+            self.hasReplaySnapshot = context.hasReplay
 
             if let debugging = self.debugging {
                 debugging.debug(applicationScope: self.applicationScope)
@@ -237,6 +245,7 @@ internal class Monitor: RUMCommandSubscriber {
 extension Monitor: RUMActiveContextReader {
     var globalAttributes: [AttributeKey: AttributeValue] { attributes }
     var activeView: (id: String?, path: String?, name: String?) { activeViewSnapshot }
+    var hasReplay: Bool? { hasReplaySnapshot }
 
     func isSessionExpired(sessionID: String, at date: Date) -> Bool {
         let activity = sessionActivitySnapshot

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -70,6 +70,15 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     /// `RUMSessionScope.Constants.sessionTimeoutDuration` even when the app goes idle with no RUM commands.
     private var lastActivityTime: Date = .distantPast
     private let now: () -> Date
+    private let mediaTimeProvider: CACurrentMediaTimeProvider
+    /// The wall-clock date and monotonic media time captured together at the start of the current session,
+    /// used to derive sample timestamps that are immune to wall-clock adjustments (see `sample()`).
+    private var anchorDate: Date = .distantPast
+    private var anchorMediaTime: CFTimeInterval = 0
+    /// Whether replay was reported active by `activeContextReader` at any point during the current session,
+    /// OR-accumulated in `sample()` (mirrors `RUMViewScope`'s per-view `hasReplay` accumulation) so a batch
+    /// still reports `hasReplay: true` even if replay stopped before the batch was flushed.
+    private var hasReplay: Bool = false
 
     /// All buffer mutations and timer events run on this queue.
     private let queue = DispatchQueue(label: "com.datadoghq.timeseries-collector", qos: .utility)
@@ -85,7 +94,8 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         ciTest: RUMCITest? = nil,
         syntheticsTest: RUMSyntheticsTest? = nil,
         sessionSampleRate: Double = 100,
-        now: @escaping () -> Date = Date.init
+        now: @escaping () -> Date = Date.init,
+        mediaTimeProvider: CACurrentMediaTimeProvider = MediaTimeProvider()
     ) {
         self.memoryReader = memoryReader
         self.batchSize = max(2, batchSize)
@@ -98,6 +108,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         self.sessionSampleRate = sessionSampleRate
         self.cpuUsageProvider = cpuUsageProvider ?? { TimeseriesSessionCollector.processCPU() }
         self.now = now
+        self.mediaTimeProvider = mediaTimeProvider
     }
 
     deinit {
@@ -162,6 +173,9 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.memoryBuffer = []
             self.cpuBuffer = []
             self.isPaused = false
+            self.hasReplay = false
+            self.anchorDate = self.now()
+            self.anchorMediaTime = self.mediaTimeProvider.current
 
             self.timer?.cancel()
             self.timer = self.makeTimer()
@@ -245,7 +259,14 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     // MARK: - Private
 
     private func sample() {
-        let currentDate = now()
+        // Derived from the monotonic media clock anchored at session start, rather than raw `now()`, so a
+        // backward wall-clock adjustment mid-session (NTP sync, manual clock change) can't produce
+        // out-of-order or inverted (`end < start`) batch timestamps.
+        let currentDate = anchorDate.addingTimeInterval(mediaTimeProvider.current - anchorMediaTime)
+
+        if let hasContextReplay = activeContextReader?.hasReplay {
+            hasReplay = hasReplay || hasContextReplay
+        }
 
         // Self-enforce the same session lifetime rules `RUMSessionScope` uses, in case this session
         // has expired without any RUM command arriving to call `stop(sessionID:)` (e.g. the app went
@@ -293,6 +314,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let ciTest = self.ciTest
         let syntheticsTest = self.syntheticsTest
         let sessionSampleRate = self.sessionSampleRate
+        let hasReplay = self.hasReplay
         let start = batch[0].timestamp
         let end = batch[batch.count - 1].timestamp
         let eventID = UUID().uuidString.lowercased()
@@ -313,7 +335,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 device: context.normalizedDevice(),
                 os: context.os,
                 service: context.service,
-                session: .init(hasReplay: context.hasReplay, id: sessionID, type: sessionType),
+                session: .init(hasReplay: hasReplay, id: sessionID, type: sessionType),
                 source: .init(rawValue: context.source) ?? .ios,
                 synthetics: syntheticsTest,
                 timeseries: .init(
@@ -346,6 +368,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let ciTest = self.ciTest
         let syntheticsTest = self.syntheticsTest
         let sessionSampleRate = self.sessionSampleRate
+        let hasReplay = self.hasReplay
         let start = batch[0].timestamp
         let end = batch[batch.count - 1].timestamp
         let eventID = UUID().uuidString.lowercased()
@@ -366,7 +389,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 device: context.normalizedDevice(),
                 os: context.os,
                 service: context.service,
-                session: .init(hasReplay: context.hasReplay, id: sessionID, type: sessionType),
+                session: .init(hasReplay: hasReplay, id: sessionID, type: sessionType),
                 source: .init(rawValue: context.source) ?? .ios,
                 synthetics: syntheticsTest,
                 timeseries: .init(

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -75,15 +75,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     /// used to derive sample timestamps that are immune to wall-clock adjustments (see `sample()`).
     private var anchorDate: Date = .distantPast
     private var anchorMediaTime: CFTimeInterval = 0
-    /// The date of the most recently emitted sample, used as a floor when re-anchoring in `resume()` so a
-    /// backward wall-clock jump while paused/backgrounded can't make the new anchor precede samples already
-    /// flushed before the pause (see `resume(sessionID:)`).
+    /// The date of the most recently emitted sample, used as a floor when re-anchoring in `resume()`.
     private var lastSampleDate: Date?
-    /// Whether replay was reported active by `activeContextReader` at any point during the current session,
-    /// OR-accumulated in `sample()` (mirrors `RUMViewScope`'s per-view `hasReplay` accumulation) so a batch
-    /// still reports `hasReplay: true` even if replay stopped before the batch was flushed. Stays `nil` until
-    /// a value has actually been observed, so sessions with no Session Replay context still omit the field
-    /// instead of reporting a false `false`.
+    /// Whether replay was reported active at any point during the session, OR-accumulated in `sample()`
+    /// (mirrors `RUMViewScope`). Stays `nil` until observed, so sessions without Session Replay omit the field.
     private var hasReplay: Bool? = nil
 
     /// All buffer mutations and timer events run on this queue.
@@ -216,11 +211,9 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 return
             }
             self.isPaused = false
-            // Re-anchor to the current wall/media time pair so a pause spanning real device sleep (during
-            // which the monotonic media clock doesn't advance) doesn't offset post-resume sample timestamps
-            // backward by the sleep duration. Clamped to `lastSampleDate` so a wall-clock jump *backward*
-            // while paused can't make the new anchor precede samples already flushed before the pause —
-            // preserving monotonicity across the pause/resume boundary in both directions.
+            // Re-anchor so a pause spanning device sleep (media clock frozen) doesn't lag post-resume
+            // samples; clamp to `lastSampleDate` so a backward wall-clock jump while paused can't make
+            // the new anchor precede samples already flushed before the pause.
             let resumeDate = self.now()
             self.anchorDate = max(resumeDate, self.lastSampleDate ?? resumeDate)
             self.anchorMediaTime = self.mediaTimeProvider.current
@@ -274,28 +267,27 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     // MARK: - Private
 
     private func sample() {
-        // Derived from the monotonic media clock anchored at session start, rather than raw `now()`, so a
-        // backward wall-clock adjustment mid-session (NTP sync, manual clock change) can't produce
-        // out-of-order or inverted (`end < start`) batch timestamps.
-        let currentDate = anchorDate.addingTimeInterval(mediaTimeProvider.current - anchorMediaTime)
+        // Anchored to the monotonic media clock so a backward wall-clock adjustment can't invert
+        // timestamps; re-anchored to `now()` when it's ahead so a forward correction isn't stuck lagging.
+        let anchoredDate = anchorDate.addingTimeInterval(mediaTimeProvider.current - anchorMediaTime)
+        let wallClockDate = now()
+        let currentDate: Date
+        if wallClockDate > anchoredDate {
+            currentDate = wallClockDate
+            anchorDate = wallClockDate
+            anchorMediaTime = mediaTimeProvider.current
+        } else {
+            currentDate = anchoredDate
+        }
         lastSampleDate = currentDate
 
         if let hasContextReplay = activeContextReader?.hasReplay {
             hasReplay = (hasReplay ?? false) || hasContextReplay
         }
 
-        // Self-enforce the same session lifetime rules `RUMSessionScope` uses, in case this session
-        // has expired without any RUM command arriving to call `stop(sessionID:)` (e.g. the app went
-        // idle with no user interaction). This is a safety net only — it does not affect RUM's own
-        // session state, it just stops this collector from uploading data past session expiry.
-        //
-        // Pulled fresh from `activeContextReader` on every tick, rather than from a locally pushed
-        // copy, so there's a single live source of truth and no race with how/when that state is updated.
-        //
-        // Compared against `now()`, not the anchored `currentDate`, because `sessionStartTime`/
-        // `lastInteractionTime` on the `Monitor` side are wall-clock `Date`s — comparing them against the
-        // sleep/adjustment-immune anchored date would reintroduce spurious expiry on the very same backward
-        // clock jumps this anchoring is meant to guard against.
+        // Self-enforce `RUMSessionScope`'s lifetime rules in case this session expired with no RUM
+        // command arriving to call `stop(sessionID:)`. Compared against `now()`, not the anchored
+        // `currentDate`, since `Monitor`'s expiry state is tracked in wall-clock `Date`s.
         if activeContextReader?.isSessionExpired(sessionID: sessionID, at: now()) == true {
             timer?.cancel()
             timer = nil

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -77,8 +77,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     private var anchorMediaTime: CFTimeInterval = 0
     /// Whether replay was reported active by `activeContextReader` at any point during the current session,
     /// OR-accumulated in `sample()` (mirrors `RUMViewScope`'s per-view `hasReplay` accumulation) so a batch
-    /// still reports `hasReplay: true` even if replay stopped before the batch was flushed.
-    private var hasReplay: Bool = false
+    /// still reports `hasReplay: true` even if replay stopped before the batch was flushed. Stays `nil` until
+    /// a value has actually been observed, so sessions with no Session Replay context still omit the field
+    /// instead of reporting a false `false`.
+    private var hasReplay: Bool? = nil
 
     /// All buffer mutations and timer events run on this queue.
     private let queue = DispatchQueue(label: "com.datadoghq.timeseries-collector", qos: .utility)
@@ -173,7 +175,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.memoryBuffer = []
             self.cpuBuffer = []
             self.isPaused = false
-            self.hasReplay = false
+            self.hasReplay = nil
             self.anchorDate = self.now()
             self.anchorMediaTime = self.mediaTimeProvider.current
 
@@ -209,6 +211,12 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
                 return
             }
             self.isPaused = false
+            // Re-anchor to the current wall/media time pair so a pause spanning real device sleep (during
+            // which the monotonic media clock doesn't advance) doesn't offset post-resume sample timestamps
+            // backward by the sleep duration. Safe to do here since no samples are taken while paused, so
+            // this can't reintroduce the out-of-order timestamps `sample()`'s anchoring guards against.
+            self.anchorDate = self.now()
+            self.anchorMediaTime = self.mediaTimeProvider.current
             self.timer = self.makeTimer()
         }
     }
@@ -265,7 +273,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         let currentDate = anchorDate.addingTimeInterval(mediaTimeProvider.current - anchorMediaTime)
 
         if let hasContextReplay = activeContextReader?.hasReplay {
-            hasReplay = hasReplay || hasContextReplay
+            hasReplay = (hasReplay ?? false) || hasContextReplay
         }
 
         // Self-enforce the same session lifetime rules `RUMSessionScope` uses, in case this session
@@ -275,7 +283,12 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         //
         // Pulled fresh from `activeContextReader` on every tick, rather than from a locally pushed
         // copy, so there's a single live source of truth and no race with how/when that state is updated.
-        if activeContextReader?.isSessionExpired(sessionID: sessionID, at: currentDate) == true {
+        //
+        // Compared against `now()`, not the anchored `currentDate`, because `sessionStartTime`/
+        // `lastInteractionTime` on the `Monitor` side are wall-clock `Date`s — comparing them against the
+        // sleep/adjustment-immune anchored date would reintroduce spurious expiry on the very same backward
+        // clock jumps this anchoring is meant to guard against.
+        if activeContextReader?.isSessionExpired(sessionID: sessionID, at: now()) == true {
             timer?.cancel()
             timer = nil
             flushMemory()

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -75,6 +75,10 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     /// used to derive sample timestamps that are immune to wall-clock adjustments (see `sample()`).
     private var anchorDate: Date = .distantPast
     private var anchorMediaTime: CFTimeInterval = 0
+    /// The date of the most recently emitted sample, used as a floor when re-anchoring in `resume()` so a
+    /// backward wall-clock jump while paused/backgrounded can't make the new anchor precede samples already
+    /// flushed before the pause (see `resume(sessionID:)`).
+    private var lastSampleDate: Date?
     /// Whether replay was reported active by `activeContextReader` at any point during the current session,
     /// OR-accumulated in `sample()` (mirrors `RUMViewScope`'s per-view `hasReplay` accumulation) so a batch
     /// still reports `hasReplay: true` even if replay stopped before the batch was flushed. Stays `nil` until
@@ -178,6 +182,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.hasReplay = nil
             self.anchorDate = self.now()
             self.anchorMediaTime = self.mediaTimeProvider.current
+            self.lastSampleDate = nil
 
             self.timer?.cancel()
             self.timer = self.makeTimer()
@@ -213,9 +218,11 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             self.isPaused = false
             // Re-anchor to the current wall/media time pair so a pause spanning real device sleep (during
             // which the monotonic media clock doesn't advance) doesn't offset post-resume sample timestamps
-            // backward by the sleep duration. Safe to do here since no samples are taken while paused, so
-            // this can't reintroduce the out-of-order timestamps `sample()`'s anchoring guards against.
-            self.anchorDate = self.now()
+            // backward by the sleep duration. Clamped to `lastSampleDate` so a wall-clock jump *backward*
+            // while paused can't make the new anchor precede samples already flushed before the pause —
+            // preserving monotonicity across the pause/resume boundary in both directions.
+            let resumeDate = self.now()
+            self.anchorDate = max(resumeDate, self.lastSampleDate ?? resumeDate)
             self.anchorMediaTime = self.mediaTimeProvider.current
             self.timer = self.makeTimer()
         }
@@ -271,6 +278,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         // backward wall-clock adjustment mid-session (NTP sync, manual clock change) can't produce
         // out-of-order or inverted (`end < start`) batch timestamps.
         let currentDate = anchorDate.addingTimeInterval(mediaTimeProvider.current - anchorMediaTime)
+        lastSampleDate = currentDate
 
         if let hasContextReplay = activeContextReader?.hasReplay {
             hasReplay = (hasReplay ?? false) || hasContextReplay

--- a/DatadogRUM/Tests/Integrations/HasReplayMessageReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/HasReplayMessageReceiverTests.swift
@@ -28,29 +28,21 @@ class HasReplayMessageReceiverTests: XCTestCase {
     }
 
     func testWhenContextMessageCarriesHasReplay_itUpdatesMonitorWithoutAnyRUMCommand() throws {
-        // When
-        let context: DatadogContext = .mockWith(
-            additionalContext: [SessionReplayCoreContext.HasReplay(value: true)]
-        )
-        _ = receiver.receive(message: .context(context), from: NOPDatadogCore())
-
-        // Then
         let activeContextReader: RUMActiveContextReader = monitor
-        XCTAssertEqual(activeContextReader.hasReplay, true)
-    }
 
-    func testWhenContextMessageHasNoReplayBaggage_itClearsMonitorSnapshot() throws {
-        // Given
+        // When — a context message carries replay baggage
         _ = receiver.receive(
             message: .context(.mockWith(additionalContext: [SessionReplayCoreContext.HasReplay(value: true)])),
             from: NOPDatadogCore()
         )
 
-        // When
+        // Then
+        XCTAssertEqual(activeContextReader.hasReplay, true)
+
+        // When — a later context message carries no replay baggage
         _ = receiver.receive(message: .context(.mockAny()), from: NOPDatadogCore())
 
-        // Then
-        let activeContextReader: RUMActiveContextReader = monitor
+        // Then — the snapshot is cleared
         XCTAssertNil(activeContextReader.hasReplay)
     }
 

--- a/DatadogRUM/Tests/Integrations/HasReplayMessageReceiverTests.swift
+++ b/DatadogRUM/Tests/Integrations/HasReplayMessageReceiverTests.swift
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogInternal
+@testable import TestUtilities
+@testable import DatadogRUM
+
+class HasReplayMessageReceiverTests: XCTestCase {
+    private let featureScope = FeatureScopeMock()
+    private var monitor: Monitor! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var receiver: HasReplayMessageReceiver! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        monitor = Monitor(
+            dependencies: .mockWith(featureScope: featureScope),
+            dateProvider: SystemDateProvider()
+        )
+        receiver = HasReplayMessageReceiver(monitor: monitor)
+    }
+
+    override func tearDown() {
+        receiver = nil
+        monitor = nil
+    }
+
+    func testWhenContextMessageCarriesHasReplay_itUpdatesMonitorWithoutAnyRUMCommand() throws {
+        // When
+        let context: DatadogContext = .mockWith(
+            additionalContext: [SessionReplayCoreContext.HasReplay(value: true)]
+        )
+        _ = receiver.receive(message: .context(context), from: NOPDatadogCore())
+
+        // Then
+        let activeContextReader: RUMActiveContextReader = monitor
+        XCTAssertEqual(activeContextReader.hasReplay, true)
+    }
+
+    func testWhenContextMessageHasNoReplayBaggage_itClearsMonitorSnapshot() throws {
+        // Given
+        _ = receiver.receive(
+            message: .context(.mockWith(additionalContext: [SessionReplayCoreContext.HasReplay(value: true)])),
+            from: NOPDatadogCore()
+        )
+
+        // When
+        _ = receiver.receive(message: .context(.mockAny()), from: NOPDatadogCore())
+
+        // Then
+        let activeContextReader: RUMActiveContextReader = monitor
+        XCTAssertNil(activeContextReader.hasReplay)
+    }
+
+    func testItDoesNotConsumeNonContextMessages() {
+        let result = receiver.receive(message: .payload("not-a-context-message"), from: NOPDatadogCore())
+        XCTAssertFalse(result)
+    }
+}

--- a/DatadogRUM/Tests/RUMMonitor/MonitorTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/MonitorTests.swift
@@ -237,6 +237,55 @@ class MonitorTests: XCTestCase {
 
         XCTAssertTrue(lastView3.view.loadingTime! > old)
     }
+
+    // MARK: - hasReplay snapshot
+
+    func testHasReplaySnapshot_isGatedByTimeseriesCollectorAndResetOnNewSession() throws {
+        let dateProvider = DateProviderMock()
+        featureScope = FeatureScopeMock(
+            context: .mockWith(additionalContext: [SessionReplayCoreContext.HasReplay(value: true)])
+        )
+
+        // Given — no timeseries collector configured
+        let monitorWithoutCollector = Monitor(
+            dependencies: .mockWith(featureScope: featureScope),
+            dateProvider: dateProvider
+        )
+
+        // When
+        monitorWithoutCollector.startView(key: "foo")
+
+        // Then — the snapshot is never updated
+        XCTAssertNil((monitorWithoutCollector as RUMActiveContextReader).hasReplay)
+
+        // Given — a timeseries collector configured
+        let monitor = Monitor(
+            dependencies: .mockWith(featureScope: featureScope, timeseriesCollector: TimeseriesCollectorStub()),
+            dateProvider: dateProvider
+        )
+        let activeContextReader: RUMActiveContextReader = monitor
+
+        monitor.startView(key: "foo")
+        XCTAssertEqual(activeContextReader.hasReplay, true)
+
+        // When — the session expires (starting a new one within a single `process(command:)` call) while
+        // the context still carries the previous session's (now stale) `hasReplay` value
+        dateProvider.now = dateProvider.now.addingTimeInterval(4 * 60 * 60 + 1) // exceeds session max duration
+        monitor.startView(key: "bar")
+
+        // Then — the stale value is not carried over into the new session
+        XCTAssertNil(activeContextReader.hasReplay)
+    }
+}
+
+private class TimeseriesCollectorStub: TimeseriesCollecting {
+    weak var activeContextReader: RUMActiveContextReader?
+    func start(sessionID: String, applicationID: String, sessionType: RUMSessionType) {}
+    func pause(sessionID: String) {}
+    func resume(sessionID: String) {}
+    func stop(sessionID: String) {}
+    func noteActivity(sessionID: String, at time: Date) {}
+    func flush() {}
 }
 
 // MARK: - Convenience

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -372,6 +372,35 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(events[0].session.hasReplay, true)
     }
 
+    func testWhenSessionReplayContextNeverObserved_hasReplayStaysNilOnEvent() {
+        // Given — no `hasReplay` value is ever reported by the active context reader (Session Replay not enabled)
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 2,
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000
+        )
+        let contextReader = RUMActiveContextReaderMock(hasReplay: nil)
+        collector.activeContextReader = contextReader
+
+        // When
+        let expectation = self.expectation(description: "batch written")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+
+        collector.start(sessionID: "session-no-replay", applicationID: "app-no-replay", sessionType: .user)
+        waitForExpectations(timeout: 2)
+        collector.stop(sessionID: "session-no-replay")
+
+        // Then — `hasReplay` stays `nil`, not `false`, so the field is omitted rather than misreported
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty)
+        XCTAssertNil(events[0].session.hasReplay)
+    }
+
     func testWhenReplayStopsBeforeFlush_hasReplayStaysTrueForTheBatch() {
         // Given
         memoryReader.vitalData = 1_000_000
@@ -753,6 +782,55 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-bg")
     }
 
+    func testWhenResumedAfterPauseSpanningDeviceSleep_reanchorsToAvoidTimestampLag() {
+        // Given — the media clock doesn't advance during real device sleep (unlike the wall clock), so a
+        // pause spanning device sleep leaves a growing gap between the two if the anchor isn't refreshed
+        memoryReader.vitalData = 1_000_000
+        let clock = MutableClock()
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush — only `stop()` triggers the flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000,
+            now: clock.now,
+            mediaTimeProvider: clock.mediaTime
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+        collector.start(sessionID: "session-sleep", applicationID: "app-1", sessionType: .user)
+
+        let pauseExpectation = self.expectation(description: "pause settled")
+        collector.pause(sessionID: "session-sleep")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { pauseExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // When — simulate a long device sleep: the wall clock jumps forward by an hour, but the monotonic
+        // media clock (paused during real sleep) does not advance — then the collector resumes and samples
+        clock.date = clock.date.addingTimeInterval(3_600)
+        let resumeExpectation = self.expectation(description: "resumed samples collected")
+        resumeExpectation.assertForOverFulfill = false
+        collector.resume(sessionID: "session-sleep")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        let syncExpectation = self.expectation(description: "stop completed")
+        collector.stop(sessionID: "session-sleep")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — post-resume samples reflect the real (post-sleep) wall-clock time, not the pre-sleep
+        // anchor lagging behind by ~1 hour
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        guard let lastEvent = events.last else {
+            XCTFail("Expected at least one memory event with a sample after resume")
+            return
+        }
+        let lastSampleDate = Date(timeIntervalSince1970: Double(lastEvent.timeseries.end) / 1_000_000_000)
+        XCTAssertEqual(lastSampleDate.timeIntervalSince(clock.date), 0, accuracy: 1, "Post-resume sample should be anchored to the real post-sleep wall-clock time, not lag behind by the sleep duration")
+    }
+
     func testWhenPauseCalledBeforeStart_itIsNoOp() {
         // Given — collector not yet started
         let collector = TimeseriesSessionCollector(
@@ -1040,6 +1118,45 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         // Then
         XCTAssertFalse(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Expected the collector to self-flush once idle past the inactivity timeout")
+    }
+
+    func testWhenWallClockJumpsBackwardThenFreshInteractionArrives_doesNotFalselyExpireSession() {
+        // Given — a backward wall-clock jump (e.g. NTP correction) happens mid-session, so the anchored
+        // media-clock-derived date and the raw wall clock diverge
+        memoryReader.vitalData = 1_000_000
+        let clock = MutableClock()
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush — only self-expiry or `stop()` triggers the flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000,
+            now: clock.now,
+            mediaTimeProvider: clock.mediaTime
+        )
+        let startTime = clock.date
+        let contextReader = RUMActiveContextReaderMock(sessionID: "session-clock-jump", sessionStartTime: startTime, lastInteractionTime: startTime)
+        collector.activeContextReader = contextReader
+        collector.start(sessionID: "session-clock-jump", applicationID: "app-1", sessionType: .user)
+
+        // When — the wall clock jumps backward by more than the inactivity timeout, then a fresh interaction
+        // is processed and reported at the new (earlier) wall-clock time, while the anchored/monotonic date
+        // this collector would otherwise compare against keeps climbing on the old anchor
+        clock.date = clock.date.addingTimeInterval(-RUMSessionScope.Constants.sessionTimeoutDuration - 60)
+        clock.mediaTime.current += 0.2
+        contextReader.sessionActivity.lastInteractionTime = clock.date
+
+        let expectation = self.expectation(description: "still sampling after the jump and fresh interaction")
+        expectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — the session must not be treated as expired: the expiry check compares against `now()`
+        // (the same wall-clock timeline `lastInteractionTime` lives on), not the sleep/adjustment-immune
+        // anchored date, so a fresh interaction on the new wall-clock timeline keeps the session alive
+        XCTAssertTrue(featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self).isEmpty, "Session must not be treated as expired by a stale comparison between the anchored date and the fresh wall-clock interaction")
+        collector.stop(sessionID: "session-clock-jump")
     }
 
     func testWhenActivityReaderReportsRecentInteraction_preventsSelfStopWithinTimeoutWindow() {

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -346,17 +346,15 @@ class TimeseriesSessionCollectorTests: XCTestCase {
     func testWhenSessionReplayHasReplay_itAttachesHasReplayToEvent() {
         // Given
         memoryReader.vitalData = 1_000_000
-        let hasReplay = SessionReplayCoreContext.HasReplay(value: true)
-        let scope = FeatureScopeMock(context: .mockWith(additionalContext: [hasReplay]))
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
-            featureScope: scope,
+            featureScope: featureScope,
             batchSize: 2,
             samplingInterval: 0.05,
             cpuUsageProvider: { nil },
             totalRAM: 4_000_000_000
         )
-        let contextReader = RUMActiveContextReaderMock()
+        let contextReader = RUMActiveContextReaderMock(hasReplay: true)
         collector.activeContextReader = contextReader
 
         // When
@@ -369,7 +367,47 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-has-replay")
 
         // Then
-        let events = scope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        XCTAssertFalse(events.isEmpty)
+        XCTAssertEqual(events[0].session.hasReplay, true)
+    }
+
+    func testWhenReplayStopsBeforeFlush_hasReplayStaysTrueForTheBatch() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush — only `stop()` triggers the flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            totalRAM: 4_000_000_000
+        )
+        let contextReader = RUMActiveContextReaderMock(hasReplay: true)
+        collector.activeContextReader = contextReader
+        collector.start(sessionID: "session-replay-stops", applicationID: "app-1", sessionType: .user)
+
+        // When — replay was active for some of the batch window, then stops before the flush
+        let replayActiveExpectation = self.expectation(description: "samples collected while replay is active")
+        replayActiveExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            contextReader.hasReplay = false
+            replayActiveExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+
+        let moreSamplesExpectation = self.expectation(description: "more samples collected after replay stopped")
+        moreSamplesExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { moreSamplesExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        let syncExpectation = self.expectation(description: "stop completed")
+        collector.stop(sessionID: "session-replay-stops")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — the whole batch still reports `hasReplay: true`, since replay was active for part of it
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
         XCTAssertFalse(events.isEmpty)
         XCTAssertEqual(events[0].session.hasReplay, true)
     }
@@ -872,6 +910,54 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(event.timeseries.end, timestamps.last)
     }
 
+    func testWhenWallClockJumpsBackwardMidSession_timestampsStayMonotonic() {
+        // Given
+        memoryReader.vitalData = 1_000_000
+        let clock = MutableClock()
+        let collector = TimeseriesSessionCollector(
+            memoryReader: memoryReader,
+            featureScope: featureScope,
+            batchSize: 100, // won't auto-flush — only `stop()` triggers the flush
+            samplingInterval: 0.05,
+            cpuUsageProvider: { nil },
+            now: clock.now,
+            mediaTimeProvider: clock.mediaTime
+        )
+        let contextReader = RUMActiveContextReaderMock()
+        collector.activeContextReader = contextReader
+        collector.start(sessionID: "session-clock-jump", applicationID: "app-1", sessionType: .user)
+
+        let beforeJumpExpectation = self.expectation(description: "samples collected before the clock jump")
+        beforeJumpExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { beforeJumpExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // When — the wall clock jumps backward (e.g. an NTP correction), but real time (and thus the
+        // monotonic media clock the collector now anchors to) keeps moving forward normally
+        clock.date = clock.date.addingTimeInterval(-60)
+        clock.mediaTime.current += 0.2
+
+        let afterJumpExpectation = self.expectation(description: "more samples collected after the clock jump")
+        afterJumpExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { afterJumpExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        let syncExpectation = self.expectation(description: "stop completed")
+        collector.stop(sessionID: "session-clock-jump")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — sample timestamps are unaffected by the wall-clock jump and remain monotonically increasing
+        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        guard let event = events.first else {
+            XCTFail("Expected at least one memory event")
+            return
+        }
+        let timestamps = event.timeseries.data.timestamps
+        XCTAssertEqual(timestamps, timestamps.sorted(), "Timestamps should stay monotonically increasing across a backward wall-clock jump")
+        XCTAssertGreaterThanOrEqual(event.timeseries.end, event.timeseries.start, "The batch end must not precede its start")
+    }
+
     // MARK: - Session lifetime self-enforcement
 
     func testWhenSessionExceedsMaxDuration_itSelfStopsAndFlushes() {
@@ -885,7 +971,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
             samplingInterval: 0.05,
             cpuUsageProvider: { nil },
             totalRAM: 4_000_000_000,
-            now: clock.now
+            now: clock.now,
+            mediaTimeProvider: clock.mediaTime
         )
         let startTime = clock.date
         let contextReader = RUMActiveContextReaderMock(sessionID: "session-expired", sessionStartTime: startTime, lastInteractionTime: startTime)
@@ -901,7 +988,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         // When — advance the (injected) clock and the activity reader's snapshot past the session's max
         // duration, mirroring how `Monitor` refreshes its snapshot on every processed command, without ever
         // calling stop() directly
-        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionMaxDuration)
+        clock.advance(by: RUMSessionScope.Constants.sessionMaxDuration)
         contextReader.sessionActivity.lastInteractionTime = clock.date
         let selfStopExpectation = self.expectation(description: "self-stop settled")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
@@ -930,7 +1017,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
             samplingInterval: 0.05,
             cpuUsageProvider: { nil },
             totalRAM: 4_000_000_000,
-            now: clock.now
+            now: clock.now,
+            mediaTimeProvider: clock.mediaTime
         )
         let startTime = clock.date
         let contextReader = RUMActiveContextReaderMock(sessionID: "session-idle", sessionStartTime: startTime, lastInteractionTime: startTime)
@@ -945,7 +1033,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         // When — advance the clock past the inactivity timeout while the activity reader's `lastInteractionTime`
         // stays fixed at `startTime` (i.e. no RUM interaction was ever processed)
-        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
+        clock.advance(by: RUMSessionScope.Constants.sessionTimeoutDuration)
         let selfStopExpectation = self.expectation(description: "self-stop settled")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) { selfStopExpectation.fulfill() }
         waitForExpectations(timeout: 2)
@@ -965,7 +1053,8 @@ class TimeseriesSessionCollectorTests: XCTestCase {
             samplingInterval: 0.05,
             cpuUsageProvider: { nil },
             totalRAM: 4_000_000_000,
-            now: clock.now
+            now: clock.now,
+            mediaTimeProvider: clock.mediaTime
         )
         let startTime = clock.date
         let contextReader = RUMActiveContextReaderMock(sessionID: "session-active", sessionStartTime: startTime, lastInteractionTime: startTime)
@@ -974,9 +1063,9 @@ class TimeseriesSessionCollectorTests: XCTestCase {
 
         // When — a RUM interaction is reported right before what would have been the inactivity timeout,
         // resetting the clock the reader exposes to `sample()`
-        clock.date = startTime.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
+        clock.advance(by: RUMSessionScope.Constants.sessionTimeoutDuration - 1)
         contextReader.sessionActivity.lastInteractionTime = clock.date
-        clock.date = clock.date.addingTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration - 1)
+        clock.advance(by: RUMSessionScope.Constants.sessionTimeoutDuration - 1)
 
         let expectation = self.expectation(description: "still sampling")
         expectation.assertForOverFulfill = false
@@ -1057,17 +1146,20 @@ private class RUMActiveContextReaderMock: RUMActiveContextReader {
     var globalAttributes: [AttributeKey: AttributeValue]
     var activeView: (id: String?, path: String?, name: String?)
     var sessionActivity: (sessionID: String?, sessionStartTime: Date?, lastInteractionTime: Date?)
+    var hasReplay: Bool?
 
     init(
         globalAttributes: [AttributeKey: AttributeValue] = [:],
         activeView: (id: String?, path: String?, name: String?) = (.mockAny(), .mockAny(), nil),
         sessionID: String? = nil,
         sessionStartTime: Date? = nil,
-        lastInteractionTime: Date? = nil
+        lastInteractionTime: Date? = nil,
+        hasReplay: Bool? = nil
     ) {
         self.globalAttributes = globalAttributes
         self.activeView = activeView
         self.sessionActivity = (sessionID, sessionStartTime, lastInteractionTime)
+        self.hasReplay = hasReplay
     }
 
     func isSessionExpired(sessionID: String, at date: Date) -> Bool {
@@ -1083,14 +1175,27 @@ private class RUMActiveContextReaderMock: RUMActiveContextReader {
 
 /// A `Date` provider whose current time can be advanced manually, used to deterministically test the
 /// collector's self-enforced session expiry without waiting on real wall-clock durations.
+///
+/// Carries a paired `mediaTime` (`MediaTimeProviderMock`), settable independently of `date`, since
+/// `TimeseriesSessionCollector` derives sample timestamps from an anchor plus elapsed monotonic media time
+/// (not `now()` directly) after session start — tests that simulate elapsed time must advance `mediaTime`
+/// alongside `date` to keep the two consistent, and tests exercising a wall-clock/media-clock divergence
+/// (e.g. a backward wall-clock jump) can advance them independently.
 private class MutableClock {
     var date: Date
+    let mediaTime = MediaTimeProviderMock()
 
     init(date: Date = Date()) {
         self.date = date
     }
 
     func now() -> Date { date }
+
+    /// Advances both `date` and `mediaTime` by the same delta, as real elapsed time would.
+    func advance(by interval: TimeInterval) {
+        date = date.addingTimeInterval(interval)
+        mediaTime.current += interval
+    }
 }
 
 #endif

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -782,7 +782,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.stop(sessionID: "session-bg")
     }
 
-    func testWhenResumedAfterPauseSpanningDeviceSleep_reanchorsToAvoidTimestampLag() {
+    func testWhenResumedAfterPause_reanchorsToAvoidLagOrPrecedeAlreadyFlushedSamples() {
         // Given — the media clock doesn't advance during real device sleep (unlike the wall clock), so a
         // pause spanning device sleep leaves a growing gap between the two if the anchor isn't refreshed
         memoryReader.vitalData = 1_000_000
@@ -790,7 +790,7 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
             featureScope: featureScope,
-            batchSize: 100, // won't auto-flush — only `stop()` triggers the flush
+            batchSize: 100, // won't auto-flush — only `pause()`/`stop()` triggers the flush
             samplingInterval: 0.05,
             cpuUsageProvider: { nil },
             totalRAM: 4_000_000_000,
@@ -799,36 +799,64 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         )
         let contextReader = RUMActiveContextReaderMock()
         collector.activeContextReader = contextReader
-        collector.start(sessionID: "session-sleep", applicationID: "app-1", sessionType: .user)
+        collector.start(sessionID: "session-clock-jumps", applicationID: "app-1", sessionType: .user)
 
         let pauseExpectation = self.expectation(description: "pause settled")
-        collector.pause(sessionID: "session-sleep")
+        collector.pause(sessionID: "session-clock-jumps")
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { pauseExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
         // When — simulate a long device sleep: the wall clock jumps forward by an hour, but the monotonic
         // media clock (paused during real sleep) does not advance — then the collector resumes and samples
         clock.date = clock.date.addingTimeInterval(3_600)
-        let resumeExpectation = self.expectation(description: "resumed samples collected")
-        resumeExpectation.assertForOverFulfill = false
-        collector.resume(sessionID: "session-sleep")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
-
-        let syncExpectation = self.expectation(description: "stop completed")
-        collector.stop(sessionID: "session-sleep")
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
+        let resumeAfterForwardJumpExpectation = self.expectation(description: "resumed samples collected after forward jump")
+        resumeAfterForwardJumpExpectation.assertForOverFulfill = false
+        collector.resume(sessionID: "session-clock-jumps")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeAfterForwardJumpExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
         // Then — post-resume samples reflect the real (post-sleep) wall-clock time, not the pre-sleep
-        // anchor lagging behind by ~1 hour
-        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
-        guard let lastEvent = events.last else {
+        // anchor lagging behind by ~1 hour. Pause again (flushing this batch) so we have a known
+        // `flushedAfterForwardJump.timeseries.end` to check the next batch against below.
+        let pauseAfterForwardJumpExpectation = self.expectation(description: "pause after forward jump settled")
+        collector.pause(sessionID: "session-clock-jumps")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { pauseAfterForwardJumpExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        let eventsAfterForwardJump = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        guard let flushedAfterForwardJump = eventsAfterForwardJump.last else {
             XCTFail("Expected at least one memory event with a sample after resume")
             return
         }
-        let lastSampleDate = Date(timeIntervalSince1970: Double(lastEvent.timeseries.end) / 1_000_000_000)
+        let lastSampleDate = Date(timeIntervalSince1970: Double(flushedAfterForwardJump.timeseries.end) / 1_000_000_000)
         XCTAssertEqual(lastSampleDate.timeIntervalSince(clock.date), 0, accuracy: 1, "Post-resume sample should be anchored to the real post-sleep wall-clock time, not lag behind by the sleep duration")
+
+        // When — the wall clock then moves backward by an hour while paused/backgrounded (e.g. an NTP
+        // correction), then the collector resumes and samples again
+        clock.date = clock.date.addingTimeInterval(-3_600)
+        let resumeAfterBackwardJumpExpectation = self.expectation(description: "resumed samples collected after backward jump")
+        resumeAfterBackwardJumpExpectation.assertForOverFulfill = false
+        collector.resume(sessionID: "session-clock-jumps")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeAfterBackwardJumpExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        let syncExpectation = self.expectation(description: "stop completed")
+        collector.stop(sessionID: "session-clock-jumps")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        // Then — the post-resume batch must not precede the batch already flushed before the pause,
+        // even though the wall clock moved backward while paused
+        let allEvents = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        guard let resumedBatch = allEvents.last, allEvents.count > eventsAfterForwardJump.count else {
+            XCTFail("Expected an additional memory event flushed after resume")
+            return
+        }
+        XCTAssertGreaterThanOrEqual(
+            resumedBatch.timeseries.start,
+            flushedAfterForwardJump.timeseries.end,
+            "Post-resume batch must not start before the batch already flushed prior to the pause"
+        )
     }
 
     func testWhenPauseCalledBeforeStart_itIsNoOp() {

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -1016,14 +1016,14 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         XCTAssertEqual(event.timeseries.end, timestamps.last)
     }
 
-    func testWhenWallClockJumpsBackwardMidSession_timestampsStayMonotonic() {
+    func testWhenWallClockJumpsMidSession_backwardStaysMonotonicAndForwardIsHonored() {
         // Given
         memoryReader.vitalData = 1_000_000
         let clock = MutableClock()
         let collector = TimeseriesSessionCollector(
             memoryReader: memoryReader,
             featureScope: featureScope,
-            batchSize: 100, // won't auto-flush — only `stop()` triggers the flush
+            batchSize: 100, // won't auto-flush — only `flush()`/`stop()` triggers the flush
             samplingInterval: 0.05,
             cpuUsageProvider: { nil },
             now: clock.now,
@@ -1043,9 +1043,30 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         clock.date = clock.date.addingTimeInterval(-60)
         clock.mediaTime.current += 0.2
 
-        let afterJumpExpectation = self.expectation(description: "more samples collected after the clock jump")
-        afterJumpExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { afterJumpExpectation.fulfill() }
+        let afterBackwardJumpExpectation = self.expectation(description: "more samples collected after the backward jump")
+        afterBackwardJumpExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { afterBackwardJumpExpectation.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        collector.flush()
+
+        // Then — sample timestamps are unaffected by the backward wall-clock jump and remain monotonically increasing
+        let eventsAfterBackwardJump = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        guard let batchAfterBackwardJump = eventsAfterBackwardJump.first else {
+            XCTFail("Expected at least one memory event")
+            return
+        }
+        let timestamps = batchAfterBackwardJump.timeseries.data.timestamps
+        XCTAssertEqual(timestamps, timestamps.sorted(), "Timestamps should stay monotonically increasing across a backward wall-clock jump")
+        XCTAssertGreaterThanOrEqual(batchAfterBackwardJump.timeseries.end, batchAfterBackwardJump.timeseries.start, "The batch end must not precede its start")
+
+        // When — the wall clock is then corrected forward by an hour (e.g. NTP sync), while the session
+        // stays foregrounded and never pauses/resumes; the monotonic media clock is left untouched
+        clock.date = clock.date.addingTimeInterval(3_600)
+
+        let afterForwardJumpExpectation = self.expectation(description: "more samples collected after the forward jump")
+        afterForwardJumpExpectation.assertForOverFulfill = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { afterForwardJumpExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
         let syncExpectation = self.expectation(description: "stop completed")
@@ -1053,15 +1074,15 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
         waitForExpectations(timeout: 2)
 
-        // Then — sample timestamps are unaffected by the wall-clock jump and remain monotonically increasing
-        let events = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
-        guard let event = events.first else {
-            XCTFail("Expected at least one memory event")
+        // Then — the most recent sample reflects the corrected wall-clock time immediately, without
+        // waiting for a pause/resume cycle to refresh the anchor
+        let allEvents = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
+        guard let batchAfterForwardJump = allEvents.last, allEvents.count > eventsAfterBackwardJump.count else {
+            XCTFail("Expected an additional memory event after the forward jump")
             return
         }
-        let timestamps = event.timeseries.data.timestamps
-        XCTAssertEqual(timestamps, timestamps.sorted(), "Timestamps should stay monotonically increasing across a backward wall-clock jump")
-        XCTAssertGreaterThanOrEqual(event.timeseries.end, event.timeseries.start, "The batch end must not precede its start")
+        let lastSampleDate = Date(timeIntervalSince1970: Double(batchAfterForwardJump.timeseries.end) / 1_000_000_000)
+        XCTAssertEqual(lastSampleDate.timeIntervalSince(clock.date), 0, accuracy: 1, "Post-correction sample should advance to the corrected wall-clock time, not lag behind by the correction amount")
     }
 
     // MARK: - Session lifetime self-enforcement
@@ -1318,14 +1339,8 @@ private class RUMActiveContextReaderMock: RUMActiveContextReader {
     }
 }
 
-/// A `Date` provider whose current time can be advanced manually, used to deterministically test the
-/// collector's self-enforced session expiry without waiting on real wall-clock durations.
-///
-/// Carries a paired `mediaTime` (`MediaTimeProviderMock`), settable independently of `date`, since
-/// `TimeseriesSessionCollector` derives sample timestamps from an anchor plus elapsed monotonic media time
-/// (not `now()` directly) after session start — tests that simulate elapsed time must advance `mediaTime`
-/// alongside `date` to keep the two consistent, and tests exercising a wall-clock/media-clock divergence
-/// (e.g. a backward wall-clock jump) can advance them independently.
+/// A manually-advanceable `Date`/`mediaTime` pair, settable independently to simulate wall-clock/media-clock
+/// divergence (e.g. a backward wall-clock jump) or together to simulate normal elapsed time.
 private class MutableClock {
     var date: Date
     let mediaTime = MediaTimeProviderMock()

--- a/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesSessionCollectorTests.swift
@@ -16,6 +16,14 @@ class TimeseriesSessionCollectorTests: XCTestCase {
     private let featureScope = FeatureScopeMock(context: .mockWith(additionalContext: [RUMCoreContext.mockAny()]))
     private let memoryReader = SamplingBasedVitalReaderMock()
 
+    /// Blocks the test until `duration` has elapsed on a background queue, giving the collector's sampling
+    /// timer time to fire before assertions run.
+    private func settle(_ duration: TimeInterval = 0.1) {
+        let expectation = self.expectation(description: "settled")
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + duration) { expectation.fulfill() }
+        waitForExpectations(timeout: 2)
+    }
+
     // MARK: - Memory events
 
     func testWhenBatchSizeIsReached_itWritesMemoryEvent() {
@@ -801,27 +809,20 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.activeContextReader = contextReader
         collector.start(sessionID: "session-clock-jumps", applicationID: "app-1", sessionType: .user)
 
-        let pauseExpectation = self.expectation(description: "pause settled")
         collector.pause(sessionID: "session-clock-jumps")
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { pauseExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.1)
 
         // When — simulate a long device sleep: the wall clock jumps forward by an hour, but the monotonic
         // media clock (paused during real sleep) does not advance — then the collector resumes and samples
         clock.date = clock.date.addingTimeInterval(3_600)
-        let resumeAfterForwardJumpExpectation = self.expectation(description: "resumed samples collected after forward jump")
-        resumeAfterForwardJumpExpectation.assertForOverFulfill = false
         collector.resume(sessionID: "session-clock-jumps")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeAfterForwardJumpExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.3)
 
         // Then — post-resume samples reflect the real (post-sleep) wall-clock time, not the pre-sleep
         // anchor lagging behind by ~1 hour. Pause again (flushing this batch) so we have a known
         // `flushedAfterForwardJump.timeseries.end` to check the next batch against below.
-        let pauseAfterForwardJumpExpectation = self.expectation(description: "pause after forward jump settled")
         collector.pause(sessionID: "session-clock-jumps")
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.1) { pauseAfterForwardJumpExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.1)
 
         let eventsAfterForwardJump = featureScope.eventsWritten(ofType: RUMTimeseriesMemoryEvent.self)
         guard let flushedAfterForwardJump = eventsAfterForwardJump.last else {
@@ -834,16 +835,11 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         // When — the wall clock then moves backward by an hour while paused/backgrounded (e.g. an NTP
         // correction), then the collector resumes and samples again
         clock.date = clock.date.addingTimeInterval(-3_600)
-        let resumeAfterBackwardJumpExpectation = self.expectation(description: "resumed samples collected after backward jump")
-        resumeAfterBackwardJumpExpectation.assertForOverFulfill = false
         collector.resume(sessionID: "session-clock-jumps")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { resumeAfterBackwardJumpExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.3)
 
-        let syncExpectation = self.expectation(description: "stop completed")
         collector.stop(sessionID: "session-clock-jumps")
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.2)
 
         // Then — the post-resume batch must not precede the batch already flushed before the pause,
         // even though the wall clock moved backward while paused
@@ -1033,20 +1029,14 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         collector.activeContextReader = contextReader
         collector.start(sessionID: "session-clock-jump", applicationID: "app-1", sessionType: .user)
 
-        let beforeJumpExpectation = self.expectation(description: "samples collected before the clock jump")
-        beforeJumpExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { beforeJumpExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.2)
 
         // When — the wall clock jumps backward (e.g. an NTP correction), but real time (and thus the
         // monotonic media clock the collector now anchors to) keeps moving forward normally
         clock.date = clock.date.addingTimeInterval(-60)
         clock.mediaTime.current += 0.2
 
-        let afterBackwardJumpExpectation = self.expectation(description: "more samples collected after the backward jump")
-        afterBackwardJumpExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { afterBackwardJumpExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.2)
 
         collector.flush()
 
@@ -1064,15 +1054,10 @@ class TimeseriesSessionCollectorTests: XCTestCase {
         // stays foregrounded and never pauses/resumes; the monotonic media clock is left untouched
         clock.date = clock.date.addingTimeInterval(3_600)
 
-        let afterForwardJumpExpectation = self.expectation(description: "more samples collected after the forward jump")
-        afterForwardJumpExpectation.assertForOverFulfill = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { afterForwardJumpExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.2)
 
-        let syncExpectation = self.expectation(description: "stop completed")
         collector.stop(sessionID: "session-clock-jump")
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) { syncExpectation.fulfill() }
-        waitForExpectations(timeout: 2)
+        settle(0.2)
 
         // Then — the most recent sample reflects the corrected wall-clock time immediately, without
         // waiting for a pause/resume cycle to refresh the anchor


### PR DESCRIPTION
### What and why?

Fixes two bugs in the RUM timeseries feature's `TimeseriesSessionCollector`:

1. **Clock monotonicity**: sample timestamps were derived from raw `now()`, so a backward wall-clock adjustment (NTP sync, manual clock change) mid-session could produce out-of-order or inverted (`end < start`) batch timestamps. Timestamps are now derived from a monotonic media-clock anchor captured at session start (`anchorDate` + elapsed `CACurrentMediaTime`), mirroring the existing pattern in `FirstFrameReader`.

2. **`hasReplay` accumulation**: each batch reported `hasReplay` from the single context snapshot read at flush time, so a batch would report `hasReplay: false` if replay had stopped before the batch was flushed, even though replay was active for part of the batch's duration. `hasReplay` is now OR-accumulated across the session (mirroring `RUMViewScope`'s per-view accumulation), and exposed to the collector via a new `RUMActiveContextReader.hasReplay` snapshot on `Monitor`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs
- [ ] Run `make api-surface` when adding new APIs