### PR TITLE
[RUM-16719] Remove dead availability guards in DatadogTrace

### DIFF
--- a/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpanBuilder.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/NOPOTelSpanBuilder.swift
@@ -64,7 +64,6 @@ internal class NOPOTelSpanBuilder: SpanBuilder {
 
 #if canImport(_Concurrency)
     /// Ref.: https://github.com/open-telemetry/opentelemetry-swift/issues/578
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) async throws -> T) async rethrows -> T {
         let span = startSpan()
         defer { span.end() }

--- a/DatadogTrace/Sources/OpenTelemetry/OTelSpanBuilder.swift
+++ b/DatadogTrace/Sources/OpenTelemetry/OTelSpanBuilder.swift
@@ -160,7 +160,6 @@ internal class OTelSpanBuilder: OpenTelemetryApi.SpanBuilder {
 
 #if canImport(_Concurrency)
     /// Ref.: https://github.com/open-telemetry/opentelemetry-swift/issues/578
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withActiveSpan<T>(_ operation: (any OpenTelemetryApi.SpanBase) async throws -> T) async rethrows -> T {
         let createdSpan = self.prepareSpan()
         defer { createdSpan.end() }

--- a/DatadogTrace/Sources/Span/SpanEventBuilder.swift
+++ b/DatadogTrace/Sources/Span/SpanEventBuilder.swift
@@ -131,33 +131,7 @@ internal struct SpanEventBuilder: Sendable {
             } else {
                 do {
                     let encodable = AnyEncodable(value)
-                    let jsonData: Data
-
-                    if #available(iOS 13.0, *) {
-                        jsonData = try attributesEncoder.encode(encodable)
-                    } else {
-                        // Prior to `iOS13.0` the `JSONEncoder` is unable to encode primitive values - it expects them to be
-                        // wrapped inside top-level JSON object (array or dictionary). Reference: https://bugs.swift.org/browse/SR-6163
-                        //
-                        // As a workaround, we serialize the `encodable` as a JSON array and then remove `[` and `]` bytes from serialized data.
-                        let temporaryJsonArrayData = try attributesEncoder.encode([encodable])
-
-                        let subdataStartIndex = temporaryJsonArrayData.startIndex.advanced(by: 1)
-                        let subdataEndIndex = temporaryJsonArrayData.endIndex.advanced(by: -1)
-
-                        guard subdataStartIndex < subdataEndIndex else {
-                            // This error should never be thrown, as the `temporaryJsonArrayData` will always contain at
-                            // least two bytes standing for `[` and `]`. This check is just for sanity.
-                            let encodingContext = EncodingError.Context(
-                                codingPath: [],
-                                debugDescription: "Failed to use temporary array container when encoding span tag '\(key)' to JSON string."
-                            )
-                            telemetry.error(encodingContext.debugDescription)
-                            throw EncodingError.invalidValue(encodable.value, encodingContext)
-                        }
-
-                        jsonData = temporaryJsonArrayData.subdata(in: subdataStartIndex..<subdataEndIndex)
-                    }
+                    let jsonData = try attributesEncoder.encode(encodable)
 
                     if let stringValue = String(data: jsonData, encoding: .utf8) {
                         casted[key] = stringValue

--- a/DatadogTrace/Tests/Utils/ActiveSpansPoolTests.swift
+++ b/DatadogTrace/Tests/Utils/ActiveSpansPoolTests.swift
@@ -81,7 +81,6 @@ class ActiveSpansPoolTests: XCTestCase, Sendable {
         XCTAssertTrue(tracer.activeSpansPool.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13, *)
     func testActiveSpanIsKeptPerTask() async throws {
         let tracer = DatadogTracer.mockAny(in: core)
         let oneSpan = tracer.startSpan(operationName: .mockAny()).setActive()


### PR DESCRIPTION
### What and why?

Removes @available/#available checks that are now dead following the minimum deployment target bump in #3155 (iOS 15.0 / tvOS 15.0 / watchOS 9.0). Part of the RUM-16719 cleanup, split per module.

### How?

Deletes availability branches whose guarded platform versions are all ≤ the new floors, keeping only the code path that is now always available. No behavior change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs