### PR TITLE
[RUM-16719] Remove dead availability guards in DatadogInternal

### DIFF
--- a/DatadogInternal/Sources/Concurrency/Threading.swift
+++ b/DatadogInternal/Sources/Concurrency/Threading.swift
@@ -12,20 +12,8 @@ import Foundation
 /// - Throws: Whatever the closure itself might throw.
 public func runOnMainThreadSync<T>(_ block: @MainActor () throws -> T) rethrows -> T {
     if Thread.isMainThread {
-        if #available(iOS 13.0, tvOS 13.0, *) {
-            return try MainActor.assumeIsolated {
-                return try block()
-            }
-        } else {
-            // Does the same as MainActor.assumeIsolated on iOS 12.
-            // This erases the @MainActor annotation from `block` and calls it synchronously.
-            // Equivalent in intent to `MainActor.assumeIsolated { try block() }`,
-            // but unlike `assumeIsolated`, this performs no runtime check that we are
-            // actually on the MainActor, so it is only safe if the caller guarantees that.
-            return try withoutActuallyEscaping(block) { block in
-                let rawBlock = unsafeBitCast(block, to: (() throws -> T).self)
-                return try rawBlock()
-            }
+        return try MainActor.assumeIsolated {
+            return try block()
         }
     } else {
         return try DispatchQueue.main.sync(execute: block)

--- a/DatadogInternal/Sources/DD.swift
+++ b/DatadogInternal/Sources/DD.swift
@@ -38,15 +38,11 @@ import OSLog
 /// Function printing `String` content to console.
 nonisolated(unsafe) public var consolePrint: @Sendable (String, CoreLoggerLevel) -> Void = { message, level in
     #if canImport(OSLog)
-    if #available(iOS 14.0, tvOS 14.0, *) {
-        switch level {
-        case .debug: Logger.datadog.debug("\(message, privacy: .private)")
-        case .warn: Logger.datadog.warning("\(message, privacy: .private)")
-        case .error: Logger.datadog.critical("\(message, privacy: .private)")
-        case .critical: Logger.datadog.fault("\(message, privacy: .private)")
-        }
-    } else {
-        print(message)
+    switch level {
+    case .debug: Logger.datadog.debug("\(message, privacy: .private)")
+    case .warn: Logger.datadog.warning("\(message, privacy: .private)")
+    case .error: Logger.datadog.critical("\(message, privacy: .private)")
+    case .critical: Logger.datadog.fault("\(message, privacy: .private)")
     }
     #else
     print(message)
@@ -54,7 +50,6 @@ nonisolated(unsafe) public var consolePrint: @Sendable (String, CoreLoggerLevel)
 }
 
 #if canImport(OSLog)
-@available(iOS 14.0, tvOS 14.0, *)
 extension Logger {
     static let datadog = Logger(subsystem: "dd-sdk-ios", category: "DatadogInternal")
 }

--- a/DatadogInternal/Sources/Models/SessionReplay/UIView+SessionReplaySlotID.swift
+++ b/DatadogInternal/Sources/Models/SessionReplay/UIView+SessionReplaySlotID.swift
@@ -23,7 +23,6 @@ public extension DatadogExtension where ExtendedType: UIView {
     /// Sets the Session Replay slot ID for this view.
     ///
     /// Changing the slot changes the recorded view hierarchy, so this triggers a new snapshot.
-    @available(iOS 13.0, tvOS 13.0, *)
     @MainActor
     func setSessionReplaySlotID(_ slotID: String?) {
         guard slotID != sessionReplaySlotID else {

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -164,9 +164,7 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
                 interceptDidFinishCollecting: { [weak self] session, task, metrics in
                     self?.task(task, didFinishCollecting: metrics)
 
-                    if #available(iOS 15, tvOS 15, *), !task.dd.hasCompletion {
-                        // iOS 15 and above, didCompleteWithError is not called hence we use task state to detect task completion
-                        // while prior to iOS 15, task state doesn't change to completed hence we use didCompleteWithError to detect task completion
+                    if !task.dd.hasCompletion {
                         self?.task(task, didCompleteWithError: task.error)
                     }
                 },

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionSwizzler.swift
@@ -29,16 +29,11 @@ internal final class URLSessionSwizzler {
             didReceive: didReceive
         )
 
-        if #available(iOS 13.0, *) {
-            // Prior to iOS 13.0 the `URLSession.dataTask(with:url, completionHandler:handler)` makes an internal
-            // call to `URLSession.dataTask(with:request, completionHandler:handler)`. To avoid duplicated call
-            // to the callback, we don't apply below swizzling prior to iOS 13.
-            dataTaskURLCompletionHandler = try DataTaskURLCompletionHandler.build()
-            dataTaskURLCompletionHandler?.swizzle(
-                interceptCompletion: interceptCompletionHandler,
-                didReceive: didReceive
-            )
-        }
+        dataTaskURLCompletionHandler = try DataTaskURLCompletionHandler.build()
+        dataTaskURLCompletionHandler?.swizzle(
+            interceptCompletion: interceptCompletionHandler,
+            didReceive: didReceive
+        )
     }
 
     /// Unswizzles all.

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTask+Tracking.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTask+Tracking.swift
@@ -21,7 +21,7 @@ extension DatadogExtension where ExtendedType: URLSessionTask {
 
     /// Returns the delegate instance the task is reporting to.
     var delegate: URLSessionDelegate? {
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, *), let delegate = type.delegate {
+        if let delegate = type.delegate {
             return delegate
         }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionTaskInterception.swift
@@ -375,16 +375,14 @@ extension ResourceMetrics {
                 download = DateInterval(start: downloadStart, end: downloadEnd)
             }
 
-            if #available(iOS 13.0, tvOS 13, *) {
-                let responseEncoded = mainTransaction.countOfResponseBodyBytesReceived
-                let responseDecoded = mainTransaction.countOfResponseBodyBytesAfterDecoding
+            let responseEncoded = mainTransaction.countOfResponseBodyBytesReceived
+            let responseDecoded = mainTransaction.countOfResponseBodyBytesAfterDecoding
 
-                responseBodySize = (encoded: responseEncoded, decoded: responseDecoded)
+            responseBodySize = (encoded: responseEncoded, decoded: responseDecoded)
 
-                let requestEncoded = mainTransaction.countOfRequestBodyBytesSent
-                let requestDecoded = mainTransaction.countOfRequestBodyBytesBeforeEncoding
-                requestBodySize = (encoded: requestEncoded, decoded: requestDecoded)
-            }
+            let requestEncoded = mainTransaction.countOfRequestBodyBytesSent
+            let requestDecoded = mainTransaction.countOfRequestBodyBytesBeforeEncoding
+            requestBodySize = (encoded: requestEncoded, decoded: requestDecoded)
         }
 
         self.init(

--- a/DatadogInternal/Sources/Upload/DefaultJSONEncoder.swift
+++ b/DatadogInternal/Sources/Upload/DefaultJSONEncoder.swift
@@ -16,9 +16,7 @@ extension DatadogExtension where ExtendedType == JSONEncoder {
             let formatted = iso8601DateFormatter.string(from: date)
             try container.encode(formatted)
         }
-        if #available(iOS 13, tvOS 13, *) {
-            encoder.outputFormatting = [.withoutEscapingSlashes]
-        }
+        encoder.outputFormatting = [.withoutEscapingSlashes]
         return encoder
     }
 }

--- a/DatadogInternal/Tests/Codable/AnyCodableTests.swift
+++ b/DatadogInternal/Tests/Codable/AnyCodableTests.swift
@@ -197,8 +197,7 @@ class AnyCodableTests: XCTestCase {
             return encodedCodableValue.utf8String
         }
 
-        if #available(iOS 13.0, *) {
-            XCTAssertEqual(try json(for: true), "true")
+        XCTAssertEqual(try json(for: true), "true")
             XCTAssertEqual(try json(for: false), "false")
             XCTAssertEqual(try json(for: 123), "123")
             XCTAssertEqual(try json(for: -123), "-123")
@@ -217,27 +216,6 @@ class AnyCodableTests: XCTestCase {
             XCTAssertEqual(try json(for: Optional<URL>.none), "null")
             XCTAssertEqual(try json(for: Optional<Foo>.none), "null")
             // swiftlint:enable syntactic_sugar
-        } else {
-            XCTAssertEqual(try json(for: EncodingContainer(true)), #"{"value":true}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(false)), #"{"value":false}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(123)), #"{"value":123}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(-123)), #"{"value":-123}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(123.45)), #"{"value":123.45}"#)
-            XCTAssertEqual(try json(for: EncodingContainer("string")), #"{"value":"string"}"#)
-
-            let url = URL(string: "https://example.com/image.png")!
-            XCTAssertEqual(try json(for: EncodingContainer(url)), #"{"value":"https:\/\/example.com\/image.png"}"#)
-
-            // swiftlint:disable syntactic_sugar
-            XCTAssertEqual(try json(for: EncodingContainer(Optional<Bool>.none)), #"{"value":null}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(Optional<UInt64>.none)), #"{"value":null}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(Optional<Int>.none)), #"{"value":null}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(Optional<Double>.none)), #"{"value":null}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(Optional<String>.none)), #"{"value":null}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(Optional<URL>.none)), #"{"value":null}"#)
-            XCTAssertEqual(try json(for: EncodingContainer(Optional<Foo>.none)), #"{"value":null}"#)
-            // swiftlint:enable syntactic_sugar
-        }
 
         XCTAssertEqual(try json(for: [true, false, true, false]), "[true,false,true,false]")
         XCTAssertEqual(try json(for: [1, 2, 3, 4, 5]), "[1,2,3,4,5]")

--- a/DatadogInternal/Tests/Heatmaps/HeatmapIdentifierTests.swift
+++ b/DatadogInternal/Tests/Heatmaps/HeatmapIdentifierTests.swift
@@ -10,7 +10,6 @@ import DatadogInternal
 
 @Suite(.datadogTesting)
 struct HeatmapIdentifierTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Produces a 32 lowercase hex character string")
     func identifierIs32LowercaseHexCharacters() {
         let identifier = HeatmapIdentifier(
@@ -24,7 +23,6 @@ struct HeatmapIdentifierTests {
         #expect(identifier.rawValue.allSatisfy { $0.isHexDigit })
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Same inputs produce the same identifier")
     func sameInputsProduceSameIdentifier() {
         let a = HeatmapIdentifier(
@@ -41,7 +39,6 @@ struct HeatmapIdentifierTests {
         #expect(a == b)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Canonical path is hashed correctly")
     func canonicalPathProducesExpectedHash() {
         let identifier = HeatmapIdentifier(

--- a/DatadogInternal/Tests/Models/UIViewSessionReplaySlotIDTests.swift
+++ b/DatadogInternal/Tests/Models/UIViewSessionReplaySlotIDTests.swift
@@ -15,7 +15,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct UIViewSessionReplaySlotIDTests {
-    @available(iOS 13.0, *)
     @Test
     func slotIDIsNilByDefault() {
         // given
@@ -28,7 +27,6 @@ struct UIViewSessionReplaySlotIDTests {
         #expect(slotID == nil)
     }
 
-    @available(iOS 13.0, *)
     @Test
     func slotIDIsStoredPerView() {
         // given
@@ -43,7 +41,6 @@ struct UIViewSessionReplaySlotIDTests {
         #expect(otherView.dd.sessionReplaySlotID == nil)
     }
 
-    @available(iOS 13.0, *)
     @Test
     func settingSlotIDToNilClearsIt() {
         // given
@@ -57,7 +54,6 @@ struct UIViewSessionReplaySlotIDTests {
         #expect(view.dd.sessionReplaySlotID == nil)
     }
 
-    @available(iOS 13.0, *)
     @Test
     func changingSlotIDMarksTheViewAsNeedingLayout() {
         // given
@@ -72,7 +68,6 @@ struct UIViewSessionReplaySlotIDTests {
         #expect(view.setNeedsLayoutCount == 1)
     }
 
-    @available(iOS 13.0, *)
     @Test
     func settingSameSlotIDDoesNotMarkTheViewAsNeedingLayout() {
         // given
@@ -88,7 +83,6 @@ struct UIViewSessionReplaySlotIDTests {
         #expect(view.setNeedsLayoutCount == 0)
     }
 
-    @available(iOS 13.0, *)
     @Test
     func clearingSlotIDMarksTheViewAsNeedingLayout() {
         // given

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -480,7 +480,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     func testRegisteredDelegate_capturesMetricsForCombineDataTask() throws {
         /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
         guard #available(iOS 16, tvOS 16, *) else {
@@ -690,7 +689,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.endDate, "Should capture approximate end date")
     }
 
-    @available(iOS 13.0, *)
     func testAutomaticMode_tracksAsyncAwaitTasks() async throws {
         /// Testing only 16.0 or above because 15.0 has ThreadSanitizer issues with async APIs
         guard #available(iOS 16, tvOS 16, *) else {
@@ -795,7 +793,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.endDate, "Should capture approximate end date")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     func testAutomaticMode_tracksCombineTasks() throws {
         guard #available(iOS 16, tvOS 16, *) else {
             return
@@ -1059,11 +1056,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testGivenBothModesEnabled_whenPerTaskDelegate_itUsesCorrectTrackingMode() throws {
-        // pre iOS 15 cannot set delegate per task
-        guard #available(iOS 15, tvOS 15, watchOS 8, *) else {
-            return
-        }
-
         let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
         notifyInterceptionDidComplete.expectedFulfillmentCount = 2
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
@@ -1154,7 +1146,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    @available(iOS 15, tvOS 15, watchOS 8, *)
     func testGivenBothModesEnabled_whenRegisteredDelegateWithCompletionHandler_itCapturesMetricsAndData() throws {
         let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
@@ -1190,7 +1181,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    @available(iOS 15, tvOS 15, watchOS 8, *)
     func testGivenBothModesEnabled_whenRegisteredDelegateWithoutCompletionHandler_itCapturesMetricsAndData() throws {
         let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
@@ -1226,7 +1216,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.completion, "Should capture completion")
     }
 
-    @available(iOS 15, tvOS 15, watchOS 8, *)
     func testGivenBothModesEnabled_whenUnregisteredDelegateWithCompletionHandler_itUsesAutomaticMode() throws {
         let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
@@ -1264,7 +1253,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.endDate, "Should capture approximate end date")
     }
 
-    @available(iOS 15, tvOS 15, watchOS 8, *)
     func testGivenBothModesEnabled_whenUnregisteredDelegateWithoutCompletionHandler_itUsesAutomaticMode() throws {
         let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
@@ -1302,7 +1290,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.endDate, "Should capture approximate end date")
     }
 
-    @available(iOS 15, tvOS 15, *)
     func testGivenBothModesEnabled_whenNoDelegateWithCompletionHandler_itUsesAutomaticMode() throws {
         let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
@@ -1337,7 +1324,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertNotNil(interception.endDate, "Should capture approximate end date")
     }
 
-    @available(iOS 15, tvOS 15, *)
     func testGivenBothModesEnabled_whenNoDelegateWithoutCompletionHandler_itUsesAutomaticMode() throws {
         let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
@@ -1422,11 +1408,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testGivenBothModesEnabled_whenUsingDownloadTask_itUsesCorrectTrackingMode() throws {
-        // pre iOS 15 cannot set delegate per task
-        guard #available(iOS 15, tvOS 15, watchOS 8, *) else {
-            return
-        }
-
         let notifyInterceptionDidComplete = expectation(description: "Notify interception did complete")
         notifyInterceptionDidComplete.expectedFulfillmentCount = 2
         handler.onInterceptionDidComplete = { _ in notifyInterceptionDidComplete.fulfill() }
@@ -2028,7 +2009,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertTrue(task.isSupportedForInstrumentation)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     func testIsSupportedForInstrumentation_returnsTrueForWebSocketTask() {
         let session = URLSession(configuration: .ephemeral)
         let task = session.webSocketTask(with: URL(string: "wss://example.com")!)
@@ -2061,7 +2041,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     // MARK: - Crash regression: resume() on various task types
 
-    @available(iOS 13.0, tvOS 13.0, *)
     func testWebSocketTask_resumeDoesNotCrash() throws {
         // Regression: verify that resuming a WebSocketTask with the swizzle installed doesn't crash.
         // The crash in interceptResume is synchronous, so no real connection is needed — we cancel immediately.
@@ -2352,11 +2331,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     // MARK: - Subclass Delegate Handling
 
     func testGivenBothModesEnabled_whenUsingDelegateSubclass_itOnlyProcessesWithRegisteredDelegate() throws {
-        // pre iOS 15 cannot set delegate per task
-        guard #available(iOS 15, tvOS 15, watchOS 8, *) else {
-            return
-        }
-
         let (server, notifyInterceptionDidStart, notifyInterceptionDidComplete) = setupInterceptionTest()
 
         // Given - Register BASE delegate class

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskInterceptionTests.swift
@@ -210,10 +210,6 @@ class ResourceMetricsTests: XCTestCase {
     }
 
     func testWhenTaskMakesSingleFetchFromNetwork_thenAllMetricsExceptRedirectionAreCollected() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
-
         let taskInterval = DateInterval(
             start: .mockDecember15th2019At10AMUTC(),
             end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 5)
@@ -253,10 +249,6 @@ class ResourceMetricsTests: XCTestCase {
     }
 
     func testWhenTaskMakesMultipleFetchesFromNetwork_thenAllMetricsAreCollected() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
-
         let taskInterval = DateInterval(
             start: .mockDecember15th2019At10AMUTC(),
             end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 10)
@@ -317,10 +309,6 @@ class ResourceMetricsTests: XCTestCase {
     }
 
     func testWhenTaskMakesFetchFromLocalCache_thenOnlyFetchMetricIsCollected() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
-
         let taskInterval = DateInterval(
             start: .mockDecember15th2019At10AMUTC(),
             end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 5)
@@ -377,10 +365,6 @@ class ResourceMetricsTests: XCTestCase {
     }
 
     func testWhenTaskFetchTypeVaries_thenLocalCacheHitReflectsOnlyKnownSignals() {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
-
         // `.unknown` is documented by Apple as "the fetch manner was not determined" -
         // it must not be reported as a measured cache miss.
         let cases: [(fetchType: URLSessionTaskMetrics.ResourceFetchType, expected: Bool?)] = [

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionTaskStateSwizzlerTests.swift
@@ -136,7 +136,6 @@ class URLSessionTaskStateSwizzlerTests: XCTestCase {
         XCTAssertEqual(interceptionCount, countAfterTask1, "Task2 should not be intercepted after unswizzle")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     func testSwizzling_setState_interceptsAsyncAwaitTasks() async throws {
         let completionExpectation = self.expectation(description: "setState for async/await")
         completionExpectation.assertForOverFulfill = false // Allow multiple setState calls with same state


### PR DESCRIPTION
### What and why?

Removes @available/#available checks that are now dead following the minimum deployment target bump in #3155 (iOS 15.0 / tvOS 15.0 / watchOS 9.0). Part of the RUM-16719 cleanup, split per module.

### How?

Deletes availability branches whose guarded platform versions are all ≤ the new floors, keeping only the code path that is now always available. No behavior change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs