### PR TITLE
[RUM-16719] Remove dead availability guards in DatadogWebViewTracking

### DIFF
--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -304,7 +304,6 @@ class WebViewTrackingTests: XCTestCase {
     }
 
     /// Loads a simulated request on a WebView, and waits for the page to finish loading.
-    @available(iOS 15.0, *)
     private func loadAndWait(on webView: WKWebView, request: URLRequest, responseHTML: String) {
         final class NavigationDelegate: NSObject, WKNavigationDelegate {
             let expectation: XCTestExpectation
@@ -332,7 +331,6 @@ class WebViewTrackingTests: XCTestCase {
         }
     }
 
-    @available(iOS 15.0, *)
     func testItChangesBridgeDecisionOnSessionRollover() throws {
         // Given
         // This session ID is not sampled at 50%, but it is sampled at 60%:
@@ -400,7 +398,6 @@ class WebViewTrackingTests: XCTestCase {
         waitForJS("window.DatadogEventBridge.getIsTraceSampled()", toReturn: "true", webView: webView, description: "sessionUUID2 after loading a new page")
     }
 
-    @available(iOS 15.0, *)
     func testItChangesBridgeDecisionOnSessionRolloverInIframes() throws {
         // Given
         // This session ID is not sampled at 50%, but it is sampled at 60%:
@@ -481,7 +478,6 @@ class WebViewTrackingTests: XCTestCase {
         waitForJS(nestedIframeJS, toReturn: "true", webView: webView, description: "nested iframe sessionUUID2")
     }
 
-    @available(iOS 15.0, *)
     func testItSetsBridgeDecisionToNullOnSessionStop() throws {
         // Given
         // This session ID is not sampled at 50%, but it is sampled at 60%:


### PR DESCRIPTION
### What and why?

Removes @available/#available checks that are now dead following the minimum deployment target bump in #3155 (iOS 15.0 / tvOS 15.0 / watchOS 9.0). Part of the RUM-16719 cleanup, split per module.

### How?

Deletes availability branches whose guarded platform versions are all ≤ the new floors, keeping only the code path that is now always available. No behavior change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs