### PR TITLE
[RUM-16719] Remove dead availability guards in DatadogRUM

### DIFF
--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -93,7 +93,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         let firstFrameReader = FirstFrameReader(dateProvider: configuration.dateProvider, mediaTimeProvider: configuration.mediaTimeProvider)
 
         #if !os(watchOS)
-        if #available(iOS 13.0, tvOS 13.0, *), configuration.collectAccessibility {
+        if configuration.collectAccessibility {
              accessibilityReader = AccessibilityReader(notificationCenter: configuration.notificationCenter)
         }
 

--- a/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -19,7 +19,6 @@ import DatadogInternal
 /// - If tracking taps inside a `List` is required, consider logging actions manually via `RUMMonitor.shared().addAction(...)`
 ///   instead of using this modifier.
 /// - We consider this a bug in SwiftUI and have reported it to Apple: [FB16488816](https://openradar.appspot.com/FB16488816).
-@available(iOS 13, watchOS 7, *)
 internal struct RUMTapActionModifier: SwiftUI.ViewModifier {
     /// The SDK core instance.
     weak var core: DatadogCoreProtocol?
@@ -49,7 +48,6 @@ internal struct RUMTapActionModifier: SwiftUI.ViewModifier {
     }
 }
 
-@available(iOS 13, watchOS 7, *)
 public extension SwiftUI.View {
     /// Monitor tap actions on this view with Datadog RUM. An Action event will be logged after the required number of taps.
     ///

--- a/DatadogRUM/Sources/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
+++ b/DatadogRUM/Sources/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
@@ -10,7 +10,6 @@ import DatadogInternal
 
 /// `SwiftUI.ViewModifier` which notifes RUM instrumentation when modified view appears and disappears.
 /// It makes an entry point to RUM views instrumentation in SwiftUI.
-@available(iOS 13, tvOS 13, watchOS 7, *)
 internal struct RUMViewModifier: SwiftUI.ViewModifier {
     /// Datadog RUM instrumentation instance
     let instrumentation: RUMInstrumentation?
@@ -45,7 +44,6 @@ internal struct RUMViewModifier: SwiftUI.ViewModifier {
     }
 }
 
-@available(iOS 13, tvOS 13, watchOS 7, *)
 public extension SwiftUI.View {
     /// Monitor this view with Datadog RUM. A start and stop events will be logged when this view appears
     /// and disappears.

--- a/DatadogRUM/Sources/RUMContext/AccessibilityReader.swift
+++ b/DatadogRUM/Sources/RUMContext/AccessibilityReader.swift
@@ -14,7 +14,6 @@ internal protocol AccessibilityReading {
 }
 
 #if !os(watchOS)
-@available(iOS 13.0, tvOS 13.0, *)
 internal final class AccessibilityReader: AccessibilityReading {
     @ReadWriteLock
     private(set) var state: AccessibilityInfo
@@ -40,25 +39,23 @@ internal final class AccessibilityReader: AccessibilityReading {
     }
 
     private func startObserving() {
-        if #available(iOS 14.0, tvOS 14.0, *) {
-            let buttonShapesObserver = notificationCenter.addObserver(
-                forName: UIAccessibility.buttonShapesEnabledStatusDidChangeNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] _ in
-                self?.updateState()
-            }
-            observers.append(buttonShapesObserver)
-
-            let crossFadeTransitionsObserver = notificationCenter.addObserver(
-                forName: UIAccessibility.prefersCrossFadeTransitionsStatusDidChange,
-                object: nil,
-                queue: .main
-            ) { [weak self] _ in
-                self?.updateState()
-            }
-            observers.append(crossFadeTransitionsObserver)
+        let buttonShapesObserver = notificationCenter.addObserver(
+            forName: UIAccessibility.buttonShapesEnabledStatusDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.updateState()
         }
+        observers.append(buttonShapesObserver)
+
+        let crossFadeTransitionsObserver = notificationCenter.addObserver(
+            forName: UIAccessibility.prefersCrossFadeTransitionsStatusDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.updateState()
+        }
+        observers.append(crossFadeTransitionsObserver)
 
         let videoAutoplayObserver = notificationCenter.addObserver(
             forName: UIAccessibility.videoAutoplayStatusDidChangeNotification,
@@ -257,10 +254,8 @@ internal final class AccessibilityReader: AccessibilityReading {
         state.speakSelectionEnabled = UIAccessibility.isSpeakSelectionEnabled
         state.rtlEnabled = UIApplication.dd.managedShared?.userInterfaceLayoutDirection == .rightToLeft
 
-        if #available(iOS 14.0, tvOS 14.0, *) {
-            state.buttonShapesEnabled = UIAccessibility.buttonShapesEnabled
-            state.reducedAnimationsEnabled = UIAccessibility.prefersCrossFadeTransitions
-        }
+        state.buttonShapesEnabled = UIAccessibility.buttonShapesEnabled
+        state.reducedAnimationsEnabled = UIAccessibility.prefersCrossFadeTransitions
 
         return state
     }

--- a/DatadogRUM/Sources/Utils/SwiftUIExtensions.swift
+++ b/DatadogRUM/Sources/Utils/SwiftUIExtensions.swift
@@ -11,7 +11,6 @@ import SwiftUI
 #endif
 
 #if canImport(SwiftUI)
-@available(iOS 13, tvOS 13, *)
 internal extension SwiftUI.View {
     /// The Type descriptionof this view.
     var typeDescription: String {

--- a/DatadogRUM/Tests/Heatmaps/HeatmapIdentifierStoreTests.swift
+++ b/DatadogRUM/Tests/Heatmaps/HeatmapIdentifierStoreTests.swift
@@ -15,7 +15,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct HeatmapIdentifierStoreTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test
     func setHeatmapIdentifiersReplacesCurrentSnapshot() {
         // given

--- a/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
@@ -254,12 +254,7 @@ class RUMActionsHandlerTests: XCTestCase {
         let handler = touchHandler()
         let view = UIControl().attached(to: mockAppWindow)
 
-        let ignoredTouchPhases: [UITouch.Phase]
-        if #available(iOS 13.4, tvOS 13.4, *) {
-            ignoredTouchPhases = [.began, .moved, .stationary, .cancelled, .regionEntered, .regionMoved, .regionExited]
-        } else {
-            ignoredTouchPhases = [.began, .moved, .stationary, .cancelled]
-        }
+        let ignoredTouchPhases: [UITouch.Phase] = [.began, .moved, .stationary, .cancelled, .regionEntered, .regionMoved, .regionExited]
 
         ignoredTouchPhases.forEach { touchPhase in
             // When

--- a/DatadogRUM/Tests/Instrumentation/Views/SwiftUIViewNameExtractorTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Views/SwiftUIViewNameExtractorTests.swift
@@ -103,7 +103,6 @@ class SwiftUIViewNameExtractorTests: XCTestCase {
     }
 
     // MARK: - Controller Detection Tests
-    @available(iOS 13.0, tvOS 13.0, *)
     func testDetectControllerType() {
         // Define test cases with controller, class name and expected controller type
         let testCases: [(String, ControllerType)] = [
@@ -154,10 +153,8 @@ class SwiftUIViewNameExtractorTests: XCTestCase {
         XCTAssertNil(extractor.extractName(from: pageViewController))
         XCTAssertNil(extractor.extractName(from: splitViewController))
 
-        if #available(iOS 13.0, tvOS 13.0, *) {
-            let hostingController = UIHostingController(rootView: EmptyView())
-            XCTAssertNotNil(hostingController)
-        }
+        let hostingController = UIHostingController(rootView: EmptyView())
+        XCTAssertNotNil(hostingController)
     }
 }
 

--- a/DatadogRUM/Tests/Integrations/SwiftUIViewNameExtractorIntegrationTests.swift
+++ b/DatadogRUM/Tests/Integrations/SwiftUIViewNameExtractorIntegrationTests.swift
@@ -9,7 +9,6 @@ import SwiftUI
 @testable import DatadogRUM
 @testable import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 class SwiftUIViewNameExtractorIntegrationTests: XCTestCase {
     // MARK: SwiftUIViewPath Tests
 

--- a/DatadogRUM/Tests/RUMContext/AccessibilityReaderTests.swift
+++ b/DatadogRUM/Tests/RUMContext/AccessibilityReaderTests.swift
@@ -10,7 +10,6 @@
 @testable import TestUtilities
 import XCTest
 
-@available(iOS 13.0, tvOS 13.0, *)
 final class AccessibilityReaderTests: XCTestCase {
     @MainActor
     func testInitialStateIsPopulated() {
@@ -42,13 +41,8 @@ final class AccessibilityReaderTests: XCTestCase {
             XCTAssertNotNil(state.speakSelectionEnabled)
             XCTAssertNotNil(state.rtlEnabled)
 
-            if #available(iOS 14.0, tvOS 14.0, *) {
-                XCTAssertNotNil(state.buttonShapesEnabled)
-                XCTAssertNotNil(state.reducedAnimationsEnabled)
-            } else {
-                XCTAssertNil(state.buttonShapesEnabled)
-                XCTAssertNil(state.reducedAnimationsEnabled)
-            }
+            XCTAssertNotNil(state.buttonShapesEnabled)
+            XCTAssertNotNil(state.reducedAnimationsEnabled)
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1.0)
@@ -83,7 +77,6 @@ final class AccessibilityReaderTests: XCTestCase {
         XCTAssertTrue(observerNames.contains(UIAccessibility.onOffSwitchLabelsDidChangeNotification))
     }
 
-    @available(iOS 14.0, tvOS 14.0, *)
     func testRegistersIOS14Observers() {
         // Given
         let mockNotificationCenter = MockNotificationCenter()

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1031,10 +1031,6 @@ class RUMResourceScopeTests: XCTestCase {
     }
 
     func testGivenStartedResource_whenResourceReceivesMetricsWithRequestAndResponseBodySizes_itAggregatesThemInSentResourceEvent() throws {
-        guard #available(iOS 13, tvOS 13, *) else {
-            return
-        }
-
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -4316,7 +4316,6 @@ class RUMViewScopeTests: XCTestCase {
     }
 
     // MARK: - View Attributes
-    @available(iOS 13.0, tvOS 13.0, *)
     @MainActor
     func testAccessibilityAttributesInViewEvents() throws {
         // Given

--- a/DatadogRUM/Tests/Utils/UIKitExtensionsTests.swift
+++ b/DatadogRUM/Tests/Utils/UIKitExtensionsTests.swift
@@ -36,7 +36,6 @@ struct UIKitExtensionsTests {
         self.mockAppWindow = UIWindow(frame: .zero)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Tests UIKit alerts and action sheets, all button styles.", arguments: 1...5, 0...2)
     @MainActor
     func expectedControlTypesInAlerts(numberOfActionButtons: Int, numberOfTextFields: Int) throws {
@@ -91,7 +90,6 @@ struct UIKitExtensionsTests {
     }
 
     /// Obtains the available button roles, based on both the compile time and run time version checks.
-    @available(iOS 15.0, tvOS 15.0, *)
     private static var buttonRoles: [ButtonRole?] {
         // We need to use both compile time and runtime checks for this,
         // to make sure we can build on Xcode <=16 (compile time check)
@@ -132,7 +130,6 @@ struct UIKitExtensionsTests {
         #endif
     }
 
-    @available(iOS 15.0, tvOS 15.0, *)
     @Test("Test SwiftUI alerts, all button roles.", arguments: 1...5, 0...2)
     @MainActor
     func expectedControlTypesInAlertsSwiftUI(numberOfActionButtons: Int, numberOfTextFields: Int) throws {
@@ -182,7 +179,6 @@ struct UIKitExtensionsTests {
         #endif
     }
 
-    @available(iOS 15.0, tvOS 15.0, *)
     @Test("Test SwiftUI confirmation dialogs, all button roles.", arguments: 1...5)
     @MainActor
     func expectedControlTypesInConfirmationDialogsSwiftUI(numberOfActionButtons: Int) throws {
@@ -219,7 +215,6 @@ struct UIKitExtensionsTests {
 
     // MARK: Tests for old style alerts and action sheets (iOS/tvOS 13.0-14.*)
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Test SwiftUI deprecated Alert constructor.")
     @MainActor
     func expectedControlTypesInDeprecatedAlertsSwiftUI() throws {
@@ -257,7 +252,6 @@ struct UIKitExtensionsTests {
         #expect(alertController.view.allSubviewsMatching(predicate: { $0.isUIAlertTextField }).count == 0)
     }
 
-    @available(iOS 15.0, tvOS 15.0, *)
     @Test("Test SwiftUI deprecated ActionSheet constructor, all button roles.", arguments: 1...5)
     @MainActor
     func expectedControlTypesInDeprecatedActionSheetsSwiftUI(numberOfActionButtons: Int) throws {


### PR DESCRIPTION
### What and why?

Removes @available/#available checks that are now dead following the minimum deployment target bump in #3155 (iOS 15.0 / tvOS 15.0 / watchOS 9.0). Part of the RUM-16719 cleanup, split per module.

### How?

Deletes availability branches whose guarded platform versions are all ≤ the new floors, keeping only the code path that is now always available. No behavior change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs