### PR TITLE
[FFLSDK-158] Harden Apple platform CI validation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,6 +67,7 @@ workflow:
           - "SmokeTests/**/*"
           - "TestUtilities/**/*"
           - "tools/**/*"
+          - "xcconfigs/**/*"
           - "*" # match any file in the root directory
         compare_to: 'develop' # cannot use $DEVELOP_BRANCH var due to: https://gitlab.com/gitlab-org/gitlab/-/issues/369916
 
@@ -166,6 +167,15 @@ Feature Docs Verify:
   script:
     - make feature-docs-verify
 
+Platform Compatibility:
+  stage: lint
+  rules:
+    - !reference [.test-pipeline-job, rules]
+    - !reference [.release-pipeline-job, rules]
+  script:
+    - ./tools/runner-setup.sh --python
+    - make platform-compatibility
+
 Unit Tests (iOS):
   stage: test
   rules: 
@@ -207,7 +217,7 @@ Unit Tests (tvOS):
     DEVICE: "Apple TV"
     RUNNER_SCRIPT_TIMEOUT: "50m"
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --tvOS
     - make clean repo-setup ENV=ci
     - make test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
   artifacts:
@@ -231,7 +241,7 @@ Unit Tests (watchOS):
     DEVICE: "Apple Watch Series 11 (46mm)"
     RUNNER_SCRIPT_TIMEOUT: "50m"
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --watchOS
     - make clean repo-setup ENV=ci
     - make test-watchos-all OS="$DEFAULT_WATCHOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
   artifacts:
@@ -255,7 +265,7 @@ Unit Tests (visionOS):
     DEVICE: "Apple Vision Pro"
     RUNNER_SCRIPT_TIMEOUT: "50m"
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --visionOS
     - make clean repo-setup ENV=ci
     - make test-visionos-all OS="$DEFAULT_VISIONOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
   artifacts:
@@ -398,7 +408,7 @@ Smoke Tests (tvOS):
     PLATFORM: "tvOS Simulator"
     DEVICE: "Apple TV"
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --tvOS --ssh
     - make clean repo-setup ENV=ci
     - make smoke-test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all: env-check repo-setup dependencies templates
 .PHONY: env-check repo-setup dependencies clean templates \
 		lint lint-cpp license-check \
+		platform-compatibility \
 		test test-ios test-ios-all test-tvos test-tvos-all test-visionos test-visionos-all \
 		ui-test ui-test-all ui-test-podinstall \
 		sr-snapshot-test sr-snapshots-pull sr-snapshots-push sr-layer-snapshot-test sr-layer-snapshots-pull sr-layer-snapshots-push sr-snapshot-tests-open \
@@ -55,6 +56,10 @@ lint-cpp:
 license-check:
 	@$(ECHO_TITLE) "make license-check"
 	./tools/license/check-license.sh
+
+platform-compatibility:
+	@$(ECHO_TITLE) "make platform-compatibility"
+	python3 ./tools/validate_platform_compatibility.py
 
 # Test env for running iOS tests in local:
 DEFAULT_IOS_OS := latest

--- a/tools/tests/test_platform_compatibility.py
+++ b/tools/tests/test_platform_compatibility.py
@@ -1,0 +1,98 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-Present Datadog, Inc.
+# -----------------------------------------------------------
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.validate_platform_compatibility import (
+    parse_package_manifest,
+    parse_podspec,
+    parse_xcconfig,
+    validate_platforms,
+)
+
+
+class PlatformCompatibilityTests(unittest.TestCase):
+    manifest_platforms = {
+        "ios": "12.0",
+        "tvos": "12.0",
+        "macos": "12.6",
+        "watchos": "7.0",
+        "visionos": "1.0",
+    }
+
+    xcconfig = {
+        "IPHONEOS_DEPLOYMENT_TARGET": "12.0",
+        "TVOS_DEPLOYMENT_TARGET": "12.0",
+        "MACOSX_DEPLOYMENT_TARGET": "12.6",
+        "WATCHOS_DEPLOYMENT_TARGET": "7.0",
+        "XROS_DEPLOYMENT_TARGET": "1.0",
+    }
+
+    def test_accepts_matching_deployment_targets(self):
+        errors = validate_platforms(
+            self.manifest_platforms,
+            self.xcconfig,
+            {"DatadogRUM.podspec": {"ios": "12", "tvos": "12.0", "watchos": "7.0"}},
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_rejects_xcconfig_deployment_target_drift(self):
+        xcconfig = self.xcconfig | {"WATCHOS_DEPLOYMENT_TARGET": "6.0"}
+
+        errors = validate_platforms(self.manifest_platforms, xcconfig, {})
+
+        self.assertIn(
+            "watchos is 7.0 in Package.swift but 6.0 in WATCHOS_DEPLOYMENT_TARGET",
+            errors,
+        )
+
+    def test_rejects_podspec_deployment_target_drift(self):
+        errors = validate_platforms(
+            self.manifest_platforms,
+            self.xcconfig,
+            {"DatadogRUM.podspec": {"watchos": "8.0"}},
+        )
+
+        self.assertIn(
+            "watchos is 7.0 in Package.swift but 8.0 in DatadogRUM.podspec",
+            errors,
+        )
+
+    def test_reads_manifest_platforms(self):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "Package.swift"
+            manifest.write_text(
+                "platforms: [.iOS(.v12), .macOS(\"12.6\"), .watchOS(.v7)]"
+            )
+
+            self.assertEqual(
+                parse_package_manifest(manifest),
+                {"ios": "12", "macos": "12.6", "watchos": "7"},
+            )
+
+    def test_reads_xcconfig_and_podspec_deployment_targets(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            xcconfig = root / "Base.xcconfig"
+            xcconfig.write_text("WATCHOS_DEPLOYMENT_TARGET=7.0\nTVOS_DEPLOYMENT_TARGET = 12.0\n")
+            podspec = root / "DatadogRUM.podspec"
+            podspec.write_text(
+                "  s.tvos.deployment_target = '12.0'\n"
+                "  s.watchos.deployment_target = \"7.0\"\n"
+            )
+
+            self.assertEqual(
+                parse_xcconfig(xcconfig),
+                {"WATCHOS_DEPLOYMENT_TARGET": "7.0", "TVOS_DEPLOYMENT_TARGET": "12.0"},
+            )
+            self.assertEqual(parse_podspec(podspec), {"tvos": "12.0", "watchos": "7.0"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tools-test.sh
+++ b/tools/tools-test.sh
@@ -18,8 +18,11 @@ test_swift_package tools/http-server-mock
 test_swift_package tools/rum-models-generator
 test_swift_package tools/sr-snapshots
 
+# Test platform compatibility validation:
+echo_subtitle "Run platform compatibility validator tests"
+python3 -m unittest discover --start-directory tools/tests --pattern "test_*.py"
+
 # Test dogfooding automation:
 echo_subtitle "Run 'make clean install test' in ./tools/dogfooding"
 cd tools/dogfooding && make clean install test
 cd -
-

--- a/tools/validate_platform_compatibility.py
+++ b/tools/validate_platform_compatibility.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-Present Datadog, Inc.
+# -----------------------------------------------------------
+
+import re
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_MANIFEST = REPOSITORY_ROOT / "Package.swift"
+BASE_XCCONFIG = REPOSITORY_ROOT / "xcconfigs" / "Base.xcconfig"
+
+PLATFORM_XCCONFIG_KEYS = {
+    "ios": "IPHONEOS_DEPLOYMENT_TARGET",
+    "tvos": "TVOS_DEPLOYMENT_TARGET",
+    "macos": "MACOSX_DEPLOYMENT_TARGET",
+    "watchos": "WATCHOS_DEPLOYMENT_TARGET",
+    "visionos": "XROS_DEPLOYMENT_TARGET",
+}
+
+PODSPEC_PLATFORM_NAMES = {
+    "ios": "ios",
+    "tvos": "tvos",
+    "osx": "macos",
+    "watchos": "watchos",
+    "visionos": "visionos",
+}
+
+
+def parse_package_manifest(path: Path) -> dict[str, str]:
+    platforms = {}
+    declaration = re.compile(
+        r"\.(iOS|tvOS|macOS|watchOS|visionOS)\(\s*(?:\.v([0-9_]+)|\"([0-9.]+)\")\s*\)"
+    )
+    for match in declaration.finditer(path.read_text()):
+        version = match.group(2).replace("_", ".") if match.group(2) else match.group(3)
+        platforms[match.group(1).lower()] = version
+    return platforms
+
+
+def parse_xcconfig(path: Path) -> dict[str, str]:
+    settings = {}
+    assignment = re.compile(r"^\s*([A-Z0-9_]+)\s*=\s*([^\s/]+)\s*$")
+    for line in path.read_text().splitlines():
+        match = assignment.match(line)
+        if match:
+            settings[match.group(1)] = match.group(2)
+    return settings
+
+
+def parse_podspec(path: Path) -> dict[str, str]:
+    platforms = {}
+    deployment_target = re.compile(
+        r"^\s*s\.(ios|tvos|osx|watchos|visionos)\.deployment_target\s*=\s*['\"]([^'\"]+)['\"]"
+    )
+    for line in path.read_text().splitlines():
+        match = deployment_target.match(line)
+        if match:
+            platforms[PODSPEC_PLATFORM_NAMES[match.group(1)]] = match.group(2)
+    return platforms
+
+
+def normalized_version(version: str) -> tuple[int, ...]:
+    components = [int(component) for component in version.split(".")]
+    while components and components[-1] == 0:
+        components.pop()
+    return tuple(components)
+
+
+def validate_platforms(
+    manifest_platforms: dict[str, str],
+    xcconfig: dict[str, str],
+    podspec_platforms: dict[str, dict[str, str]],
+) -> list[str]:
+    errors = []
+
+    for platform, setting in PLATFORM_XCCONFIG_KEYS.items():
+        manifest_version = manifest_platforms.get(platform)
+        xcconfig_version = xcconfig.get(setting)
+        if manifest_version is None:
+            errors.append(f"Package.swift does not declare {platform}")
+        elif xcconfig_version is None:
+            errors.append(f"xcconfigs/Base.xcconfig does not declare {setting}")
+        elif normalized_version(manifest_version) != normalized_version(xcconfig_version):
+            errors.append(
+                f"{platform} is {manifest_version} in Package.swift but "
+                f"{xcconfig_version} in {setting}"
+            )
+
+    for podspec, platforms in podspec_platforms.items():
+        for platform, podspec_version in platforms.items():
+            manifest_version = manifest_platforms.get(platform)
+            if manifest_version is None:
+                errors.append(f"{podspec} declares unsupported platform {platform}")
+            elif normalized_version(manifest_version) != normalized_version(podspec_version):
+                errors.append(
+                    f"{platform} is {manifest_version} in Package.swift but "
+                    f"{podspec_version} in {podspec}"
+                )
+
+    return errors
+
+
+def main() -> None:
+    manifest_platforms = parse_package_manifest(PACKAGE_MANIFEST)
+    xcconfig = parse_xcconfig(BASE_XCCONFIG)
+    podspec_platforms = {
+        podspec.name: parse_podspec(podspec)
+        for podspec in sorted(REPOSITORY_ROOT.glob("*.podspec"))
+    }
+    errors = validate_platforms(manifest_platforms, xcconfig, podspec_platforms)
+
+    if errors:
+        print("Platform compatibility validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        raise SystemExit(1)
+
+    platforms = ", ".join(
+        f"{platform} {version}" for platform, version in manifest_platforms.items()
+    )
+    print(f"Platform compatibility validated: {platforms}")
+    print("All xcconfig and podspec deployment targets match Package.swift.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What and why?

#### Motivation

The Strava watchOS compatibility investigation exposed that several `dd-sdk-ios` simulator jobs rely on watchOS, tvOS, or visionOS runtimes already being present in the runner image. The generic SPM device builds provide a separate package-level safety net, but the simulator jobs themselves are not hermetic.

Feature-branch CI also omitted `xcconfigs/**/*`, and there was no automated contract preventing deployment-target drift between `Package.swift`, the shared xcconfig, and podspec metadata.

Tracks [FFLSDK-158](https://linear.app/datadoghq/issue/FFLSDK-158/ios-harden-dd-sdk-ios-watchos-and-tvos-ci-validation).

### How?

#### Changes

- Provision tvOS explicitly in tvOS unit and smoke-test jobs.
- Provision watchOS explicitly in the watchOS unit-test job.
- Provision visionOS explicitly in the visionOS unit-test job.
- Include `xcconfigs/**/*` in feature-branch CI change rules.
- Add `make platform-compatibility` to validate deployment targets across `Package.swift`, `xcconfigs/Base.xcconfig`, and root podspecs.
- Add five focused validator tests to the existing tools-test suite.

#### Decisions

- Preserve the existing generic watchOS and tvOS SPM device builds instead of adding duplicate jobs.
- Keep platform provisioning correctness-first: each simulator job requests the platform it consumes rather than assuming runner-image contents.
- Compare podspec deployment targets only for platforms each podspec declares, because SDK modules intentionally support different platform subsets.

### Validation

- `make platform-compatibility`
- `python3 -m unittest discover --start-directory tools/tests --pattern "test_*.py"`
- GitLab CI YAML parsing
- `zsh -n tools/tools-test.sh`
- `git diff --check`

### Review checklist

- [x] Feature or bugfix has appropriate tests.
- [x] The commit and PR mention FFLSDK-158.
- [x] CHANGELOG entry is not applicable because this only changes CI validation.
- [x] Objective-C interface changes are not applicable.
- [x] API surface generation is not applicable.