### PR TITLE
[RUM-17847] Add customURL to remote configuration for endpoint override

### DIFF
--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -76,6 +76,7 @@ extension RemoteConfigurationCache.Metadata {
 internal final class RemoteConfigurationProvider {
     let id: String
     let site: DatadogSite
+    let customURL: URL?
     let directory: Directory
     let httpClient: HTTPClient
 
@@ -90,6 +91,7 @@ internal final class RemoteConfigurationProvider {
     init(
         id: String,
         site: DatadogSite,
+        customURL: URL? = nil,
         directory: Directory,
         httpClient: HTTPClient,
         notificationCenter: NotificationCenter,
@@ -97,6 +99,7 @@ internal final class RemoteConfigurationProvider {
     ) {
         self.id = id
         self.site = site
+        self.customURL = customURL
         self.directory = directory
         self.httpClient = httpClient
         self.notificationCenter = notificationCenter
@@ -215,7 +218,7 @@ internal final class RemoteConfigurationProvider {
 
         // Build request with conditional ETag header if a previous ETag is stored.
         var request = URLRequest(
-            url: site.remoteConfigurationEndpoint
+            url: customURL ?? site.remoteConfigurationEndpoint
                 .appendingPathComponent("v1")
                 .appendingPathComponent(id)
                 .appendingPathExtension("json")

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -91,10 +91,10 @@ internal final class RemoteConfigurationProvider {
     init(
         id: String,
         site: DatadogSite,
-        customURL: URL? = nil,
         directory: Directory,
         httpClient: HTTPClient,
         notificationCenter: NotificationCenter,
+        customURL: URL? = nil,
         dateProvider: DateProvider = SystemDateProvider()
     ) {
         self.id = id

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -435,10 +435,10 @@ extension DatadogCore {
             return RemoteConfigurationProvider(
                 id: remoteConfiguration.id,
                 site: configuration.site,
-                customURL: remoteConfiguration.customURL,
                 directory: persistentDirectory.coreDirectory,
                 httpClient: httpClient,
                 notificationCenter: configuration.notificationCenter,
+                customURL: remoteConfiguration.customURL,
                 dateProvider: configuration.dateProvider
             )
         }

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -424,7 +424,7 @@ extension DatadogCore {
         )
 
         let httpClient = configuration.httpClientFactory(configuration.proxyConfiguration)
-        let remoteConfigurationProvider = try configuration.remoteConfigurationID.map { id in
+        let remoteConfigurationProvider = try configuration.remoteConfiguration.map { remoteConfiguration in
             // Remote configuration must survive `/Library/Caches` purges, so it is stored under
             // `/Library/Application Support` instead of the (purgeable) core directory.
             let persistentDirectory = try CoreDirectory(
@@ -433,8 +433,9 @@ extension DatadogCore {
                 site: configuration.site
             )
             return RemoteConfigurationProvider(
-                id: id,
+                id: remoteConfiguration.id,
                 site: configuration.site,
+                customURL: remoteConfiguration.customURL,
                 directory: persistentDirectory.coreDirectory,
                 httpClient: httpClient,
                 notificationCenter: configuration.notificationCenter,
@@ -476,7 +477,7 @@ extension DatadogCore {
                 notificationCenter: configuration.notificationCenter,
                 appLaunchHandler: configuration.appLaunchHandler,
                 appStateProvider: configuration.appStateProvider,
-                remoteConfigurationId: configuration.remoteConfigurationID
+                remoteConfigurationId: configuration.remoteConfiguration?.id
             ),
             applicationVersion: applicationVersion,
             maxBatchesPerUpload: configuration.batchProcessingLevel.maxBatchesPerUpload,

--- a/DatadogCore/Sources/DatadogConfiguration+objc.swift
+++ b/DatadogCore/Sources/DatadogConfiguration+objc.swift
@@ -303,13 +303,12 @@ public final class objc_Configuration: NSObject {
         set { sdkConfiguration.backgroundTasksEnabled = newValue }
     }
 
-    /// The remote configuration used to fetch SDK settings from the Datadog CDN at startup.
+    /// Sets the remote configuration used to fetch SDK settings from the Datadog CDN at startup.
     ///
-    /// When non-nil, the SDK asynchronously fetches and caches the remote configuration document.
-    /// Default is `nil` — no fetch is performed.
-    public var remoteConfiguration: objc_RemoteConfiguration? {
-        get { sdkConfiguration.remoteConfiguration.map { objc_RemoteConfiguration(swiftType: $0) } }
-        set { sdkConfiguration.remoteConfiguration = newValue?.swiftType }
+    /// When set, the SDK asynchronously fetches and caches the remote configuration document.
+    /// By default, no remote configuration is set and no fetch is performed.
+    public func setRemoteConfiguration(_ remoteConfiguration: objc_RemoteConfiguration?) {
+        sdkConfiguration.remoteConfiguration = remoteConfiguration?.swiftType
     }
 
     /// Creates a Datadog SDK Configuration object.

--- a/DatadogCore/Sources/DatadogConfiguration+objc.swift
+++ b/DatadogCore/Sources/DatadogConfiguration+objc.swift
@@ -160,6 +160,34 @@ internal struct DDServerDateProviderBridge: ServerDateProvider {
     }
 }
 
+@objc(DDRemoteConfiguration)
+@objcMembers
+@_spi(objc)
+public final class objc_RemoteConfiguration: NSObject {
+    internal var swiftType: Datadog.Configuration.RemoteConfiguration
+
+    /// The remote configuration ID used to fetch SDK settings from the Datadog CDN.
+    public var id: String {
+        get { swiftType.id }
+        set { swiftType.id = newValue }
+    }
+
+    /// A custom URL to fetch the remote configuration document from, overriding the
+    /// default CDN endpoint derived from the resolved `site`.
+    public var customURL: URL? {
+        get { swiftType.customURL }
+        set { swiftType.customURL = newValue }
+    }
+
+    public init(id: String) {
+        swiftType = .init(id: id)
+    }
+
+    internal init(swiftType: Datadog.Configuration.RemoteConfiguration) {
+        self.swiftType = swiftType
+    }
+}
+
 @objc(DDConfiguration)
 @objcMembers
 @_spi(objc)
@@ -275,13 +303,13 @@ public final class objc_Configuration: NSObject {
         set { sdkConfiguration.backgroundTasksEnabled = newValue }
     }
 
-    /// The remote configuration ID used to fetch SDK settings from the Datadog CDN at startup.
+    /// The remote configuration used to fetch SDK settings from the Datadog CDN at startup.
     ///
     /// When non-nil, the SDK asynchronously fetches and caches the remote configuration document.
     /// Default is `nil` — no fetch is performed.
-    public var remoteConfigurationID: String? {
-        get { sdkConfiguration.remoteConfigurationID }
-        set { sdkConfiguration.remoteConfigurationID = newValue }
+    public var remoteConfiguration: objc_RemoteConfiguration? {
+        get { sdkConfiguration.remoteConfiguration.map { objc_RemoteConfiguration(swiftType: $0) } }
+        set { sdkConfiguration.remoteConfiguration = newValue?.swiftType }
     }
 
     /// Creates a Datadog SDK Configuration object.

--- a/DatadogCore/Sources/DatadogConfiguration.swift
+++ b/DatadogCore/Sources/DatadogConfiguration.swift
@@ -123,17 +123,40 @@ extension Datadog {
         /// `false` by default.
         public var backgroundTasksEnabled: Bool
 
-        /// The remote configuration ID used to fetch SDK settings from the Datadog CDN.
+        /// Identifies and optionally overrides where the SDK fetches its remote configuration from.
+        public struct RemoteConfiguration {
+            /// The remote configuration ID used to fetch SDK settings from the Datadog CDN.
+            public var id: String
+
+            /// A custom URL to fetch the remote configuration document from, overriding the
+            /// default CDN endpoint derived from the resolved `site`.
+            ///
+            /// Default is `nil` — the default `site`-derived endpoint is used.
+            public var customURL: URL?
+
+            /// Creates a remote configuration identifier.
+            ///
+            /// - Parameters:
+            ///   - id: The remote configuration ID used to fetch SDK settings from the Datadog CDN.
+            ///   - customURL: A custom URL to fetch the remote configuration document from,
+            ///                overriding the default CDN endpoint derived from the resolved `site`.
+            public init(id: String, customURL: URL? = nil) {
+                self.id = id
+                self.customURL = customURL
+            }
+        }
+
+        /// The remote configuration used to fetch SDK settings from the Datadog CDN.
         ///
-        /// When non-nil, the SDK constructs a CDN URL from this ID and the resolved `site`,
-        /// fetches the remote config document asynchronously at startup, and caches the
-        /// raw JSON to disk for use on subsequent launches.
+        /// When non-nil, the SDK constructs a CDN URL from its `id` and the resolved `site`
+        /// (or from `customURL`, if set), fetches the remote config document asynchronously
+        /// at startup, and caches the raw JSON to disk for use on subsequent launches.
         ///
         /// Default is `nil` — no fetch is performed.
         ///
         /// RFC also specifies a `requireRemoteConfiguration` flag: when `true` and no cache
         /// exists, `Datadog.initialize` should return without starting the SDK. Not yet implemented.
-        public var remoteConfigurationID: String? = nil
+        public var remoteConfiguration: RemoteConfiguration? = nil
 
         /// Creates a Datadog SDK Configuration object.
         ///
@@ -182,7 +205,7 @@ extension Datadog {
         ///                                 any upload blocker such us no internet connection or low battery.
         ///                                 By default it's set to `false`.
         ///
-        ///   - remoteConfigurationID:      The identifier used to fetch SDK settings from the Datadog CDN.
+        ///   - remoteConfiguration:        The remote configuration used to fetch SDK settings from the Datadog CDN.
         ///                                 When non-nil, the SDK fetches the remote configuration document
         ///                                 asynchronously at startup and caches the raw JSON for subsequent launches.
         ///                                 Default is `nil` — no fetch is performed.
@@ -200,7 +223,7 @@ extension Datadog {
             serverDateProvider: ServerDateProvider? = nil,
             batchProcessingLevel: BatchProcessingLevel = .medium,
             backgroundTasksEnabled: Bool = false,
-            remoteConfigurationID: String? = nil
+            remoteConfiguration: RemoteConfiguration? = nil
         ) {
             self.clientToken = clientToken
             self.env = env
@@ -215,7 +238,7 @@ extension Datadog {
             self.serverDateProvider = serverDateProvider ?? DatadogNTPDateProvider()
             self.batchProcessingLevel = batchProcessingLevel
             self.backgroundTasksEnabled = backgroundTasksEnabled
-            self.remoteConfigurationID = remoteConfigurationID
+            self.remoteConfiguration = remoteConfiguration
         }
 
         // MARK: - Internal

--- a/DatadogCore/Tests/Datadog/DatadogTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogTests.swift
@@ -538,7 +538,7 @@ class DatadogTests: XCTestCase {
     func testGivenRemoteConfigurationID_remoteConfigurationIsCreated() throws {
         // Given
         var config = defaultConfig
-        config.remoteConfigurationID = "test-id"
+        config.remoteConfiguration = .init(id: "test-id")
 
         // When
         Datadog.initialize(with: config, trackingConsent: .granted)
@@ -556,7 +556,7 @@ class DatadogTests: XCTestCase {
         let cachesDirectory = Directory(url: obtainUniqueTemporaryDirectory())
         let persistentDirectory = Directory(url: obtainUniqueTemporaryDirectory())
         var config = defaultConfig
-        config.remoteConfigurationID = "test-id"
+        config.remoteConfiguration = .init(id: "test-id")
         config.systemDirectory = { cachesDirectory }
         config.persistentDirectory = { persistentDirectory }
         config.httpClientFactory = { _ in HTTPClientMock() }

--- a/DatadogCore/Tests/Objc/DDConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDConfigurationTests.swift
@@ -109,6 +109,21 @@ class DDConfigurationTests: XCTestCase {
         XCTAssertEqual(objcConfig.sdkConfiguration.backgroundTasksEnabled, fakeBackgroundTasksEnabled)
     }
 
+    func testSetRemoteConfigurationForwardsToSwiftConfiguration() throws {
+        let objcConfig = objc_Configuration(clientToken: "abc-123", env: "tests")
+
+        let remoteConfiguration = objc_RemoteConfiguration(id: "abc-123")
+        let customURL: URL = .mockRandom()
+        remoteConfiguration.customURL = customURL
+
+        objcConfig.setRemoteConfiguration(remoteConfiguration)
+        XCTAssertEqual(objcConfig.sdkConfiguration.remoteConfiguration?.id, "abc-123")
+        XCTAssertEqual(objcConfig.sdkConfiguration.remoteConfiguration?.customURL, customURL)
+
+        objcConfig.setRemoteConfiguration(nil)
+        XCTAssertNil(objcConfig.sdkConfiguration.remoteConfiguration)
+    }
+
     func testDataEncryption() throws {
         // Given
         class ObjCDataEncryption: objc_DataEncryption {

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -69,8 +69,8 @@
     configuration.additionalConfiguration = @{@"additional": @"config"};
     [configuration setEncryption:[CustomDDDataEncryption new]];
     configuration.backgroundTasksEnabled = true;
-    configuration.remoteConfigurationID = @"abc-123";
-    configuration.remoteConfigurationID = nil;
+    configuration.remoteConfiguration = [[DDRemoteConfiguration alloc] initWithId:@"abc-123"];
+    configuration.remoteConfiguration = nil;
 }
 
 - (void)testDatadogCrashReporterAPI {

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -69,8 +69,8 @@
     configuration.additionalConfiguration = @{@"additional": @"config"};
     [configuration setEncryption:[CustomDDDataEncryption new]];
     configuration.backgroundTasksEnabled = true;
-    configuration.remoteConfiguration = [[DDRemoteConfiguration alloc] initWithId:@"abc-123"];
-    configuration.remoteConfiguration = nil;
+    [configuration setRemoteConfiguration:[[DDRemoteConfiguration alloc] initWithId:@"abc-123"]];
+    [configuration setRemoteConfiguration:nil];
 }
 
 - (void)testDatadogCrashReporterAPI {

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -58,6 +58,10 @@ public protocol objc_DataEncryption: AnyObject
     func decrypt(data: Data) throws -> Data
 public protocol objc_ServerDateProvider: AnyObject
     func synchronize(update: @escaping (TimeInterval) -> Void)
+public final class objc_RemoteConfiguration: NSObject
+    public var id: String
+    public var customURL: URL?
+    public init(id: String)
 public final class objc_Configuration: NSObject
     public var clientToken: String
     public var env: String
@@ -73,7 +77,7 @@ public final class objc_Configuration: NSObject
     public var bundle: Bundle
     public var additionalConfiguration: [String: Any]
     public var backgroundTasksEnabled: Bool
-    public var remoteConfigurationID: String?
+    public var remoteConfiguration: objc_RemoteConfiguration?
     public init(clientToken: String, env: String)
 public final class objc_URLSessionInstrumentationConfiguration: NSObject
     public init(delegateClass: URLSessionDataDelegate.Type)

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -77,7 +77,7 @@ public final class objc_Configuration: NSObject
     public var bundle: Bundle
     public var additionalConfiguration: [String: Any]
     public var backgroundTasksEnabled: Bool
-    public var remoteConfiguration: objc_RemoteConfiguration?
+    public func setRemoteConfiguration(_ remoteConfiguration: objc_RemoteConfiguration?)
     public init(clientToken: String, env: String)
 public final class objc_URLSessionInstrumentationConfiguration: NSObject
     public init(delegateClass: URLSessionDataDelegate.Type)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -59,8 +59,12 @@ public extension Datadog
         public var bundle: Bundle
         public var batchProcessingLevel: BatchProcessingLevel
         public var backgroundTasksEnabled: Bool
-        public var remoteConfigurationID: String? = nil
-        public init(clientToken: String,env: String,site: DatadogSite = .us1,service: String? = nil,version: String? = nil,bundle: Bundle = .main,batchSize: BatchSize = .medium,uploadFrequency: UploadFrequency = .average,proxyConfiguration: [AnyHashable: Any]? = nil,encryption: DataEncryption? = nil,serverDateProvider: ServerDateProvider? = nil,batchProcessingLevel: BatchProcessingLevel = .medium,backgroundTasksEnabled: Bool = false,remoteConfigurationID: String? = nil)
+        public struct RemoteConfiguration
+            public var id: String
+            public var customURL: URL?
+            public init(id: String, customURL: URL? = nil)
+        public var remoteConfiguration: RemoteConfiguration? = nil
+        public init(clientToken: String,env: String,site: DatadogSite = .us1,service: String? = nil,version: String? = nil,bundle: Bundle = .main,batchSize: BatchSize = .medium,uploadFrequency: UploadFrequency = .average,proxyConfiguration: [AnyHashable: Any]? = nil,encryption: DataEncryption? = nil,serverDateProvider: ServerDateProvider? = nil,batchProcessingLevel: BatchProcessingLevel = .medium,backgroundTasksEnabled: Bool = false,remoteConfiguration: RemoteConfiguration? = nil)
 public class SharedContext: NSObject
     public let userId: String?
     public let accountId: String?


### PR DESCRIPTION
### What and why?

Turns `Configuration.remoteConfigurationID: String?` into a `Configuration.RemoteConfiguration` struct (`id: String`, `customURL: URL? = nil`), so a custom URL can override the default CDN endpoint used to fetch the remote configuration document.

### How?

- Added `Datadog.Configuration.RemoteConfiguration` (`id`, `customURL`), replacing `remoteConfigurationID`.
- `RemoteConfigurationProvider` now takes an optional `customURL`; when set, it's used verbatim as the fetch URL instead of `site.remoteConfigurationEndpoint` + `v1/<id>.json`.
- Added Objective-C bridging (`DDRemoteConfiguration`).
- Regenerated `api-surface-swift` / `api-surface-objc`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes (deferred until feature/remote-config merges into develop, consistent with prior PRs on this feature branch)
- [x] Add Objective-C interface for public APIs
- [x] Run `make api-surface` when adding new APIs