### PR TITLE
[PANA-8792] Add main and background CPU benchmark metrics

### DIFF
--- a/BenchmarkTests/Benchmarks/Sources/Metrics.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Metrics.swift
@@ -155,10 +155,13 @@ public final class Memory: MetricAggregator<Double> {
     }
 }
 
-/// Collect CPU usage metric.
+/// Collect CPU usage metrics.
 ///
-/// Based on a timer, the `CPU` aggregator will periodically record the CPU usage.
-public final class CPU: MetricAggregator<Double> {
+/// Based on a timer, `CPU` periodically records total, main-thread, and background CPU usage.
+public final class CPU {
+    /// Aggregates total CPU usage for the application.
+    public let total = MetricAggregator<Double>()
+
     /// Aggregates CPU usage for the application main thread.
     public let main = MetricAggregator<Double>()
 
@@ -171,7 +174,7 @@ public final class CPU: MetricAggregator<Double> {
     /// Mach port identifying the application main thread.
     private let mainThread: thread_t
 
-    /// Create a `CPU` aggregator to periodically record the CPU usage on the
+    /// Create a `CPU` collector to periodically record CPU usage on the
     /// provided queue.
     ///
     /// By default, the timer is scheduled with 100 ms interval with 10 ms leeway.
@@ -181,21 +184,20 @@ public final class CPU: MetricAggregator<Double> {
     ///   - interval: The timer interval, default to 100 ms.
     ///   - leeway: The timer leeway, default to 10 ms.
     @MainActor
-    public required init(
+    public init(
         queue: DispatchQueue,
         every interval: DispatchTimeInterval = .milliseconds(100),
         leeway: DispatchTimeInterval = .milliseconds(10)
     ) {
         self.timer = DispatchSource.makeTimerSource(queue: queue)
         self.mainThread = pthread_mach_thread_np(pthread_self())
-        super.init()
 
         timer.setEventHandler { [weak self] in
             guard let self, let usage = try? self.usage() else {
                 return
             }
 
-            self.record(value: usage.total)
+            self.total.record(value: usage.total)
             self.main.record(value: usage.main)
             self.background.record(value: usage.total - usage.main)
         }

--- a/BenchmarkTests/Benchmarks/Sources/Metrics.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Metrics.swift
@@ -162,6 +162,9 @@ public final class CPU: MetricAggregator<Double> {
     /// Aggregates CPU usage for the application main thread.
     public let main = MetricAggregator<Double>()
 
+    /// Aggregates CPU usage for the application background threads.
+    public let background = MetricAggregator<Double>()
+
     /// Dispatch source object for monitoring timer events.
     private let timer: DispatchSourceTimer
 
@@ -194,6 +197,7 @@ public final class CPU: MetricAggregator<Double> {
 
             self.record(value: usage.total)
             self.main.record(value: usage.main)
+            self.background.record(value: usage.total - usage.main)
         }
 
         timer.schedule(deadline: .now(), repeating: interval, leeway: leeway)

--- a/BenchmarkTests/Benchmarks/Sources/Metrics.swift
+++ b/BenchmarkTests/Benchmarks/Sources/Metrics.swift
@@ -159,8 +159,14 @@ public final class Memory: MetricAggregator<Double> {
 ///
 /// Based on a timer, the `CPU` aggregator will periodically record the CPU usage.
 public final class CPU: MetricAggregator<Double> {
+    /// Aggregates CPU usage for the application main thread.
+    public let main = MetricAggregator<Double>()
+
     /// Dispatch source object for monitoring timer events.
     private let timer: DispatchSourceTimer
+
+    /// Mach port identifying the application main thread.
+    private let mainThread: thread_t
 
     /// Create a `CPU` aggregator to periodically record the CPU usage on the
     /// provided queue.
@@ -171,12 +177,14 @@ public final class CPU: MetricAggregator<Double> {
     ///   - queue: The queue on which to execute the timer handler.
     ///   - interval: The timer interval, default to 100 ms.
     ///   - leeway: The timer leeway, default to 10 ms.
+    @MainActor
     public required init(
         queue: DispatchQueue,
         every interval: DispatchTimeInterval = .milliseconds(100),
         leeway: DispatchTimeInterval = .milliseconds(10)
     ) {
         self.timer = DispatchSource.makeTimerSource(queue: queue)
+        self.mainThread = pthread_mach_thread_np(pthread_self())
         super.init()
 
         timer.setEventHandler { [weak self] in
@@ -184,7 +192,8 @@ public final class CPU: MetricAggregator<Double> {
                 return
             }
 
-            self.record(value: usage)
+            self.record(value: usage.total)
+            self.main.record(value: usage.main)
         }
 
         timer.schedule(deadline: .now(), repeating: interval, leeway: leeway)
@@ -198,10 +207,10 @@ public final class CPU: MetricAggregator<Double> {
     /// Collect single sample of current cpu usage.
     ///
     /// The computation is based on https://gist.github.com/hisui/10004131#file-cpu-usage-cpp
-    /// It reads the `cpu_usage` from all thread to compute the application usage percentage.
+    /// It reads the `cpu_usage` from all threads to compute the application and main-thread usage percentages.
     ///
-    /// - Returns: The cpu usage of all threads.
-    private func usage() throws -> Double {
+    /// - Returns: The CPU usage of all threads and of the main thread.
+    private func usage() throws -> (total: Double, main: Double) {
         var threads_list: thread_act_array_t?
         var threads_count = mach_msg_type_number_t()
         let kr = withUnsafeMutablePointer(to: &threads_list) {
@@ -218,12 +227,16 @@ public final class CPU: MetricAggregator<Double> {
             vm_deallocate(mach_task_self_, vm_address_t(bitPattern: threads_list), vm_size_t(Int(threads_count) * MemoryLayout<thread_t>.stride))
         }
 
-        return try (0..<threads_count).reduce(0) { result, index in
+        var totalUsage = 0.0
+        var mainUsage = 0.0
+
+        for index in 0..<threads_count {
+            let thread = threads_list[Int(index)]
             var basic_info = thread_basic_info()
             var basic_info_count = mach_msg_type_number_t(THREAD_INFO_MAX)
             let kr = withUnsafeMutablePointer(to: &basic_info) {
                 $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
-                    thread_info(threads_list[Int(index)], thread_flavor_t(THREAD_BASIC_INFO), $0, &basic_info_count)
+                    thread_info(thread, thread_flavor_t(THREAD_BASIC_INFO), $0, &basic_info_count)
                 }
             }
 
@@ -231,12 +244,21 @@ public final class CPU: MetricAggregator<Double> {
                 throw MachError.thread_info(return: kr)
             }
 
-            guard basic_info.flags != TH_FLAGS_IDLE else {
-                return result
+            let usage: Double
+            if basic_info.flags == TH_FLAGS_IDLE {
+                usage = 0
+            } else {
+                usage = Double(basic_info.cpu_usage) / Double(TH_USAGE_SCALE)
             }
 
-            return result + Double(basic_info.cpu_usage) / Double(TH_USAGE_SCALE)
+            totalUsage += usage
+
+            if thread == mainThread {
+                mainUsage = usage
+            }
         }
+
+        return (total: totalUsage, main: mainUsage)
     }
 }
 

--- a/BenchmarkTests/Runner/BenchmarkVitals.swift
+++ b/BenchmarkTests/Runner/BenchmarkVitals.swift
@@ -59,7 +59,16 @@ internal final class Vitals {
             cpu.main.reset()
         }
 
-        return [total, main]
+        let background = meter.gaugeBuilder(name: "ios.benchmark.cpu.background").buildWithCallback { measurement in
+            // report the average background cpu usage that was recorded during push interval
+            if let value = cpu.background.aggregation?.avg {
+                measurement.record(value: value)
+            }
+
+            cpu.background.reset()
+        }
+
+        return [total, main, background]
     }
 
     @discardableResult

--- a/BenchmarkTests/Runner/BenchmarkVitals.swift
+++ b/BenchmarkTests/Runner/BenchmarkVitals.swift
@@ -36,10 +36,12 @@ internal final class Vitals {
         }
     }
 
+    @MainActor
     @discardableResult
-    func observeCPU() -> ObservableInstrumentSdk {
+    func observeCPU() -> [ObservableInstrumentSdk] {
         let cpu = CPU(queue: queue)
-        return meter.gaugeBuilder(name: "ios.benchmark.cpu").buildWithCallback { measurement in
+
+        let total = meter.gaugeBuilder(name: "ios.benchmark.cpu").buildWithCallback { measurement in
             // report the average cpu usage that was recorded during push interval
             if let value = cpu.aggregation?.avg {
                 measurement.record(value: value)
@@ -47,6 +49,17 @@ internal final class Vitals {
 
             cpu.reset()
         }
+
+        let main = meter.gaugeBuilder(name: "ios.benchmark.cpu.main").buildWithCallback { measurement in
+            // report the average main-thread cpu usage that was recorded during push interval
+            if let value = cpu.main.aggregation?.avg {
+                measurement.record(value: value)
+            }
+
+            cpu.main.reset()
+        }
+
+        return [total, main]
     }
 
     @discardableResult

--- a/BenchmarkTests/Runner/BenchmarkVitals.swift
+++ b/BenchmarkTests/Runner/BenchmarkVitals.swift
@@ -43,11 +43,11 @@ internal final class Vitals {
 
         let total = meter.gaugeBuilder(name: "ios.benchmark.cpu").buildWithCallback { measurement in
             // report the average cpu usage that was recorded during push interval
-            if let value = cpu.aggregation?.avg {
+            if let value = cpu.total.aggregation?.avg {
                 measurement.record(value: value)
             }
 
-            cpu.reset()
+            cpu.total.reset()
         }
 
         let main = meter.gaugeBuilder(name: "ios.benchmark.cpu.main").buildWithCallback { measurement in


### PR DESCRIPTION
### What and why?

This PR reports main-thread and background CPU usage alongside the existing total CPU metric in iOS benchmarks. This helps distinguish UI-sensitive work from work performed on background threads.

### How?

The CPU collector captures the main thread and enumerates the application threads once per sample. It records three separate aggregates:

- `ios.benchmark.cpu`
- `ios.benchmark.cpu.main`
- `ios.benchmark.cpu.background`

Background CPU is calculated as `total - main` from the same sample. `CPU` uses composition to own the three aggregators.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
