### PR TITLE
[RUM-16719] Remove dead availability guards in DatadogCore

### DIFF
--- a/DatadogCore/Sources/Core/Context/NetworkConnectionInfoPublisher.swift
+++ b/DatadogCore/Sources/Core/Context/NetworkConnectionInfoPublisher.swift
@@ -59,12 +59,7 @@ extension NetworkConnectionInfo {
             supportsIPv4: path.supportsIPv4,
             supportsIPv6: path.supportsIPv6,
             isExpensive: path.isExpensive,
-            isConstrained: {
-                guard #available(iOS 13, tvOS 13, *) else {
-                    return nil
-                }
-                return path.isConstrained
-            }(),
+            isConstrained: path.isConstrained,
             linkQuality: {
                 #if compiler(>=6.2)
                 guard #available(iOS 26.0, tvOS 26.0, macOS 26.0, watchOS 26.0, visionOS 26.0, *) else {

--- a/DatadogCore/Sources/Core/Storage/Files/File.swift
+++ b/DatadogCore/Sources/Core/Storage/Files/File.swift
@@ -67,52 +67,15 @@ internal struct File: WritableFile, ReadableFile, FileProtocol, Equatable {
     /// Appends given data at the end of this file.
     func append(data: Data) throws {
         let fileHandle = try FileHandle(forWritingTo: url)
-
-        // NOTE: RUMM-669
-        // https://github.com/DataDog/dd-sdk-ios/issues/214
-        // https://en.wikipedia.org/wiki/Xcode#11.x_series
-        // compiler version needs to have iOS 13.4+ as base SDK
-        #if compiler(>=5.2)
-        /**
-         Even though the `fileHandle.seekToEnd()` should be available since iOS 13.0:
-         ```
-         @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-         public func seekToEnd() throws -> UInt64
-         ```
-         it crashes on iOS Simulators prior to iOS 13.4:
-         ```
-         Symbol not found: _$sSo12NSFileHandleC10FoundationE9seekToEnds6UInt64VyKF
-         ```
-         This is fixed in iOS 14/Xcode 12
-        */
-        if #available(iOS 13.4, tvOS 13.4, *) {
-            defer { try? fileHandle.close() }
-            try fileHandle.seekToEnd()
-            try fileHandle.write(contentsOf: data)
-        } else {
-            try legacyAppend(data, to: fileHandle)
-        }
-        #else
-        try legacyAppend(data, to: fileHandle)
-        #endif
+        defer { try? fileHandle.close() }
+        try fileHandle.seekToEnd()
+        try fileHandle.write(contentsOf: data)
     }
 
     func write(data: Data) throws {
         // The `.atomic` option writes data to an auxiliary file first and then replace the original
         // file with the auxiliary file when the write completes
         try data.write(to: url, options: .atomic)
-    }
-
-    private func legacyAppend(_ data: Data, to fileHandle: FileHandle) throws {
-        defer {
-            try? objc_rethrow {
-                fileHandle.closeFile()
-            }
-        }
-        try objc_rethrow {
-            fileHandle.seekToEndOfFile()
-            fileHandle.write(data)
-        }
     }
 
     func stream() throws -> InputStream {

--- a/DatadogCore/Sources/Core/Upload/URLSessionClient.swift
+++ b/DatadogCore/Sources/Core/Upload/URLSessionClient.swift
@@ -39,9 +39,7 @@ internal class URLSessionClient: HTTPClient {
         let task = session.dataTask(with: request) { data, response, error in
             completion(httpClientResult(for: (data, response, error)))
         }
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, *) {
-            task.delegate = delegate
-        }
+        task.delegate = delegate
         task.resume()
     }
 }

--- a/DatadogCore/Tests/Datadog/Core/Utils/JSONEncoderTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Utils/JSONEncoderTests.swift
@@ -26,10 +26,6 @@ class JSONEncoderTests: XCTestCase {
             EncodingContainer(URL(string: "https://example.com/foo")!)
         )
 
-        if #available(iOS 13.0, OSX 10.15, *) {
-            XCTAssertEqual(encodedURL.utf8String, #"{"value":"https://example.com/foo"}"#)
-        } else {
-            XCTAssertEqual(encodedURL.utf8String, #"{"value":"https:\/\/example.com\/foo"}"#)
-        }
+        XCTAssertEqual(encodedURL.utf8String, #"{"value":"https://example.com/foo"}"#)
     }
 }

--- a/DatadogCore/Tests/Datadog/LoggerTests.swift
+++ b/DatadogCore/Tests/Datadog/LoggerTests.swift
@@ -151,9 +151,7 @@ class LoggerTests: XCTestCase {
         logMatcher.assertValue(forKeyPath: "network.client.is_expensive", isTypeOf: Bool.self)
         logMatcher.assertValue(forKeyPath: "network.client.supports_ipv4", isTypeOf: Bool.self)
         logMatcher.assertValue(forKeyPath: "network.client.supports_ipv6", isTypeOf: Bool.self)
-        if #available(iOS 13.0, *) {
-            logMatcher.assertValue(forKeyPath: "network.client.is_constrained", isTypeOf: Bool.self)
-        }
+        logMatcher.assertValue(forKeyPath: "network.client.is_constrained", isTypeOf: Bool.self)
     }
 
     // MARK: - Sending Customized Logs

--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
@@ -171,10 +171,6 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingNativeResourceWithRequestWithMetrics() throws {
-        guard #available(iOS 13, *) else {
-            return // `URLSessionTaskMetrics` mocking doesn't work prior to iOS 13.0
-        }
-
         RUM.enable(with: config, in: core)
 
         let monitor = RUMMonitor.shared(in: core)

--- a/DatadogCore/Tests/Datadog/RUM/UIKitRUMViewsPredicateTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/UIKitRUMViewsPredicateTests.swift
@@ -57,9 +57,6 @@ class UIKitRUMViewsPredicateTests: XCTestCase {
 
 #if canImport(SwiftUI)
     func testGivenDefaultPredicate_whenAskingSwiftUIViewController_itReturnsNoView() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
         // Given
         let predicate = DefaultUIKitRUMViewsPredicate()
 

--- a/DatadogCore/Tests/Datadog/TracerTests.swift
+++ b/DatadogCore/Tests/Datadog/TracerTests.swift
@@ -135,9 +135,7 @@ class TracerTests: XCTestCase {
         XCTAssertNoThrow(try spanMatcher.meta.mobileNetworkCarrierRadioTechnology())
         XCTAssertNoThrow(try spanMatcher.meta.networkConnectionSupportsIPv4())
         XCTAssertNoThrow(try spanMatcher.meta.networkConnectionSupportsIPv6())
-        if #available(iOS 13.0, *) {
-            XCTAssertNoThrow(try spanMatcher.meta.networkConnectionIsConstrained())
-        }
+        XCTAssertNoThrow(try spanMatcher.meta.networkConnectionIsConstrained())
     }
 
     func testSendingSpanWithGlobalTags() throws {

--- a/DatadogCore/Tests/Datadog/Utils/SwiftUIExtensionsTests.swift
+++ b/DatadogCore/Tests/Datadog/Utils/SwiftUIExtensionsTests.swift
@@ -15,26 +15,17 @@ import SwiftUI
 
 class CustomViewController: UIViewController {}
 
-@available(iOS 13, tvOS 13, *)
 final class TestView: View {
     var body = EmptyView()
 }
 
 class SwiftUIExtensionsTests: XCTestCase {
     func testSwiftUIViewTypeDescription() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
-
         let view = TestView().cornerRadius(8)
         XCTAssertEqual(view.typeDescription, "ModifiedContent<TestView, _ClipEffect<RoundedRectangle>>")
     }
 
     func testBundleIsSwiftUI() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
-
         // Given
         let someSwiftUITypes: [AnyClass] = [
             UIHostingController<AnyView>.self // The only class in SwiftUI

--- a/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMMonitorTests.swift
@@ -384,10 +384,6 @@ class DDRUMMonitorTests: XCTestCase {
     }
 
     func testSendingResourceEvents() throws {
-        guard #available(iOS 13, *) else {
-            return // `URLSessionTaskMetrics` mocking doesn't work prior to iOS 13.0
-        }
-
         RUM.enable(with: config)
         let objcRUMMonitor = objc_RUMMonitor.shared()
 

--- a/DatadogCore/Tests/Objc/DDUIKitRUMActionsPredicateTests.swift
+++ b/DatadogCore/Tests/Objc/DDUIKitRUMActionsPredicateTests.swift
@@ -50,9 +50,6 @@ class DDUIKitRUMActionsPredicateTests: XCTestCase {
 
 #if canImport(SwiftUI)
     func testGivenDefaultPredicate_whenAskingSwiftUIView_itReturnsAction() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
         // Given
         let predicate = objc_DefaultUIKitRUMActionsPredicate()
 

--- a/DatadogCore/Tests/Objc/DDUIKitRUMViewsPredicateTests.swift
+++ b/DatadogCore/Tests/Objc/DDUIKitRUMViewsPredicateTests.swift
@@ -56,9 +56,6 @@ class DDUIKitRUMViewsPredicateTests: XCTestCase {
 
 #if canImport(SwiftUI)
     func testGivenDefaultPredicate_whenAskingSwiftUIViewController_itReturnsNoView() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
         // Given
         let predicate = objc_DefaultUIKitRUMViewsPredicate()
 


### PR DESCRIPTION
### What and why?

Removes @available/#available checks that are now dead following the minimum deployment target bump in #3155 (iOS 15.0 / tvOS 15.0 / watchOS 9.0). Part of the RUM-16719 cleanup, split per module.

### How?

Deletes availability branches whose guarded platform versions are all ≤ the new floors, keeping only the code path that is now always available. No behavior change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs