### PR TITLE
[RUM-16719] Remove dead availability guards in DatadogFlags

### DIFF
--- a/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
@@ -131,7 +131,6 @@ extension FlagsClientProtocol {
     /// - Parameter context: The evaluation context containing targeting key and custom attributes.
     ///
     /// - Throws: ``FlagsError`` if the operation fails.
-    @available(iOS 13.0, tvOS 13.0, *)
     public func setEvaluationContext(_ context: FlagsEvaluationContext) async throws {
         try await withCheckedThrowingContinuation { continuation in
             setEvaluationContext(context) { result in


### PR DESCRIPTION
### What and why?

Removes @available/#available checks that are now dead following the minimum deployment target bump in #3155 (iOS 15.0 / tvOS 15.0 / watchOS 9.0). Part of the RUM-16719 cleanup, split per module.

### How?

Deletes availability branches whose guarded platform versions are all ≤ the new floors, keeping only the code path that is now always available. No behavior change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs