### PR TITLE
[RUM-16719] Remove dead availability guards in test utilities, example app, and integration tests

### DIFF
--- a/Datadog/Example/Debugging/BackgroundEvents/BackgroundLocationMonitor.swift
+++ b/Datadog/Example/Debugging/BackgroundEvents/BackgroundLocationMonitor.swift
@@ -163,17 +163,13 @@ internal class BackgroundLocationMonitor: NSObject, CLLocationManagerDelegate {
     // MARK: - Helpers
 
     private func authorizationStatusDescription(for manager: CLLocationManager) -> String {
-        if #available(iOS 14.0, *) {
-            switch locationManager.authorizationStatus {
-            case .authorizedAlways: return "authorizedAlways"
-            case .notDetermined: return "notDetermined"
-            case .restricted: return "restricted"
-            case .denied: return "denied"
-            case .authorizedWhenInUse: return "authorizedWhenInUse"
-            @unknown default: return "unrecognized (sth new)"
-            }
-        } else {
-            return "unavailable prior to iOS 14.0"
+        switch locationManager.authorizationStatus {
+        case .authorizedAlways: return "authorizedAlways"
+        case .notDetermined: return "notDetermined"
+        case .restricted: return "restricted"
+        case .denied: return "denied"
+        case .authorizedWhenInUse: return "authorizedWhenInUse"
+        @unknown default: return "unrecognized (sth new)"
         }
     }
 }

--- a/Datadog/Example/Debugging/BackgroundEvents/DebugBackgroundEventsViewController.swift
+++ b/Datadog/Example/Debugging/BackgroundEvents/DebugBackgroundEventsViewController.swift
@@ -9,14 +9,12 @@
 import SwiftUI
 import DatadogCore
 
-@available(iOS 13, *)
 internal class DebugBackgroundEventsViewController: UIHostingController<DebugBackgroundEventsView> {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder, rootView: DebugBackgroundEventsView())
     }
 }
 
-@available(iOS 13, *)
 private class DebugBackgroundEventsViewModel: ObservableObject {
     private let locationMonitor: BackgroundLocationMonitor
 
@@ -57,7 +55,6 @@ private class DebugBackgroundEventsViewModel: ObservableObject {
     }
 }
 
-@available(iOS 13, *)
 internal struct DebugBackgroundEventsView: View {
     @ObservedObject private var viewModel = DebugBackgroundEventsViewModel()
 
@@ -78,10 +75,8 @@ internal struct DebugBackgroundEventsView: View {
                 Text("Location Monitoring:")
                     .font(.body).fontWeight(.light)
                 Spacer()
-                if #available(iOS 14, *) {
-                    if viewModel.isLocationMonitoringON {
-                        ProgressView().padding(.trailing, 8)
-                    }
+                if viewModel.isLocationMonitoringON {
+                    ProgressView().padding(.trailing, 8)
                 }
                 Button(viewModel.isLocationMonitoringON ? "STOP" : "START") {
                     if viewModel.isLocationMonitoringON {
@@ -118,7 +113,6 @@ internal struct DebugBackgroundEventsView: View {
 
 // MARK - Preview
 
-@available(iOS 13, *)
 internal struct DebugBackgroundEventsView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Datadog/Example/Debugging/DebugManualTraceInjectionViewController.swift
+++ b/Datadog/Example/Debugging/DebugManualTraceInjectionViewController.swift
@@ -8,7 +8,6 @@ import SwiftUI
 import DatadogTrace
 import DatadogInternal
 
-@available(iOS 13, tvOS 13, *)
 internal class DebugManualTraceInjectionViewController: UIHostingController<DebugManualTraceInjectionView> {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder, rootView: DebugManualTraceInjectionView())
@@ -28,7 +27,6 @@ extension TraceContextInjection {
     }
 }
 
-@available(iOS 13, tvOS 13, *)
 internal struct DebugManualTraceInjectionView: View {
     enum TraceHeaderType: String, CaseIterable, Identifiable {
         case datadog = "Datadog"
@@ -174,7 +172,6 @@ internal struct DebugManualTraceInjectionView: View {
 
 // MARK - Preview
 
-@available(iOS 13, tvOS 13, *)
 struct DebugTraceInjectionView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
@@ -8,7 +8,6 @@ import SwiftUI
 import DatadogRUM
 import DatadogTrace
 
-@available(iOS 13, tvOS 13, *)
 internal class DebugRUMSessionViewController: UIHostingController<DebugRUMSessionView> {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder, rootView: DebugRUMSessionView())
@@ -22,7 +21,6 @@ private enum SessionItemType {
     case error
 }
 
-@available(iOS 13, tvOS 13, *)
 private class DebugRUMSessionViewModel: ObservableObject {
     struct SessionItem: Identifiable {
         let label: String
@@ -196,7 +194,6 @@ private class DebugRUMSessionViewModel: ObservableObject {
     }
 }
 
-@available(iOS 13, tvOS 13, *)
 internal struct DebugRUMSessionView: View {
     @ObservedObject private var viewModel = DebugRUMSessionViewModel()
 
@@ -289,7 +286,6 @@ internal struct DebugRUMSessionView: View {
     }
 }
 
-@available(iOS 13, tvOS 13, *)
 private struct FormItemView: View {
     let title: String
     let placeholder: String
@@ -317,7 +313,6 @@ private struct FormItemView: View {
     }
 }
 
-@available(iOS 13, tvOS 13, *)
 private struct SessionItemView: View {
     let item: DebugRUMSessionViewModel.SessionItem
 
@@ -368,7 +363,6 @@ private struct SessionItemView: View {
 
 // MARK - Preview
 
-@available(iOS 13, tvOS 13, *)
 struct DebugRUMSessionViewController_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Datadog/Example/Debugging/Helpers/SwiftUI.swift
+++ b/Datadog/Example/Debugging/Helpers/SwiftUI.swift
@@ -6,7 +6,6 @@
 
 import SwiftUI
 
-@available(iOS 13, tvOS 13,*)
 extension Color {
     /// Datadog purple.
     static var datadogPurple: Color {
@@ -30,7 +29,6 @@ extension Color {
     }
 }
 
-@available(iOS 13, tvOS 13,*)
 internal struct DatadogButtonStyle: ButtonStyle {
     func makeBody(configuration: DatadogButtonStyle.Configuration) -> some View {
         return configuration.label

--- a/Datadog/Example/Utils/MultiSelector.swift
+++ b/Datadog/Example/Utils/MultiSelector.swift
@@ -6,7 +6,6 @@
 
 import SwiftUI
 
-@available(iOS 13, tvOS 13, *)
 struct MultiSelector<LabelView: View, Selectable: Identifiable & Hashable>: View {
     let label: LabelView
     let options: [Selectable]
@@ -44,7 +43,6 @@ struct MultiSelector<LabelView: View, Selectable: Identifiable & Hashable>: View
 }
 
 
-@available(iOS 13, tvOS 13, *)
 struct MultiSelectionView<Selectable: Identifiable & Hashable>: View {
     let options: [Selectable]
     let optionToString: (Selectable) -> String

--- a/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/ViewLoadingMetricsTests.swift
@@ -63,7 +63,6 @@ class ViewLoadingMetricsTests: XCTestCase {
         XCTAssertEqual(actualTNS, expectedTNS, "TNS should span from the view start to the last completed initial resource.")
     }
 
-    @available(iOS 13, *)
     func testWhenResourcesHaveMetrics_thenTheyAreIncludedInTNSMetricCalculation() throws {
         let rumTime = DateProviderMock()
         rumConfig.dateProvider = rumTime

--- a/TestUtilities/Sources/Helpers/DDAssert.swift
+++ b/TestUtilities/Sources/Helpers/DDAssert.swift
@@ -132,15 +132,8 @@ private func _DDAssertJSONEqual<T, U>(_ expression1: @autoclosure () throws -> T
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
-    let data1: Data
-    let data2: Data
-    if #available(iOS 13.0, *) {
-        data1 = try encoder.encode(value1)
-        data2 = try encoder.encode(value2)
-    } else {
-        data1 = try encoder.encode(EncodingContainer(value1))
-        data2 = try encoder.encode(EncodingContainer(value2))
-    }
+    let data1 = try encoder.encode(value1)
+    let data2 = try encoder.encode(value2)
     let string1 = data1.utf8String
     let string2 = data2.utf8String
     guard string1 == string2 else {

--- a/TestUtilities/Sources/Helpers/XCTestCase.swift
+++ b/TestUtilities/Sources/Helpers/XCTestCase.swift
@@ -75,7 +75,6 @@ extension XCTestCase {
         closure()
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     public func dd_fulfillment(
         for expectations: [XCTestExpectation],
         timeout seconds: TimeInterval = .infinity,

--- a/TestUtilities/Sources/Mocks/DatadogRUM/AccessibilityValuesMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogRUM/AccessibilityValuesMock.swift
@@ -64,7 +64,6 @@ extension AccessibilityInfo: AnyMockable, RandomMockable {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 public final class AccessibilityReaderMock: AccessibilityReading, AnyMockable, RandomMockable {
     public var state: AccessibilityInfo
 

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/FeatureFlagsMock.swift
@@ -18,9 +18,7 @@ extension SessionReplay.Configuration.FeatureFlags {
             .heatmaps: true,
         ]
 
-        if #available(iOS 13.0, tvOS 13.0, *) {
-            flags[.compositionTreeRecording] = true
-        }
+        flags[.compositionTreeRecording] = true
 
         return flags
     }

--- a/TestUtilities/Sources/Mocks/DatadogSessionReplay/ReflectionMocks.swift
+++ b/TestUtilities/Sources/Mocks/DatadogSessionReplay/ReflectionMocks.swift
@@ -31,7 +31,6 @@ extension StyledTextContentView: AnyMockable, RandomMockable {
 }
 
 // MARK: Color
-@available(iOS 13.0, tvOS 13.0, *)
 extension SwiftUI.Color._Resolved: AnyMockable, RandomMockable {
     public static func mockAny() -> Color._Resolved {
         return SwiftUI.Color._Resolved(
@@ -52,7 +51,6 @@ extension SwiftUI.Color._Resolved: AnyMockable, RandomMockable {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ResolvedPaint: AnyMockable, RandomMockable {
     public static func mockAny() -> ResolvedPaint {
         return ResolvedPaint(paint: .mockAny())
@@ -64,7 +62,6 @@ extension ResolvedPaint: AnyMockable, RandomMockable {
 }
 
 // MARK: GraphicsImage
-@available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage.Contents: Equatable {
     public static func == (lhs: GraphicsImage.Contents, rhs: GraphicsImage.Contents) -> Bool {
         switch (lhs, rhs) {
@@ -135,7 +132,6 @@ public struct MockCGImage: RandomMockable {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage: AnyMockable, RandomMockable {
     public static func mockAny() -> GraphicsImage {
         return GraphicsImage(
@@ -156,7 +152,6 @@ extension GraphicsImage: AnyMockable, RandomMockable {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage.Contents: AnyMockable, RandomMockable {
     public static func mockAny() -> GraphicsImage.Contents {
         return .cgImage(MockCGImage.mockRandom().cgImage)
@@ -167,7 +162,6 @@ extension GraphicsImage.Contents: AnyMockable, RandomMockable {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension SwiftUI.Image.Orientation: AnyMockable, RandomMockable {
     public static func mockAny() -> SwiftUI.Image.Orientation {
         return SwiftUI.Image.Orientation.up
@@ -179,7 +173,6 @@ extension SwiftUI.Image.Orientation: AnyMockable, RandomMockable {
 }
 
 // MARK: ImageRepresentable
-@available(iOS 13.0, tvOS 13.0, *)
 struct MockImageRepresentable: ImageRepresentable, AnyMockable, RandomMockable {
     private let cgImage: CGImage?
 

--- a/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/TestUtilities/Sources/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -639,7 +639,6 @@ extension URLSessionTaskMetrics {
         return URLSessionTaskMetrics()
     }
 
-    @available(iOS 13, *)
     public static func mockWith(
         taskInterval: DateInterval = .init(start: Date(), duration: 1),
         transactionMetrics: [URLSessionTaskTransactionMetrics] = []
@@ -657,7 +656,6 @@ extension URLSessionTaskTransactionMetrics {
     }
 
     /// Mocks `URLSessionTaskTransactionMetrics` by spreading out detailed values between `start` and `end`.
-    @available(iOS 13, *)
     public static func mockBySpreadingDetailsBetween(
         start: Date,
         end: Date,
@@ -700,7 +698,6 @@ extension URLSessionTaskTransactionMetrics {
         )
     }
 
-    @available(iOS 13, *)
     public static func mockWith(
         resourceFetchType: URLSessionTaskMetrics.ResourceFetchType = .networkLoad,
         fetchStartDate: Date? = nil,
@@ -750,7 +747,6 @@ private class URLSessionDataTaskMock: URLSessionDataTask, @unchecked Sendable {
     }
 }
 
-@available(iOS 13, *) // We can't rely on subclassing the `URLSessionTaskMetrics` prior to iOS 13.0
 private class URLSessionTaskMetricsMock: URLSessionTaskMetrics, @unchecked Sendable {
     private let _taskInterval: DateInterval
     override var taskInterval: DateInterval { _taskInterval }
@@ -764,7 +760,6 @@ private class URLSessionTaskMetricsMock: URLSessionTaskMetrics, @unchecked Senda
     }
 }
 
-@available(iOS 13, *) // We can't rely on subclassing the `URLSessionTaskTransactionMetrics` prior to iOS 13.0
 private class URLSessionTaskTransactionMetricsMock: URLSessionTaskTransactionMetrics, @unchecked Sendable {
     private let _resourceFetchType: URLSessionTaskMetrics.ResourceFetchType
     override var resourceFetchType: URLSessionTaskMetrics.ResourceFetchType { _resourceFetchType }

--- a/TestUtilities/Sources/Mocks/SystemFrameworks/UIKitMocks.swift
+++ b/TestUtilities/Sources/Mocks/SystemFrameworks/UIKitMocks.swift
@@ -326,9 +326,7 @@ extension UITextContentType: RandomMockable {
             .oneTimeCode,
         ]
 
-        if #available(iOS 15.0, tvOS 15.0, *) {
-            all.formUnion([.shipmentTrackingNumber, .flightNumber, .dateTime])
-        }
+        all.formUnion([.shipmentTrackingNumber, .flightNumber, .dateTime])
 
         return all
     }


### PR DESCRIPTION
### What and why?

Removes @available/#available checks that are now dead following the minimum deployment target bump in #3155 (iOS 15.0 / tvOS 15.0 / watchOS 9.0). Part of the RUM-16719 cleanup, split per module.

### How?

Deletes availability branches whose guarded platform versions are all ≤ the new floors, keeping only the code path that is now always available. No behavior change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs