### PR TITLE
[RUM-16719] Remove dead availability guards in DatadogSessionReplay

### DIFF
--- a/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
+++ b/DatadogSessionReplay/Sources/Feature/RecordingComponents.swift
@@ -18,7 +18,7 @@ internal struct RecordingComponents {
         resourcesWriter: any ResourcesWriting,
         srContextPublisher: SRContextPublisher
     ) throws {
-        if #available(iOS 13.0, tvOS 13.0, *), configuration.featureFlags[.compositionTreeRecording] {
+        if configuration.featureFlags[.compositionTreeRecording] {
             // This is purely defensive, as `SessionReplay.enable()` initializes on the main thread
             self = try runOnMainThreadSync {
                 try .layerTreeRecordingComponents(
@@ -106,7 +106,6 @@ internal struct RecordingComponents {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @MainActor
     private static func layerTreeRecordingComponents(
         core: DatadogCoreProtocol,

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayer+ReplayID.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayer+ReplayID.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayer {
     /// Stable identifier for this layer in Session Replay snapshots.
     ///
@@ -26,7 +25,6 @@ extension CALayer {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ReplayIDGenerator: Sendable {
     var next: @Sendable @MainActor () -> Int64
 
@@ -42,7 +40,6 @@ internal struct ReplayIDGenerator: Sendable {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayer {
     /// Overrides replay ID generation for deterministic snapshot tests.
     @MainActor
@@ -56,7 +53,6 @@ extension CALayer {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayer {
     fileprivate enum ReplayID {
         enum Context {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayer+Semantics.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayer+Semantics.swift
@@ -9,7 +9,6 @@ import Foundation
 import QuartzCore
 import UIKit
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayer {
     var isBarBackground: Bool {
         delegate?.isKind(of: Classes.barBackground) == true

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Context.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Context.swift
@@ -11,7 +11,6 @@ import WebKit
 
 @preconcurrency import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// State shared by all layers captured in one snapshot.
     final class Context {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+CornerRadii.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+CornerRadii.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// Radius values for each layer corner.
     struct CornerRadii: Sendable, Equatable {
@@ -43,7 +42,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.CornerRadii {
     var uniformCornerRadius: CGFloat? {
         guard

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Filter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Filter.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// Captured subset of Core Animation filters that affect layer rendering.
     enum Filter: Sendable, Equatable {
@@ -23,7 +22,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.Filter {
     /// Reads a supported layer filter. Unknown enabled filters are kept by name.
     init?(_ filterValue: Any) {
@@ -78,7 +76,6 @@ extension CALayerSnapshot.Filter {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// A 4-by-5 color transform matrix used by layer filters.
     struct ColorMatrix: Sendable, Equatable {
@@ -108,7 +105,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     struct CompositingFilter: Sendable, Hashable, RawRepresentable {
         let rawValue: String
@@ -126,7 +122,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.CompositingFilter {
     static let normal = Self(rawValue: "normalBlendMode")
     static let plusDarker = Self(rawValue: "plusD")

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+ImageSnapshot.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// Returns the image snapshot requests needed to represent this layer tree.
     func imageSnapshotRequests(for changeset: CALayerChangeset, cache: ImageSnapshotCache) -> [ImageSnapshotRequest] {
@@ -83,7 +82,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension MaskSnapshotRequest {
     fileprivate init?(
         layerSnapshot: CALayerSnapshot,
@@ -112,7 +110,6 @@ extension MaskSnapshotRequest {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ContentSnapshotRequest {
     fileprivate init?(
         layerSnapshot: CALayerSnapshot,

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Mask.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Mask.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     struct Mask: Sendable, Equatable {
         let replayID: Int64
@@ -26,7 +25,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayer {
     @MainActor
     fileprivate func maskDependencies() -> [CALayerReference] {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Occlusion.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Occlusion.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// A Boolean value indicating whether the layer draws any content.
     var drawsContent: Bool {
@@ -49,7 +48,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.CornerRadii {
     /// Returns the rectangles that cover the rounded shape, excluding the corner caps.
     ///
@@ -95,7 +93,6 @@ extension CALayerSnapshot.CornerRadii {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     var hasBackgroundColor: Bool {
         guard let backgroundColor else {
@@ -184,7 +181,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.Filter {
     fileprivate var preservesOpacity: Bool {
         switch self {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Portal.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+Portal.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// Replaces supported portal layers with their hidden source layer hierarchy.
     func resolvingPortalLayers() -> CALayerSnapshot {
@@ -17,7 +16,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private struct PortalLayerResolver {
     typealias PortalSemantics = CALayerSnapshot.SemanticObservation.PortalSemantics
 
@@ -136,7 +134,6 @@ private struct PortalLayerResolver {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     fileprivate mutating func move(contentsFrom sourceRect: CGRect, to destinationFrame: CGRect) -> Bool {
         guard sourceRect.size == destinationFrame.size else {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SRCompositionLayer.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot+SRCompositionLayer.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     var requiresCompositionLayer: Bool {
         masksToBounds
@@ -120,7 +119,6 @@ extension CALayerSnapshot {
 }
 
 extension SRCompositionLayer.CompositeOperation {
-    @available(iOS 13.0, tvOS 13.0, *)
     init?(
         compositingFilter: CALayerSnapshot.CompositingFilter?,
         semantics: CALayerSnapshot.SemanticObservation.Semantics
@@ -146,7 +144,6 @@ extension SRCompositionLayer.CompositeOperation {
 }
 
 extension SRCompositionLayerModifier {
-    @available(iOS 13.0, tvOS 13.0, *)
     fileprivate init?(
         filter: CALayerSnapshot.Filter,
         semantics: CALayerSnapshot.SemanticObservation.Semantics
@@ -185,7 +182,6 @@ extension SRCompositionLayerModifier {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.ColorMatrix {
     fileprivate var values: [Double] {
         [

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CALayerSnapshot.swift
@@ -18,7 +18,6 @@ import UIKit
 /// payload needed by later Session Replay recording steps.
 /// Frames are captured in the root layer coordinate space, matching the
 /// coordinate space used by Session Replay wireframes.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct CALayerSnapshot: Sendable {
     let layer: CALayerReference
     let replayID: Int64
@@ -71,7 +70,6 @@ internal struct CALayerSnapshot: Sendable {
     let shadowPath: CGPath?
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// Describes the bounds and placement of a layer's rendered content.
     struct ContentGeometry: Sendable {
@@ -232,7 +230,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.ContentGeometry {
     @MainActor
     fileprivate init(
@@ -270,7 +267,6 @@ extension CALayerSnapshot.ContentGeometry {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     fileprivate struct ResolvedPrivacy {
         var textAndInputPrivacyLevel: TextAndInputPrivacyLevel
@@ -289,7 +285,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayer {
     @MainActor fileprivate var privacyOverrides: SessionReplayPrivacyOverrides? {
         (delegate as? UIView)?.dd._privacyOverrides

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CATransform3D+AxisAligned.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CATransform3D+AxisAligned.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CATransform3D {
     /// A Boolean value indicating whether the transform contains no rotation, skew, or perspective.
     var isAxisAligned: Bool {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionLayerBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionLayerBuilder.swift
@@ -9,7 +9,6 @@ import DatadogInternal
 import Foundation
 
 /// Maps layer snapshots to composition layers and mask resources.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct CompositionLayerBuilder {
     struct Output {
         let layer: SRCompositionLayer

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/CompositionTreeBuilder.swift
@@ -9,7 +9,6 @@ import CoreGraphics
 import DatadogInternal
 
 /// Builds the composition tree produced by the layer recording pipeline.
-@available(iOS 13.0, tvOS 13.0, *)
 internal class CompositionTreeBuilder {
     private typealias TextInputSemantics = CALayerSnapshot.SemanticObservation.TextInputSemantics
     private typealias VisualEffect = CALayerSnapshot.SemanticObservation.VisualEffect
@@ -178,7 +177,6 @@ internal class CompositionTreeBuilder {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension CALayerSnapshot.SemanticObservation {
     var gradient: GradientSemantics? {
         guard case .gradient(let gradient) = semantics else {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ContentSnapshot+Redaction.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ContentSnapshot+Redaction.swift
@@ -10,7 +10,6 @@ import QuartzCore
 import UIKit
 
 /// Redaction to apply to a rendered image snapshot.
-@available(iOS 13.0, tvOS 13.0, *)
 internal enum ImageRedactionAction: Hashable {
     case none
     case redactText
@@ -18,13 +17,11 @@ internal enum ImageRedactionAction: Hashable {
 }
 
 /// Redacted image or placeholder instruction.
-@available(iOS 13.0, tvOS 13.0, *)
 internal enum ImageRedactionResult {
     case image(UIImage)
     case placeholder(UIColor)
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ContentSnapshot {
     func redacted(
         parentTextInput: CALayerSnapshot.SemanticObservation.TextInputSemantics?

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ContentSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ContentSnapshot.swift
@@ -11,7 +11,6 @@ import UIKit
 @preconcurrency import DatadogInternal
 
 /// Rendered content for one layer snapshot.
-@available(iOS 13.0, tvOS 13.0, *)
 internal final class ContentSnapshot: Sendable {
     let image: UIImage
 
@@ -45,7 +44,6 @@ internal final class ContentSnapshot: Sendable {
 }
 
 /// A content snapshot and the geometry used to render it.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ContentSnapshotData: Sendable {
     let snapshot: ContentSnapshot
 
@@ -63,7 +61,6 @@ internal struct ContentSnapshotData: Sendable {
 }
 
 /// Failure reason for a layer image snapshot.
-@available(iOS 13.0, tvOS 13.0, *)
 internal enum ImageSnapshotError: Error, Equatable {
     /// The recorder exhausted its time budget before rendering this image.
     case timedOut
@@ -73,6 +70,5 @@ internal enum ImageSnapshotError: Error, Equatable {
 }
 
 /// Result of rendering one layer image snapshot.
-@available(iOS 13.0, tvOS 13.0, *)
 internal typealias ContentSnapshotResult = Result<ContentSnapshot, ImageSnapshotError>
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotCache.swift
@@ -11,7 +11,6 @@ import Foundation
 ///
 /// Stores rendered snapshots across image snapshot passes and keeps the render
 /// metadata needed to decide when a cached snapshot can be reused.
-@available(iOS 13.0, tvOS 13.0, *)
 internal final class ImageSnapshotCache {
     struct Policy {
         let expirationFrameCount: UInt64

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotRequest.swift
@@ -11,7 +11,6 @@ import QuartzCore
 @preconcurrency import DatadogInternal
 
 /// Request to render one layer bitmap.
-@available(iOS 13.0, tvOS 13.0, *)
 internal enum ImageSnapshotRequest: Sendable {
     case content(ContentSnapshotRequest)
     case mask(MaskSnapshotRequest)
@@ -36,7 +35,6 @@ internal enum ImageSnapshotRequest: Sendable {
 }
 
 /// Request to render one `CALayerSnapshot` as a content image.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ContentSnapshotRequest: Sendable {
     let replayID: Int64
     let layer: CALayerReference
@@ -87,7 +85,6 @@ internal struct ContentSnapshotRequest: Sendable {
 }
 
 /// A content snapshot request with its live layer resolved for rendering.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ResolvedContentSnapshotRequest {
     let layer: CALayer
     let geometry: CALayerSnapshot.ContentGeometry
@@ -95,7 +92,6 @@ internal struct ResolvedContentSnapshotRequest {
 }
 
 /// Request to render one layer mask as an image.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct MaskSnapshotRequest: Sendable {
     let replayID: Int64
     let layer: CALayerReference
@@ -129,7 +125,6 @@ internal struct MaskSnapshotRequest: Sendable {
 }
 
 /// A mask snapshot request resolved against the current layer tree.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ResolvedMaskSnapshotRequest {
     let layer: CALayer
     let bounds: CGRect
@@ -138,13 +133,11 @@ internal struct ResolvedMaskSnapshotRequest {
 }
 
 /// Failure reason for resolving an image snapshot request.
-@available(iOS 13.0, tvOS 13.0, *)
 internal enum ImageSnapshotRequestResolutionError: Error {
     case missingLayer
     case invalidRect
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ContentSnapshotRequest {
     @MainActor
     func resolved() throws -> ResolvedContentSnapshotRequest {
@@ -198,7 +191,6 @@ extension ContentSnapshotRequest {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension MaskSnapshotRequest {
     @MainActor
     func resolved() throws -> ResolvedMaskSnapshotRequest {
@@ -223,7 +215,6 @@ extension MaskSnapshotRequest {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ContentSnapshotData {
     fileprivate var isPartial: Bool {
         !renderBounds.equalTo(localRect)

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotResource.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotResource.swift
@@ -8,7 +8,6 @@
 import DatadogInternal
 import UIKit
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ImageSnapshotResource: Resource {
     let image: UIImage
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/ImageSnapshotter.swift
@@ -11,7 +11,6 @@ import QuartzCore
 import UIKit
 
 /// Captures rendered image snapshots from layer snapshot requests.
-@available(iOS 13.0, tvOS 13.0, *)
 internal protocol ImageSnapshotting: AnyObject {
     /// Renders images for the optimized layer tree within the given time budget.
     @MainActor
@@ -23,7 +22,6 @@ internal protocol ImageSnapshotting: AnyObject {
 }
 
 /// Rendered snapshots produced by `ImageSnapshotter`.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ImageSnapshotBatch: Sendable {
     let contentSnapshots: [Int64: ContentSnapshotResult]
     let maskSnapshots: [Int64: MaskSnapshotResult]
@@ -37,7 +35,6 @@ internal struct ImageSnapshotBatch: Sendable {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 @MainActor
 internal final class ImageSnapshotter: ImageSnapshotting {
     private enum Constants {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerProvider.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerProvider.swift
@@ -9,12 +9,10 @@ import QuartzCore
 import UIKit
 
 /// Provides the root layer for a layer tree capture.
-@available(iOS 13.0, tvOS 13.0, *)
 internal protocol LayerProvider {
     @MainActor var rootLayer: CALayer? { get }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension KeyWindowObserver: LayerProvider {
     var rootLayer: CALayer? {
         relevantWindow?.layer

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecordBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecordBuilder.swift
@@ -8,7 +8,6 @@
 import Foundation
 import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct LayerRecordBuilder {
     func metaRecord(from snapshot: LayerTreeSnapshot) -> SRRecord {
         let record = SRMetaRecord(

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecorder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecorder.swift
@@ -12,7 +12,6 @@ import Foundation
 ///
 /// Only one recording task runs at a time. New requests are ignored while the
 /// current task is still running.
-@available(iOS 13.0, tvOS 13.0, *)
 internal actor LayerRecorder: LayerRecording {
     private let snapshotBuilder: any LayerTreeSnapshotBuilding
     private let uiApplicationSwizzler: UIApplicationSwizzler

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecording.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerRecording.swift
@@ -9,7 +9,6 @@ import Foundation
 @preconcurrency import DatadogInternal
 
 /// Immutable inputs needed to build one layer recording.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct LayerRecordingContext: Sendable {
     let textAndInputPrivacy: TextAndInputPrivacyLevel
     let imagePrivacy: ImagePrivacyLevel
@@ -23,7 +22,6 @@ internal struct LayerRecordingContext: Sendable {
     let telemetry: any Telemetry
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal protocol LayerRecording {
     /// Schedules a recording from collected screen changes.
     func scheduleRecording(_ changeset: CALayerChangeset, context: LayerRecordingContext) async

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerSnapshotProcessor.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerSnapshotProcessor.swift
@@ -9,7 +9,6 @@ import DatadogInternal
 import Foundation
 
 /// Turns layer tree, image, and touch snapshots into Session Replay records.
-@available(iOS 13.0, tvOS 13.0, *)
 internal protocol LayerSnapshotProcessing {
     func process(
         layerTreeSnapshot: LayerTreeSnapshot,
@@ -19,7 +18,6 @@ internal protocol LayerSnapshotProcessing {
 }
 
 /// Builds and writes Session Replay records for the Core Animation recording pipeline.
-@available(iOS 13.0, tvOS 13.0, *)
 internal final class LayerSnapshotProcessor: LayerSnapshotProcessing {
     private let queue: Queue
     private let recordWriter: RecordWriting
@@ -173,7 +171,6 @@ internal final class LayerSnapshotProcessor: LayerSnapshotProcessing {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension LayerTreeSnapshot {
     func shouldStartNewSegment(after previousSnapshot: LayerTreeSnapshot?) -> Bool {
         return context.applicationID != previousSnapshot?.context.applicationID ||
@@ -182,7 +179,6 @@ private extension LayerTreeSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension EnrichedRecord {
     init(context: LayerRecordingContext, records: [SRRecord]) {
         self.applicationID = context.applicationID

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeRecordingCoordinator.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeRecordingCoordinator.swift
@@ -12,7 +12,6 @@ import Foundation
 ///
 /// It starts monitoring only when Session Replay is enabled and the current
 /// session is sampled.
-@available(iOS 13.0, tvOS 13.0, *)
 internal final class LayerTreeRecordingCoordinator: RecordingController {
     let replaySampleRate: SampleRate
     let textAndInputPrivacy: TextAndInputPrivacyLevel
@@ -138,7 +137,6 @@ internal final class LayerTreeRecordingCoordinator: RecordingController {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension LayerTreeRecordingCoordinator: FeatureMessageReceiver {
     func receive(message: FeatureMessage, from _: DatadogCoreProtocol) -> Bool {
         guard case let .context(context) = message else {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerTreeSnapshotBuilder.swift
@@ -13,7 +13,6 @@ import WebKit
 import DatadogInternal
 
 /// Snapshot of a layer tree and the recording context used to capture it.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct LayerTreeSnapshot: Sendable {
     let date: Date
     let context: LayerRecordingContext
@@ -24,14 +23,12 @@ internal struct LayerTreeSnapshot: Sendable {
 }
 
 /// Creates layer tree snapshots on the main actor.
-@available(iOS 13.0, tvOS 13.0, *)
 @MainActor
 internal protocol LayerTreeSnapshotBuilding: AnyObject {
     func takeSnapshot(context: LayerRecordingContext) -> LayerTreeSnapshot?
 }
 
 /// Builds immutable snapshots from the current root layer.
-@available(iOS 13.0, tvOS 13.0, *)
 @MainActor
 internal final class LayerTreeSnapshotBuilder: LayerTreeSnapshotBuilding {
     private let layerProvider: any LayerProvider
@@ -75,7 +72,6 @@ internal final class LayerTreeSnapshotBuilder: LayerTreeSnapshotBuilding {
 }
 
 extension UIView {
-    @available(iOS 13.0, tvOS 13.0, *)
     fileprivate var embeddedContentSlot: (Int64, String)? {
         self.dd.sessionReplaySlotID.map {
             (self.layer.replayID, $0)

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerWireframeBuilder.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/LayerWireframeBuilder.swift
@@ -9,7 +9,6 @@ import DatadogInternal
 import UIKit
 
 /// Maps layer snapshots to wireframes and resources.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct LayerWireframeBuilder {
     typealias TextInputSemantics = CALayerSnapshot.SemanticObservation.TextInputSemantics
 

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/MaskSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/MaskSnapshot.swift
@@ -9,7 +9,6 @@ import Foundation
 import UIKit
 
 /// Rendered mask for one layer snapshot.
-@available(iOS 13.0, tvOS 13.0, *)
 internal final class MaskSnapshot: Sendable {
     let image: UIImage
 
@@ -19,7 +18,6 @@ internal final class MaskSnapshot: Sendable {
 }
 
 /// A mask snapshot and the layer state used to render it.
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct MaskSnapshotData: Sendable {
     let snapshot: MaskSnapshot
 
@@ -34,6 +32,5 @@ internal struct MaskSnapshotData: Sendable {
 }
 
 /// Result of rendering one layer mask snapshot.
-@available(iOS 13.0, tvOS 13.0, *)
 internal typealias MaskSnapshotResult = Result<MaskSnapshot, ImageSnapshotError>
 #endif

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SRWireframe+CALayerSnapshot.swift
@@ -10,7 +10,6 @@ import Foundation
 import UIKit
 
 extension SRWireframe {
-    @available(iOS 13.0, tvOS 13.0, *)
     init(hiddenEmbeddedContentReplayID replayID: Int64, slotID: String) {
         self = .embeddedContentWireframe(
             value: .init(
@@ -25,7 +24,6 @@ extension SRWireframe {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     init(hiddenWebViewSlotID slotID: Int) {
         self = .webviewWireframe(
             value: .init(
@@ -40,7 +38,6 @@ extension SRWireframe {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     init?(
         layerSnapshot: CALayerSnapshot,
         backgroundGradient: SRShapeGradient? = nil,
@@ -67,7 +64,6 @@ extension SRWireframe {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     init(
         layerSnapshot: CALayerSnapshot,
         backgroundColor: UIColor,
@@ -89,7 +85,6 @@ extension SRWireframe {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     init?(
         layerSnapshot: CALayerSnapshot,
         label: CALayerSnapshot.SemanticObservation.LabelSemantics,
@@ -119,7 +114,6 @@ extension SRWireframe {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     init(
         replayID: Int64,
         imageSnapshot: ContentSnapshot,
@@ -139,7 +133,6 @@ extension SRWireframe {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     init(
         placeholderFor layerSnapshot: CALayerSnapshot,
         label: String
@@ -156,7 +149,6 @@ extension SRWireframe {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     init(
         layerSnapshot: CALayerSnapshot,
         embeddedContent: CALayerSnapshot.SemanticObservation.EmbeddedContentSemantics
@@ -176,7 +168,6 @@ extension SRWireframe {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     init(
         layerSnapshot: CALayerSnapshot,
         webView: CALayerSnapshot.SemanticObservation.WebViewSemantics
@@ -198,7 +189,6 @@ extension SRWireframe {
 }
 
 extension SRTextPosition {
-    @available(iOS 13.0, tvOS 13.0, *)
     fileprivate init(label: CALayerSnapshot.SemanticObservation.LabelSemantics) {
         self.init(
             alignment: .init(systemTextAlignment: label.textAlignment)
@@ -207,7 +197,6 @@ extension SRTextPosition {
 }
 
 extension SRTextStyle {
-    @available(iOS 13.0, tvOS 13.0, *)
     fileprivate init(
         label: CALayerSnapshot.SemanticObservation.LabelSemantics,
         frame: CGRect
@@ -232,7 +221,6 @@ extension SRTextStyle {
 }
 
 extension SRShapeBorder {
-    @available(iOS 13.0, tvOS 13.0, *)
     fileprivate init?(layerSnapshot: CALayerSnapshot) {
         guard
             let borderColor = layerSnapshot.borderColor,
@@ -248,7 +236,6 @@ extension SRShapeBorder {
 }
 
 extension SRShapeStyle {
-    @available(iOS 13.0, tvOS 13.0, *)
     fileprivate init?(
         layerSnapshot: CALayerSnapshot,
         backgroundGradient: SRShapeGradient? = nil,
@@ -269,7 +256,6 @@ extension SRShapeStyle {
 }
 
 extension SRShapeGradient {
-    @available(iOS 13.0, tvOS 13.0, *)
     init?(
         gradient: CALayerSnapshot.SemanticObservation.GradientSemantics
     ) {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservation.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservation.swift
@@ -8,7 +8,6 @@
 import Foundation
 import UIKit
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     /// Semantic meaning captured for a layer, plus capture hints for its sublayers.
     struct SemanticObservation: Sendable, Equatable {
@@ -22,7 +21,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     enum VisualEffect: Sendable, Equatable {
         case automaticCapsule
@@ -36,7 +34,6 @@ extension CALayerSnapshot.SemanticObservation {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct PortalSemantics: Sendable, Equatable {
         let sourceReplayID: Int64
@@ -47,7 +44,6 @@ extension CALayerSnapshot.SemanticObservation {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     enum Semantics: Sendable, Equatable {
         case layer
@@ -63,7 +59,6 @@ extension CALayerSnapshot.SemanticObservation {
 
 // MARK: - GradientSemantics
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct GradientSemantics: Sendable, Equatable {
         let type: CAGradientLayerType
@@ -95,7 +90,6 @@ extension CALayerSnapshot.SemanticObservation {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     @MainActor
     init(layer: CALayer, context: CALayerSnapshot.Context) {
@@ -113,7 +107,6 @@ extension CALayerSnapshot.SemanticObservation {
 
 // MARK: - LabelSemantics
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct LabelSemantics: Sendable, Equatable {
         let text: String?
@@ -143,7 +136,6 @@ extension CALayerSnapshot.SemanticObservation {
 
 // MARK: - ImageSemantics
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct ImageSemantics: Sendable, Equatable {
         let hasContent: Bool
@@ -158,7 +150,6 @@ extension CALayerSnapshot.SemanticObservation {
 
 // MARK: - TextInputSemantics
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct TextInputSemantics: Sendable, Equatable {
         let isSensitiveText: Bool
@@ -175,7 +166,6 @@ extension CALayerSnapshot.SemanticObservation {
 
 // MARK: - EmbeddedContentSemantics
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct EmbeddedContentSemantics: Sendable, Equatable {
         let slotID: String
@@ -188,7 +178,6 @@ extension CALayerSnapshot.SemanticObservation {
 
 // MARK: - WebViewSemantics
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation {
     struct WebViewSemantics: Sendable, Equatable {
         let slotID: Int

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping+Common.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping+Common.swift
@@ -13,7 +13,6 @@ import WebKit
 @_spi(Internal)
 import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservationMapping {
     static let embeddedContent = Self { layer, _, context in
         guard
@@ -133,7 +132,6 @@ extension CALayerSnapshot.SemanticObservationMapping {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation.GradientSemantics {
     fileprivate init?(gradientLayer: CAGradientLayer) {
         guard let colorValues = gradientLayer.colors else {
@@ -156,7 +154,6 @@ extension CALayerSnapshot.SemanticObservation.GradientSemantics {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation.LabelSemantics {
     fileprivate init(label: UILabel) {
         self.init(
@@ -170,7 +167,6 @@ extension CALayerSnapshot.SemanticObservation.LabelSemantics {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation.ImageSemantics {
     fileprivate init(imageView: UIImageView) {
         let image = imageView.isHighlighted ? imageView.highlightedImage ?? imageView.image : imageView.image
@@ -182,7 +178,6 @@ extension CALayerSnapshot.SemanticObservation.ImageSemantics {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation.TextInputSemantics {
     fileprivate init(textView: UITextView) {
         self.init(
@@ -201,7 +196,6 @@ extension CALayerSnapshot.SemanticObservation.TextInputSemantics {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservation.WebViewSemantics {
     fileprivate init(webView: WKWebView, absoluteFrame: CGRect) {
         self.init(

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping+VisualEffect.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping+VisualEffect.swift
@@ -8,7 +8,6 @@
 import Foundation
 import UIKit
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservationMapping {
     static let signedDistanceField = Self { layer, _, _ in
         guard layer.isSignedDistanceField else {

--- a/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping.swift
+++ b/DatadogSessionReplay/Sources/LayerTreeRecorder/SemanticObservationMapping.swift
@@ -8,7 +8,6 @@
 import Foundation
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     struct SemanticObservationMapping {
         let observe: @MainActor (
@@ -19,7 +18,6 @@ extension CALayerSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.SemanticObservationMapping: CaseIterable {
     static let allCases: [Self] = [
         .embeddedContent,

--- a/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerReference.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ScreenChangeMonitor/CALayerReference.swift
@@ -26,7 +26,6 @@ internal struct CALayerReference: @unchecked Sendable {
         layer === other
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @MainActor
     func resolve() -> CALayer? {
         layer

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/Path+CornerRadii.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/Path+CornerRadii.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension SwiftUI.Path {
     init(roundedRect rect: CGRect, cornerRadii: CALayerSnapshot.CornerRadii, cornerCurve: CALayerCornerCurve) {
         if cornerRadii == .zero {
@@ -91,7 +90,6 @@ extension CGFloat {
     fileprivate static let bezierKappa: CGFloat = 0.5522847498307933
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.CornerRadii {
     fileprivate func clamped(to rect: CGRect) -> Self {
         .init(
@@ -115,7 +113,6 @@ extension CALayerSnapshot.CornerRadii {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension RoundedCornerStyle {
     fileprivate init(cornerCurve: CALayerCornerCurve) {
         switch cornerCurve {

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/Path+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/Path+SessionReplay.swift
@@ -10,10 +10,8 @@ import DatadogInternal
 import Foundation
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension SwiftUI.Path: DatadogExtended {}
 
-@available(iOS 13.0, *)
 extension DatadogExtension where ExtendedType == SwiftUI.Path {
     var svgString: String {
         var d = ""

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
@@ -18,66 +18,31 @@ internal enum SystemColors {
     static let clear: CGColor = UIColor.clear.cgColor
 
     static var tertiarySystemFill: CGColor {
-        if #available(iOS 13.0, *) {
-            return UIColor.tertiarySystemFill.cgColor
-        } else {
-            // Fallback to iOS 16.2 light mode color:
-            return UIColor(red: 118 / 255, green: 118 / 255, blue: 128 / 255, alpha: 1).cgColor
-        }
+        return UIColor.tertiarySystemFill.cgColor
     }
 
     static var tertiarySystemBackground: CGColor {
-        if #available(iOS 13.0, *) {
-            return UIColor.tertiarySystemBackground.cgColor
-        } else {
-            // Fallback to iOS 16.2 light mode color:
-            return UIColor(red: 255 / 255, green: 255 / 255, blue: 255 / 255, alpha: 1).cgColor
-        }
+        return UIColor.tertiarySystemBackground.cgColor
     }
 
     static var systemBackground: CGColor {
-        if #available(iOS 13.0, *) {
-            return UIColor.systemBackground.cgColor
-        } else {
-            // Fallback to iOS 16.2 light mode color:
-            return UIColor(red: 255 / 255, green: 255 / 255, blue: 255 / 255, alpha: 1).cgColor
-        }
+        return UIColor.systemBackground.cgColor
     }
 
     static var secondarySystemGroupedBackground: CGColor {
-        if #available(iOS 13.0, *) {
-            return UIColor.secondarySystemGroupedBackground.cgColor
-        } else {
-            // Fallback to iOS 16.2 light mode color:
-            return UIColor(red: 255 / 255, green: 255 / 255, blue: 255 / 255, alpha: 1).cgColor
-        }
+        return UIColor.secondarySystemGroupedBackground.cgColor
     }
 
     static var secondarySystemFill: CGColor {
-        if #available(iOS 13.0, *) {
-            return UIColor.secondarySystemFill.cgColor
-        } else {
-            // Fallback to iOS 16.2 light mode color:
-            return UIColor(red: 120 / 255, green: 120 / 255, blue: 128 / 255, alpha: 1).cgColor
-        }
+        return UIColor.secondarySystemFill.cgColor
     }
 
     static var tintColor: CGColor {
-        if #available(iOS 15.0, *) {
-            return UIColor.tintColor.cgColor
-        } else {
-            // Fallback to iOS 16.2 light mode color:
-            return UIColor(red: 0 / 255, green: 122 / 255, blue: 255 / 255, alpha: 1).cgColor
-        }
+        return UIColor.tintColor.cgColor
     }
 
     static var label: CGColor {
-        if #available(iOS 13.0, *) {
-            return UIColor.label.cgColor
-        } else {
-            // Fallback to iOS 16.2 light mode color:
-            return UIColor(red: 0 / 255, green: 0 / 255, blue: 0 / 255, alpha: 1).cgColor
-        }
+        return UIColor.label.cgColor
     }
 
     static var systemGreen: CGColor {
@@ -93,12 +58,7 @@ internal enum SystemColors {
     }
 
     static var placeholderText: CGColor {
-        if #available(iOS 13.0, *) {
-            return UIColor.placeholderText.cgColor
-        } else {
-            // Fallback to iOS 16.2 light mode color:
-            return UIColor(red: 197 / 255, green: 197 / 255, blue: 197 / 255, alpha: 1).cgColor
-        }
+        return UIColor.placeholderText.cgColor
     }
 }
 #endif

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIImage+SessionReplay.swift
@@ -88,7 +88,7 @@ extension DatadogExtension where ExtendedType: UIImage {
     ///   - tintColor: The tint color to apply.
     /// - Returns: The PNG data.
     func pngData(maxSize: CGSize = .init(width: 1_000, height: 1_000), tintColor: UIColor? = nil) -> Data? {
-        if #available(iOS 13.0, *), type.isSymbolImage, let tintColor = tintColor {
+        if type.isSymbolImage, let tintColor = tintColor {
             return png(image: type.withTintColor(tintColor), maxSize: maxSize, tintColor: nil)
         }
 
@@ -132,12 +132,10 @@ extension DatadogExtension where ExtendedType: UIImage {
 }
 
 extension UIImage {
-    @available(iOS 13.0, *)
     var isContextual: Bool {
         return isSymbolImage || isBundled || isAlwaysTemplate
     }
 
-    @available(iOS 13.0, *)
     var isTinted: Bool {
         return isSymbolImage || isAlwaysTemplate
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color+Reflection.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftUI
 import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension SwiftUI.Color._Resolved: Reflection {
     init(from reflector: Reflector) throws {
         linearRed = try reflector.descendant("linearRed")
@@ -20,7 +19,6 @@ extension SwiftUI.Color._Resolved: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension SwiftUI.Color._ResolvedHDR: Reflection {
     init(from reflector: Reflector) throws {
         base = try reflector.descendant("base")
@@ -28,14 +26,12 @@ extension SwiftUI.Color._ResolvedHDR: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ColorView: Reflection {
     init(from reflector: Reflector) throws {
         color = try reflector.descendant("color")
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ResolvedPaint: Reflection {
     init(from reflector: Reflector) throws {
         if #available(iOS 26, tvOS 26, *) {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Color.swift
@@ -9,7 +9,6 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension SwiftUI.Color {
     struct _Resolved: Hashable {
         let linearRed: Float
@@ -33,12 +32,10 @@ extension SwiftUI.Color {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ColorView {
     let color: SwiftUI.Color._ResolvedHDR
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct ResolvedPaint: Hashable {
     let paint: SwiftUI.Color._Resolved?
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList+Reflection.swift
@@ -10,35 +10,30 @@ import Foundation
 import SwiftUI
 import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList: Reflection {
     init(from reflector: Reflector) throws {
         items = try reflector.descendant("items")
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Identity: Reflection {
     init(from reflector: Reflector) throws {
         value = try reflector.descendant("value")
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Seed: Reflection {
     init(from reflector: Reflector) throws {
         value = try reflector.descendant("value")
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewRenderer: Reflection {
     init(from reflector: Reflector) throws {
         renderer = try reflector.descendant("renderer")
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater: Reflection {
     init(from reflector: Reflector) throws {
         viewCache = try reflector.descendant("viewCache")
@@ -46,7 +41,6 @@ extension DisplayList.ViewUpdater: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Effect: Reflection {
     init(from reflector: Reflector) throws {
         switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
@@ -68,28 +62,24 @@ extension DisplayList.Effect: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater.ViewCache: Reflection {
     init(from reflector: Reflector) throws {
         map = try reflector.descendant("map")
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater.ViewCache.Key: Reflection {
     init(from reflector: Reflector) throws {
         id = try reflector.descendant("id")
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Index.ID: Reflection {
     init(from reflector: Reflector) throws {
         identity = try reflector.descendant("identity")
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.ViewUpdater.ViewInfo: Reflection {
     init(from reflector: Reflector) throws {
         // do not retain the views or layer, only get values required
@@ -129,7 +119,6 @@ extension DisplayList.ViewUpdater.ViewInfo: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Content: Reflection {
     init(from reflector: Reflector) throws {
         seed = try reflector.descendant("seed")
@@ -137,7 +126,6 @@ extension DisplayList.Content: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Content.Value: Reflection {
     init(from reflector: Reflector) throws {
         switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
@@ -173,7 +161,6 @@ extension DisplayList.Content.Value: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Item: Reflection {
     init(from reflector: Reflector) throws {
         identity = try reflector.descendant("identity")
@@ -182,7 +169,6 @@ extension DisplayList.Item: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension DisplayList.Item.Value: Reflection {
     init(from reflector: Reflector) throws {
         switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayList.swift
@@ -11,7 +11,6 @@ import SwiftUI
 import UIKit
 import QuartzCore
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct DisplayList {
     internal struct Identity: Hashable {
         let value: UInt32

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Drawing.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/Drawing.swift
@@ -10,7 +10,6 @@ import CoreGraphics
 import Foundation
 import UIKit
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct Drawing {
     private enum Constants {
         static let cls: AnyClass? = NSClassFromString("RBMovedDisplayListContents")
@@ -51,7 +50,6 @@ internal struct Drawing {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension Drawing: ImageRepresentable {
     static func == (lhs: Drawing, rhs: Drawing) -> Bool {
         lhs.contents.isEqual(rhs.contents) && lhs.origin == rhs.origin

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsFilter+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsFilter+Reflection.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsFilter: Reflection {
     init(from reflector: Reflector) throws {
         switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsFilter.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsFilter.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal enum GraphicsFilter {
     case colorMultiply(Color._Resolved)
     case unknown

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImage+Reflection.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImage+Reflection.swift
@@ -10,7 +10,6 @@ import CoreGraphics
 import SwiftUI
 import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage: Reflection {
     init(from reflector: Reflector) throws {
         scale = try reflector.descendant("scale")
@@ -24,7 +23,6 @@ extension GraphicsImage: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage.Contents: Reflection {
     init(from reflector: Reflector) throws {
         switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {
@@ -38,7 +36,6 @@ extension GraphicsImage.Contents: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage.VectorImage: Reflection {
     init(from reflector: Reflector) throws {
         location = try reflector.descendant("location")
@@ -46,7 +43,6 @@ extension GraphicsImage.VectorImage: Reflection {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension GraphicsImage.Location: Reflection {
     init(from reflector: Reflector) throws {
         switch (reflector.displayStyle, reflector.descendantIfPresent(0)) {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImage.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImage.swift
@@ -9,7 +9,6 @@ import CoreGraphics
 import SwiftUI
 
 /// Represents a SwiftUI.GraphicsImage
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct GraphicsImage {
     let contents: Contents
     let scale: CGFloat
@@ -41,7 +40,6 @@ internal struct GraphicsImage {
 }
 
 /// Mapping SwiftUI orientation to UIImage orientation
-@available(iOS 13.0, tvOS 13.0, *)
 internal extension UIImage.Orientation {
     init(_ orientation: SwiftUI.Image.Orientation) {
         switch orientation {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ImageRenderer.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ImageRenderer.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal final class ImageRenderer {
     private class Key: NSObject {
         private let contents: AnyImageRepresentable

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ImageRepresentable.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ImageRepresentable.swift
@@ -9,12 +9,10 @@
 import Foundation
 import UIKit
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal protocol ImageRepresentable: Hashable {
     func makeImage() -> UIImage?
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 internal struct AnyImageRepresentable: ImageRepresentable {
     private let base: any ImageRepresentable
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResource.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResource.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 import CommonCrypto
 
-@available(iOS 13.0, *)
 internal final class ShapeResource: NSObject {
     let svgString: String
 
@@ -33,7 +32,6 @@ internal final class ShapeResource: NSObject {
     }
 }
 
-@available(iOS 13.0, *)
 extension ShapeResource: Resource {
     var mimeType: String {
         "image/svg+xml"

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResourceBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResourceBuilder.swift
@@ -14,7 +14,6 @@ import SwiftUI
 /// `ShapeResourceBuilder` implements a multi-level caching strategy to eliminate expensive
 /// recomputations during UI updates and scrolling animations. This addresses performance
 /// issues that can occur when the same shapes are rendered repeatedly in Session Replay.
-@available(iOS 13.0, *)
 internal final class ShapeResourceBuilder {
     /// Cache key for SwiftUI path data, used to avoid redundant SVG path string generation.
     private class PathKey: NSObject {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilder.swift
@@ -11,7 +11,6 @@ import UIKit
 import DatadogInternal
 import SwiftUI
 
-@available(iOS 13.0, *)
 internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
     internal struct Context {
         var frame: CGRect
@@ -260,7 +259,6 @@ internal struct SwiftUIWireframesBuilder: NodeWireframesBuilder {
     }
 }
 
-@available(iOS 13.0, *)
 internal extension SwiftUIWireframesBuilder.Context {
     func convert(frame: CGRect) -> CGRect {
         frame.offsetBy(
@@ -277,7 +275,6 @@ internal extension SwiftUIWireframesBuilder.Context {
     }
 }
 
-@available(iOS 13.0, *)
 internal extension ImagePrivacyLevel {
     var shouldRecordGraphicsImagePredicate: (_ graphicImage: GraphicsImage) -> Bool {
         switch self {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -31,23 +31,18 @@ internal struct UIDatePickerRecorder: NodeRecorder {
         }
 
         var nodes: [Node]?
-        if #available(iOS 13.4, *) {
-            switch datePicker.datePickerStyle {
-            case .wheels:
-                nodes = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
-            case .compact:
-                nodes = compactStyleRecorder.record(datePicker, with: attributes, in: context)
-            case .inline:
-                nodes = inlineStyleRecorder.record(datePicker, with: attributes, in: context)
-            case .automatic:
-                // According to `datePicker.datePickerStyle` documentation:
-                // > "This property always returns a concrete style, never `UIDatePickerStyle.automatic`."
-                break
-            @unknown default:
-                nodes = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
-            }
-        } else {
-            // Observation: older OS versions use the "wheels" style
+        switch datePicker.datePickerStyle {
+        case .wheels:
+            nodes = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
+        case .compact:
+            nodes = compactStyleRecorder.record(datePicker, with: attributes, in: context)
+        case .inline:
+            nodes = inlineStyleRecorder.record(datePicker, with: attributes, in: context)
+        case .automatic:
+            // According to `datePicker.datePickerStyle` documentation:
+            // > "This property always returns a concrete style, never `UIDatePickerStyle.automatic`."
+            break
+        @unknown default:
             nodes = wheelsStyleRecorder.record(datePicker, with: attributes, in: context)
         }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorder.swift
@@ -11,7 +11,6 @@ import UIKit
 import SwiftUI
 import DatadogInternal
 
-@available(iOS 13, tvOS 13, *)
 internal class UIHostingViewRecorder: NodeRecorder {
     let identifier: UUID
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -20,7 +20,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
     internal init(
         identifier: UUID,
         tintColorProvider: @escaping (UIImageView) -> UIColor? = { imageView in
-            if #available(iOS 13.0, *), let image = imageView.image {
+            if let image = imageView.image {
                 return image.isTinted ? imageView.tintColor : nil
             } else {
                 return nil
@@ -174,7 +174,7 @@ fileprivate extension ImagePrivacyLevel {
         switch self {
         case .maskNone: return { _ in true }
         case .maskNonBundledOnly: return { imageView in
-            if #available(iOS 13.0, *), let image = imageView.image {
+            if let image = imageView.image {
                 return image.isContextual || imageView.isSystemControlBackground
             } else {
                 return false

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -65,16 +65,12 @@ internal struct UINavigationBarRecorder: NodeRecorder {
             return UIColor.black.cgColor
         }
 
-        if #available(iOS 13.0, *) {
-            switch UITraitCollection.current.userInterfaceStyle {
-            case .light:
-                return UIColor.white.cgColor
-            case .dark:
-                return UIColor.black.cgColor
-            default:
-                return UIColor.white.cgColor
-            }
-        } else {
+        switch UITraitCollection.current.userInterfaceStyle {
+        case .light:
+            return UIColor.white.cgColor
+        case .dark:
+            return UIColor.black.cgColor
+        default:
             return UIColor.white.cgColor
         }
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -39,11 +39,9 @@ internal struct UIPickerViewRecorder: NodeRecorder {
                 UIViewRecorder(
                     identifier: identifier,
                     semanticsOverride: { view, attributes in
-                        if #available(iOS 13.0, *) {
-                            if !attributes.isVisible || attributes.alpha < 1 || !CATransform3DIsIdentity(view.transform3D) {
-                                // If this view has any 3D effect applied, do not enter its subtree:
-                                return IgnoredElement(subtreeStrategy: .ignore)
-                            }
+                        if !attributes.isVisible || attributes.alpha < 1 || !CATransform3DIsIdentity(view.transform3D) {
+                            // If this view has any 3D effect applied, do not enter its subtree:
+                            return IgnoredElement(subtreeStrategy: .ignore)
                         }
                         // Otherwise, enter the subtree of this element, but do not consider it significant (`InvisibleElement`):
                         return InvisibleElement(subtreeStrategy: .record)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -36,13 +36,7 @@ internal struct UISegmentRecorder: NodeRecorder {
             segmentWireframeIDs: Array(ids[1..<ids.count]),
             segmentTitles: (0..<segment.numberOfSegments).map { segment.titleForSegment(at: $0) },
             selectedSegmentIndex: context.recorder.textAndInputPrivacy.shouldMaskInputElements ? nil : segment.selectedSegmentIndex,
-            selectedSegmentTintColor: {
-                if #available(iOS 13.0, *) {
-                    return segment.selectedSegmentTintColor
-                } else {
-                    return nil
-                }
-            }()
+            selectedSegmentTintColor: segment.selectedSegmentTintColor
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node])

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -89,16 +89,12 @@ internal final class UITabBarRecorder: NodeRecorder {
             return color.cgColor
         }
 
-        if #available(iOS 13.0, *) {
-            switch UITraitCollection.current.userInterfaceStyle {
-            case .light:
-                return UIColor.white.cgColor
-            case .dark:
-                return UIColor.black.cgColor
-            default:
-                return UIColor.white.cgColor
-            }
-        } else {
+        switch UITraitCollection.current.userInterfaceStyle {
+        case .light:
+            return UIColor.white.cgColor
+        case .dark:
+            return UIColor.black.cgColor
+        default:
             return UIColor.white.cgColor
         }
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -123,9 +123,7 @@ internal func createDefaultNodeRecorders(featureFlags: SessionReplay.Configurati
         UIActivityIndicatorRecorder(identifier: UUID()),
     ]
 
-    if #available(iOS 13, tvOS 13, *) {
-        recorders.append(UIHostingViewRecorder(identifier: UUID()))
-    }
+    recorders.append(UIHostingViewRecorder(identifier: UUID()))
 
     return recorders
 }

--- a/DatadogSessionReplay/Sources/Recorder/WindowObserver/KeyWindowObserver.swift
+++ b/DatadogSessionReplay/Sources/Recorder/WindowObserver/KeyWindowObserver.swift
@@ -15,14 +15,9 @@ import UIKit
 internal class KeyWindowObserver: AppWindowObserver {
     /// Returns the key window of the app.
     var relevantWindow: UIWindow? {
-        if #available(iOS 13.0, tvOS 13.0, *) {
-            return findONiOS13AndLater()
-        } else {
-            return nil
-        }
+        return findONiOS13AndLater()
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     private func findONiOS13AndLater() -> UIWindow? {
         return UIApplication.managedShared?
             .connectedScenes

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -120,7 +120,6 @@ extension SessionReplay.Configuration {
         /// extracted from UIKit and SwiftUI properties. This pipeline uses the rendered
         /// layer tree as its primary source, preserving its structure and rendering
         /// effects to improve replay fidelity in UIKit, SwiftUI, and React Native apps.
-        @available(iOS 13.0, tvOS 13.0, *)
         case compositionTreeRecording = "composition_tree_recording"
     }
 }

--- a/DatadogSessionReplay/Tests/Feature/EmbeddedContentReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/EmbeddedContentReceiverTests.swift
@@ -14,7 +14,6 @@ import TestUtilities
 
 @Suite(.datadogTesting)
 struct EmbeddedContentReceiverTests {
-    @available(iOS 13.0, *)
     @Test("Writes embedded records using native session context and embedded view ID")
     func writesEmbeddedRecordsUsingNativeSessionContextAndEmbeddedViewID() throws {
         // Given
@@ -67,7 +66,6 @@ struct EmbeddedContentReceiverTests {
         #expect(resourcesWriter.resources.isEmpty)
     }
 
-    @available(iOS 13.0, *)
     @Test("Adds embedded records to the existing native record count")
     func embeddedRecordsContributeToExistingNativeRecordCount() {
         // Given
@@ -107,7 +105,6 @@ struct EmbeddedContentReceiverTests {
         #expect(recordsCountByViewID == ["shared-view-id": 5])
     }
 
-    @available(iOS 13.0, *)
     @Test("Writes embedded resources using the native application ID")
     func writesEmbeddedResourcesUsingNativeApplicationID() throws {
         // Given
@@ -148,7 +145,6 @@ struct EmbeddedContentReceiverTests {
         #expect(resource.context == .init(rumContext.applicationID))
     }
 
-    @available(iOS 13.0, *)
     @Test("Drops embedded messages when RUM context is unavailable")
     func dropsEmbeddedMessagesWhenRUMContextIsUnavailable() {
         // Given
@@ -176,7 +172,6 @@ struct EmbeddedContentReceiverTests {
         #expect(resourcesWriter.resources.isEmpty)
     }
 
-    @available(iOS 13.0, *)
     @Test("Drops embedded messages when the native RUM session is not sampled")
     func dropsEmbeddedMessagesWhenNativeRUMSessionIsNotSampled() {
         // Given
@@ -207,7 +202,6 @@ struct EmbeddedContentReceiverTests {
         #expect(resourcesWriter.resources.isEmpty)
     }
 
-    @available(iOS 13.0, *)
     @Test("Rejects messages for other receivers")
     func rejectsMessagesForOtherReceivers() {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerChangesetMock.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerChangesetMock.swift
@@ -9,7 +9,6 @@ import QuartzCore
 
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerChangeset {
     static func mockChange(for layer: CALayer, aspects: CALayerChange.Aspect.Set) -> CALayerChangeset {
         CALayerChangeset(

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerReplayIDTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerReplayIDTests.swift
@@ -14,7 +14,6 @@ import QuartzCore
 @Suite(.datadogTesting)
 @MainActor
 struct CALayerReplayIDTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test
     func autoincrementingGeneratorAssignsSequentialIDsToLayers() {
         CALayer.withReplayIDGenerator(.autoincrementing) {
@@ -37,7 +36,6 @@ struct CALayerReplayIDTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test
     func replayIDIsCachedAndGeneratorInvokedOnlyOncePerLayer() {
         var calls = 0
@@ -61,7 +59,6 @@ struct CALayerReplayIDTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test
     func taskLocalGeneratorOverridesWithinScopeAndRestoresAfter() {
         var outerCounter: Int64 = 10
@@ -92,7 +89,6 @@ struct CALayerReplayIDTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test
     func sameLayerKeepsIDAcrossGeneratorOverrides() {
         var outerCounter: Int64 = 7
@@ -122,7 +118,6 @@ struct CALayerReplayIDTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test
     func autoincrementingGeneratorWrapsToZeroAfterInt32Max() {
         var currentID = Int64(Int32.max - 1)

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotContextMock.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotContextMock.swift
@@ -11,7 +11,6 @@ import WebKit
 
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot.Context {
     static func mockAny(
         textAndInputPrivacyLevel: TextAndInputPrivacyLevel = .maskAll,

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotFilterTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotFilterTests.swift
@@ -14,7 +14,6 @@ import Testing
 
 @Suite(.datadogTesting)
 struct CALayerSnapshotFilterTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Ignores unsupported filter values")
     func ignoresUnsupportedFilterValues() {
         // Given
@@ -27,7 +26,6 @@ struct CALayerSnapshotFilterTests {
         #expect(snapshotFilter == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Ignores disabled filters")
     func ignoresDisabledFilters() throws {
         // Given
@@ -41,7 +39,6 @@ struct CALayerSnapshotFilterTests {
         #expect(snapshotFilter == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures gaussian blur filter", arguments: ["gaussianBlur", "variableBlur"])
     func capturesGaussianBlurFilter(type: String) throws {
         // Given
@@ -56,7 +53,6 @@ struct CALayerSnapshotFilterTests {
         #expect(snapshotFilter == .gaussianBlur(radius))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures color matrix filter")
     func capturesColorMatrixFilter() throws {
         // Given
@@ -78,7 +74,6 @@ struct CALayerSnapshotFilterTests {
         #expect(snapshotFilter == .colorMatrix(matrix))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures vibrant color matrix filter")
     func capturesVibrantColorMatrixFilter() throws {
         // Given
@@ -100,7 +95,6 @@ struct CALayerSnapshotFilterTests {
         #expect(snapshotFilter == .vibrantColorMatrix(matrix))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures color saturate filter")
     func capturesColorSaturateFilter() throws {
         // Given
@@ -115,7 +109,6 @@ struct CALayerSnapshotFilterTests {
         #expect(snapshotFilter == .saturate(amount))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures color brightness filter")
     func capturesColorBrightnessFilter() throws {
         // Given
@@ -130,7 +123,6 @@ struct CALayerSnapshotFilterTests {
         #expect(snapshotFilter == .brightness(amount))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures multiply color filter")
     func capturesMultiplyColorFilter() throws {
         // Given
@@ -145,7 +137,6 @@ struct CALayerSnapshotFilterTests {
         #expect(snapshotFilter == .multiplyColor(color))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures unknown filter names")
     func capturesUnknownFilterNames() throws {
         // Given
@@ -160,7 +151,6 @@ struct CALayerSnapshotFilterTests {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension CALayerSnapshot.ColorMatrix {
     var nsValue: NSValue {
         var value = self

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotImageSnapshotRequestTests.swift
@@ -17,7 +17,6 @@ import WebKit
 @Suite(.datadogTesting)
 @MainActor
 struct CALayerSnapshotImageSnapshotRequestTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips content snapshot request for visual effect")
     func skipsContentSnapshotRequestForVisualEffect() {
         // Given
@@ -34,7 +33,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.compactMap(\.content).isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips content snapshot request for gradient")
     func skipsContentSnapshotRequestForGradient() throws {
         // Given
@@ -60,7 +58,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.compactMap(\.content).isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for plain layer with contents")
     func createsRequestForPlainLayerWithContents() throws {
         // Given
@@ -84,7 +81,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.hasChanges == false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for plain layer with content changes")
     func createsRequestForPlainLayerWithContentChanges() throws {
         // Given
@@ -104,7 +100,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.hasChanges)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for plain layer with cached snapshot data")
     func createsRequestForPlainLayerWithCachedSnapshotData() throws {
         // Given
@@ -127,7 +122,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.previousSnapshotData?.snapshot === imageSnapshot)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates mask request for container with mask")
     func createsMaskRequestForContainerWithMask() throws {
         // Given
@@ -163,7 +157,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(!request.hasChanges)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Marks mask request changed when mask dependency changes")
     func marksMaskRequestChangedWhenMaskDependencyChanges() throws {
         // Given
@@ -193,7 +186,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.hasChanges)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates mask request for transparent container mask")
     func createsMaskRequestForTransparentContainerMask() throws {
         // Given
@@ -221,7 +213,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.dependencies.contains { $0.matches(mask) })
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips mask request for leaf layer")
     func skipsMaskRequestForLeafLayer() throws {
         // Given
@@ -242,7 +233,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(!requests.contains { $0.mask != nil })
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips plain layer without contents, content changes, or cache")
     func skipsPlainLayerWithoutContentsChangesOrCachedSnapshotData() throws {
         // Given
@@ -258,7 +248,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for layer subclass without contents")
     func createsRequestForLayerSubclassWithoutContents() throws {
         // Given
@@ -279,7 +268,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.hasLayerSemantics)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for semantic image layer when image privacy masks none")
     func createsRequestForSemanticImageLayerWhenImagePrivacyMasksNone() throws {
         // Given
@@ -307,7 +295,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(!requests.contains { $0.content?.layer.matches(child) == true })
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips empty semantic image layer")
     func skipsEmptySemanticImageLayer() throws {
         // Given
@@ -324,7 +311,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for semantic image layer with dependencies")
     func createsRequestForSemanticImageLayerWithDependencies() throws {
         // Given
@@ -349,7 +335,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.dependencies.contains { $0.matches(dependency) })
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips semantic image layer when image privacy masks all")
     func skipsSemanticImageLayerWhenImagePrivacyMasksAll() throws {
         // Given
@@ -367,7 +352,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for progress view image sublayer when image privacy masks all")
     func createsRequestForProgressViewImageSublayerWhenImagePrivacyMasksAll() throws {
         // Given
@@ -390,7 +374,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.imagePrivacyLevel == .maskNone)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for slider image sublayer when image privacy masks all")
     func createsRequestForSliderImageSublayerWhenImagePrivacyMasksAll() throws {
         // Given
@@ -413,7 +396,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.imagePrivacyLevel == .maskNone)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for button image sublayer when image privacy masks all")
     func createsRequestForButtonImageSublayerWhenImagePrivacyMasksAll() throws {
         // Given
@@ -436,7 +418,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.imagePrivacyLevel == .maskNone)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips button image sublayer when button image privacy override masks all")
     func skipsButtonImageSublayerWhenButtonImagePrivacyOverrideMasksAll() throws {
         // Given
@@ -458,7 +439,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips semantic image layer when image privacy masks non-bundled images")
     func skipsSemanticImageLayerWhenImagePrivacyMasksNonBundledImages() throws {
         // Given
@@ -476,7 +456,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for highlighted semantic image layer when highlighted image is bundled")
     func createsRequestForHighlightedSemanticImageLayerWhenHighlightedImageIsBundled() throws {
         // Given
@@ -497,7 +476,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.layer.matches(imageView.layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for highlighted semantic image layer when fallback image is bundled")
     func createsRequestForHighlightedSemanticImageLayerWhenFallbackImageIsBundled() throws {
         // Given
@@ -518,7 +496,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.layer.matches(imageView.layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for semantic image layer when ignored sublayer changes")
     func createsRequestForSemanticImageLayerWhenIgnoredSublayerChanges() throws {
         // Given
@@ -549,7 +526,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.hasChanges)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for semantic image layer when ignored sublayer lays out")
     func createsRequestForSemanticImageLayerWhenIgnoredSublayerLaysOut() throws {
         // Given
@@ -575,7 +551,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.hasChanges)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for semantic image layer when ignored sublayer is replaced")
     func createsRequestForSemanticImageLayerWhenIgnoredSublayerIsReplaced() throws {
         // Given
@@ -616,7 +591,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.hasChanges)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not mark semantic image layer changed when owner only lays out")
     func doesNotMarkSemanticImageLayerChangedWhenOwnerOnlyLaysOut() throws {
         // Given
@@ -644,7 +618,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(!request.hasChanges)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips web view layer")
     func skipsWebViewLayer() throws {
         // Given
@@ -660,7 +633,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips private layer")
     func skipsPrivateLayer() throws {
         // Given
@@ -677,7 +649,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates request for visible child of zero-sized non-clipping container")
     func createsRequestForVisibleChildOfZeroSizedNonClippingContainer() throws {
         // Given
@@ -704,7 +675,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(requests.first?.content?.layer.matches(imageView.layer) == true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps traversing image-capable container")
     func keepsTraversingImageCapableContainer() throws {
         // Given
@@ -732,7 +702,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
         #expect(request.layer.matches(child))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps traversing when container image would include web view")
     func keepsTraversingWhenContainerImageWouldIncludeWebView() throws {
         // Given
@@ -770,7 +739,6 @@ struct CALayerSnapshotImageSnapshotRequestTests {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension ImageSnapshotRequest {
     var content: ContentSnapshotRequest? {
         guard case .content(let request) = self else {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotOcclusionTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotOcclusionTests.swift
@@ -16,7 +16,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct CALayerSnapshotOcclusionTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Draws content when the contents property is set")
     func drawsContentWhenContentsPropertyIsSet() throws {
         // Given
@@ -31,7 +30,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(snapshot.drawsContent)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Draws content when the layer has a visible background color")
     func drawsContentWhenLayerHasAVisibleBackgroundColor() throws {
         // Given
@@ -46,7 +44,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(snapshot.drawsContent)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Draws content when the layer has a visible border")
     func drawsContentWhenLayerHasAVisibleBorder() throws {
         // Given
@@ -62,7 +59,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(snapshot.drawsContent)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not draw content when the layer is bare")
     func doesNotDrawContentWhenLayerIsBare() throws {
         // Given
@@ -76,7 +72,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(!snapshot.drawsContent)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Draws content when the layer subclass has unmodeled drawing state")
     func drawsContentWhenLayerSubclassHasUnmodeledDrawingState() throws {
         // Given
@@ -92,7 +87,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(snapshot.drawsContent)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is an occluder when fully opaque with a solid background")
     func isOccluderWhenFullyOpaqueWithSolidBackground() throws {
         // Given
@@ -107,7 +101,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(snapshot.isOccluder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is not an occluder when opacity is less than one")
     func isNotOccluderWhenOpacityIsLessThanOne() throws {
         // Given
@@ -123,7 +116,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(!snapshot.isOccluder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is not an occluder when the background is translucent")
     func isNotOccluderWhenBackgroundIsTranslucent() throws {
         // Given
@@ -138,7 +130,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(!snapshot.isOccluder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is not an occluder when a mask is present")
     func isNotOccluderWhenMaskIsPresent() throws {
         // Given
@@ -154,7 +145,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(!snapshot.isOccluder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is not an occluder when rotated")
     func isNotOccluderWhenRotated() throws {
         // Given
@@ -170,7 +160,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(!snapshot.isOccluder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is not an occluder when a filter affects opacity")
     func isNotOccluderWhenFilterAffectsOpacity() throws {
         // Given
@@ -186,7 +175,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(!snapshot.isOccluder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is not an occluder when a compositing filter is applied")
     func isNotOccluderWhenCompositingFilterIsApplied() throws {
         // Given
@@ -202,7 +190,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(!snapshot.isOccluder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is an occluder when filters preserve opacity")
     func isOccluderWhenFiltersPreserveOpacity() throws {
         // Given
@@ -218,7 +205,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(snapshot.isOccluder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Returns the visible frame as the only occlusion rect when corners are not rounded")
     func returnsVisibleFrameAsOnlyOcclusionRectWhenCornersAreNotRounded() throws {
         // Given
@@ -233,7 +219,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(rects == [CGRect(x: 0, y: 0, width: 40, height: 60)])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Insets each edge by the larger of the two adjacent corner radii")
     func insetsEachEdgeByTheLargerOfTheTwoAdjacentCornerRadii() {
         // Given
@@ -252,7 +237,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(rects.contains(CGRect(x: 4, y: 0, width: 84, height: 100)))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Drops a band whose inset exceeds the available extent")
     func dropsBandWhoseInsetExceedsAvailableExtent() {
         // Given
@@ -270,7 +254,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(rects == [CGRect(x: 12, y: 0, width: 16, height: 20)])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes a content-bearing leaf fully covered by an opaque sibling in front")
     func removesLeafFullyCoveredByOpaqueSiblingInFront() throws {
         // Given
@@ -297,7 +280,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(result.sublayers.map(\.absoluteFrame) == [CGRect(x: 0, y: 0, width: 100, height: 100)])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps a content-bearing leaf that is only partially covered")
     func keepsLeafPartiallyCoveredByOpaqueSibling() throws {
         // Given
@@ -329,7 +311,6 @@ struct CALayerSnapshotOcclusionTests {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps a layer subclass with unmodeled drawing state")
     func keepsLayerSubclassWithUnmodeledDrawingState() throws {
         // Given
@@ -350,7 +331,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(result.sublayers.map(\.absoluteFrame) == [CGRect(x: 10, y: 10, width: 20, height: 20)])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps a covered content-bearing leaf when it casts a shadow")
     func keepsCoveredContentBearingLeafWhenItCastsShadow() throws {
         // Given
@@ -381,7 +361,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(result.sublayers.map(\.backgroundColor) == [behindColor, frontColor])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes a covered content-bearing container once its children are removed")
     func removesCoveredContentBearingContainerOnceChildrenAreRemoved() throws {
         // Given
@@ -412,7 +391,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(result.sublayers.map(\.absoluteFrame) == [CGRect(x: 0, y: 0, width: 100, height: 100)])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not propagate opaque coverage past a masksToBounds ancestor")
     func doesNotPropagateCoveragePastMasksToBoundsAncestor() throws {
         // Given
@@ -449,7 +427,6 @@ struct CALayerSnapshotOcclusionTests {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not treat a descendant of a semi-transparent ancestor as an occluder")
     func doesNotTreatDescendantOfSemiTransparentAncestorAsOccluder() throws {
         // Given
@@ -486,7 +463,6 @@ struct CALayerSnapshotOcclusionTests {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes an empty structural container when all its children are removed")
     func removesEmptyStructuralContainerWhenAllChildrenRemoved() throws {
         // Given
@@ -517,7 +493,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(result.sublayers.map(\.absoluteFrame) == [CGRect(x: 0, y: 0, width: 100, height: 100)])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps visible children of a zero-sized container that does not clip")
     func keepsVisibleChildrenOfZeroSizedNonClippingContainer() throws {
         // Given
@@ -541,7 +516,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(visibleContainer.sublayers.map(\.replayID) == [child.replayID])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not treat a rotated layer as an occluder")
     func doesNotTreatRotatedLayerAsOccluder() throws {
         // Given
@@ -569,7 +543,6 @@ struct CALayerSnapshotOcclusionTests {
         #expect(result.sublayers.map(\.absoluteFrame).contains(CGRect(x: 10, y: 10, width: 10, height: 10)))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not treat a descendant of a masked ancestor as an occluder")
     func doesNotTreatDescendantOfMaskedAncestorAsOccluder() throws {
         // Given
@@ -608,7 +581,6 @@ struct CALayerSnapshotOcclusionTests {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not treat descendants of an opacity-filtered ancestor as occluders")
     func doesNotTreatDescendantsOfOpacityFilteredAncestorAsOccluders() throws {
         // Given
@@ -645,7 +617,6 @@ struct CALayerSnapshotOcclusionTests {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not cull a layer in the corner area of a rounded occluder")
     func doesNotCullLayerInCornerAreaOfRoundedOccluder() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotPortalTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotPortalTests.swift
@@ -13,7 +13,6 @@ import Testing
 
 @MainActor
 struct CALayerSnapshotPortalTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Resolves a position-matched portal and removes the original source subtree")
     func resolvesPositionMatchedPortalAndRemovesOriginalSourceSubtree() throws {
         // Given
@@ -70,7 +69,6 @@ struct CALayerSnapshotPortalTests {
         #expect(resolvedSource.sublayers.map(\.replayID) == [sourceContent.replayID])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Positions unmatched portal content relative to the portal")
     func positionsUnmatchedPortalContentRelativeToPortal() throws {
         // Given
@@ -121,7 +119,6 @@ struct CALayerSnapshotPortalTests {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Omits portal content when its unmatched source transform cannot be represented")
     func omitsPortalContentForUnsupportedUnmatchedSourceTransform() throws {
         // Given
@@ -156,7 +153,6 @@ struct CALayerSnapshotPortalTests {
         #expect(unresolvedPortal.sublayers.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Stops resolving when portal sources form a cycle")
     func stopsResolvingPortalSourceCycles() throws {
         // Given
@@ -198,7 +194,6 @@ struct CALayerSnapshotPortalTests {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension CALayerSnapshot.SemanticObservation {
     static func portal(
         sourceReplayID: Int64,

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSRCompositionLayerTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotSRCompositionLayerTests.swift
@@ -17,7 +17,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct CALayerSnapshotSRCompositionLayerTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates modifiers in rendering order")
     func createsModifiersInRenderingOrder() throws {
         // Given
@@ -58,7 +57,6 @@ struct CALayerSnapshotSRCompositionLayerTests {
         #expect(maskImageModifier.resourceId == resourceID)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Maps shadows to shadow modifiers")
     func mapsShadowsToShadowModifiers() throws {
         // Given
@@ -90,7 +88,6 @@ struct CALayerSnapshotSRCompositionLayerTests {
         #expect(shadow.path == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Maps automatic capsule effect to clip and shadow modifiers")
     func mapsAutomaticCapsuleEffectToClipAndShadowModifiers() throws {
         // Given
@@ -137,7 +134,6 @@ struct CALayerSnapshotSRCompositionLayerTests {
         #expect(shadow.path == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Maps multiply color filters to color matrix modifiers")
     func mapsMultiplyColorFiltersToColorMatrixModifiers() throws {
         // Given
@@ -171,7 +167,6 @@ struct CALayerSnapshotSRCompositionLayerTests {
         })
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Maps vibrant color matrix filters while preserving source alpha")
     func mapsVibrantColorMatrixFiltersPreservingSourceAlpha() throws {
         // Given
@@ -203,7 +198,6 @@ struct CALayerSnapshotSRCompositionLayerTests {
         ])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Maps Gaussian blur only for regular layers")
     func mapsGaussianBlurOnlyForRegularLayers() {
         // Given
@@ -224,7 +218,6 @@ struct CALayerSnapshotSRCompositionLayerTests {
         #expect(backdropLayerModifiers.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Maps scroll pocket effects to destination-out compositing")
     func mapsScrollPocketEffectsToDestinationOutCompositing() {
         // Given
@@ -242,7 +235,6 @@ struct CALayerSnapshotSRCompositionLayerTests {
         #expect(compositeOperation == .destinationOut)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     private func modifierTypes(_ modifiers: [SRCompositionLayerModifier]) -> [String] {
         modifiers.map { modifier in
             switch modifier {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CALayerSnapshotTests.swift
@@ -16,7 +16,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct CALayerSnapshotTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures layer identity and visual properties")
     func capturesLayerIdentityAndVisualProperties() throws {
         try CALayer.withReplayIDGenerator(ReplayIDGenerator { 42 }) {
@@ -80,7 +79,6 @@ struct CALayerSnapshotTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Preserves sublayer order")
     func preservesSublayerOrder() throws {
         // Given
@@ -110,7 +108,6 @@ struct CALayerSnapshotTests {
         #expect(capturedLayers.elementsEqual([backLayer, middleLayer, frontLayer]) { $0.matches($1) })
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures nested hierarchy with absolute frames")
     func capturesNestedHierarchyWithAbsoluteFrames() throws {
         // Given
@@ -137,7 +134,6 @@ struct CALayerSnapshotTests {
         #expect(childSnapshot.absoluteFrame == CGRect(x: 30, y: 45, width: 20, height: 25))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Prunes hidden and transparent layer trees")
     func prunesHiddenAndTransparentLayerTrees() throws {
         // Given
@@ -180,7 +176,6 @@ struct CALayerSnapshotTests {
         #expect(snapshot.sublayers.first?.layer.matches(visibleChild) == true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Prunes layer trees outside visible bounds")
     func prunesLayerTreesOutsideVisibleBounds() throws {
         // Given
@@ -204,7 +199,6 @@ struct CALayerSnapshotTests {
         #expect(snapshot.sublayers.first?.layer.matches(visibleChild) == true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Prunes sublayers outside clipping parent bounds")
     func prunesSublayersOutsideClippingParentBounds() throws {
         // Given
@@ -228,7 +222,6 @@ struct CALayerSnapshotTests {
         #expect(parentSnapshot.sublayers.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Prunes sublayers outside nested clipping bounds")
     func prunesSublayersOutsideNestedClippingBounds() throws {
         // Given
@@ -264,7 +257,6 @@ struct CALayerSnapshotTests {
         #expect(innerSnapshot.sublayers.first?.layer.matches(visibleChild) == true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Prunes empty clipping layer trees")
     func prunesEmptyClippingLayerTrees() throws {
         // Given
@@ -283,7 +275,6 @@ struct CALayerSnapshotTests {
         #expect(snapshot.sublayers.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Applies hide privacy override and ignores private subtree")
     func appliesHidePrivacyOverrideAndIgnoresPrivateSubtree() throws {
         // Given
@@ -308,7 +299,6 @@ struct CALayerSnapshotTests {
         #expect(privateSnapshot.sublayers.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Propagates privacy overrides to descendants")
     func propagatesPrivacyOverridesToDescendants() throws {
         // Given
@@ -344,7 +334,6 @@ struct CALayerSnapshotTests {
         #expect(childSnapshot.imagePrivacyLevel == .maskNonBundledOnly)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures content geometry")
     func capturesContentGeometry() throws {
         // Given
@@ -365,7 +354,6 @@ struct CALayerSnapshotTests {
         #expect(layerSnapshot.contentGeometry.frame == layer.frame)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Expands content geometry to include ignored sublayers")
     func expandsContentGeometryToIncludeIgnoredSublayers() throws {
         // Given
@@ -389,7 +377,6 @@ struct CALayerSnapshotTests {
         #expect(imageSnapshot.contentGeometry.frame == CGRect(x: 40, y: 48, width: 50, height: 54))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps content geometry within an ignored subtree owner that clips")
     func keepsContentGeometryWithinIgnoredSublayerOwnerThatClips() throws {
         // Given
@@ -414,7 +401,6 @@ struct CALayerSnapshotTests {
         #expect(imageSnapshot.contentGeometry.frame == imageView.layer.frame)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures complete geometry for a non-oversized layer clipped by an ancestor")
     func capturesCompleteGeometryForNonOversizedLayerClippedByAncestor() throws {
         // Given
@@ -441,7 +427,6 @@ struct CALayerSnapshotTests {
         #expect(childSnapshot.contentGeometry.frame == child.convert(child.bounds, to: root))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Crops oversized content geometry to the viewport")
     func cropsOversizedContentGeometryToViewport() throws {
         // Given
@@ -462,7 +447,6 @@ struct CALayerSnapshotTests {
         #expect(oversizedSnapshot.contentGeometry.frame == root.bounds)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures per-corner radii")
     func capturesPerCornerRadii() throws {
         // Given
@@ -485,7 +469,6 @@ struct CALayerSnapshotTests {
         #expect(snapshot.cornerRadii == cornerRadii)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures masked corner radii")
     func capturesMaskedCornerRadii() throws {
         // Given
@@ -504,7 +487,6 @@ struct CALayerSnapshotTests {
         #expect(snapshot.cornerRadii.bottomRight == CGSize(width: 8, height: 8))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Ignores non-finite corner radius")
     func ignoresNonFiniteCornerRadius() throws {
         // Given
@@ -520,7 +502,6 @@ struct CALayerSnapshotTests {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension CALayerSnapshot.CornerRadii {
     var nsValue: NSValue {
         var value = self

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CATransform3DAxisAlignedTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CATransform3DAxisAlignedTests.swift
@@ -13,7 +13,6 @@ import QuartzCore
 
 @Suite(.datadogTesting)
 struct CATransform3DAxisAlignedTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test(
         "Is not axis-aligned for transforms with rotation or perspective",
         arguments: [
@@ -41,7 +40,6 @@ struct CATransform3DAxisAlignedTests {
         #expect(!transform.isAxisAligned)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Is axis-aligned when scaled uniformly")
     func isAxisAlignedWhenScaledUniformly() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionLayerBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionLayerBuilderTests.swift
@@ -13,7 +13,6 @@ import UIKit
 
 @MainActor
 struct CompositionLayerBuilderTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build maps geometry and children")
     func buildMapsGeometryAndChildren() {
         // Given
@@ -37,7 +36,6 @@ struct CompositionLayerBuilderTests {
         #expect(output.resource == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates mask image resource")
     func buildCreatesMaskImageResource() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/CompositionTreeBuilderTests.swift
@@ -17,7 +17,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct CompositionTreeBuilderTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates background and content references for container")
     func buildCreatesBackgroundAndContentReferencesForContainer() throws {
         // Given
@@ -68,7 +67,6 @@ struct CompositionTreeBuilderTests {
         #expect(output.resources.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates fallback and content references for automatic capsule")
     func buildCreatesFallbackAndContentReferencesForAutomaticCapsule() throws {
         // Given
@@ -104,7 +102,6 @@ struct CompositionTreeBuilderTests {
         ])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates composition layer for leaf with modifiers")
     func buildCreatesCompositionLayerForLeafWithModifiers() throws {
         // Given
@@ -142,7 +139,6 @@ struct CompositionTreeBuilderTests {
         #expect(output.wireframes.count == 1)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build applies inherited visual effect to descendant wireframe")
     func buildAppliesInheritedVisualEffectToDescendantWireframe() throws {
         // Given
@@ -183,7 +179,6 @@ struct CompositionTreeBuilderTests {
         #expect(shapeWireframe.shapeStyle?.cornerRadius == 12)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build includes embedded content visibility state")
     func buildIncludesEmbeddedContentVisibilityState() throws {
         // Given
@@ -231,7 +226,6 @@ struct CompositionTreeBuilderTests {
         #expect(visibleWireframe.isVisible == true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build can be reused without accumulating output state")
     func buildCanBeReusedWithoutAccumulatingOutputState() throws {
         // Given
@@ -268,17 +262,14 @@ struct CompositionTreeBuilderTests {
         #expect(secondOutput.resources.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     private func visibleWebViewSlotIDs(in wireframes: [SRWireframe]) -> [String] {
         webViewSlotIDs(in: wireframes, isVisible: true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     private func hiddenWebViewSlotIDs(in wireframes: [SRWireframe]) -> [String] {
         webViewSlotIDs(in: wireframes, isVisible: false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     private func webViewSlotIDs(in wireframes: [SRWireframe], isVisible: Bool) -> [String] {
         wireframes.compactMap { wireframe in
             guard case .webviewWireframe(let value) = wireframe, value.isVisible == isVisible else {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ContentSnapshotRedactionTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ContentSnapshotRedactionTests.swift
@@ -15,7 +15,6 @@ import UIKit
 
 @Suite(.datadogTesting)
 struct ContentSnapshotRedactionTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Returns the original image when no redaction is needed")
     func returnsOriginalImageWhenNoRedactionIsNeeded() throws {
         // Given
@@ -33,7 +32,6 @@ struct ContentSnapshotRedactionTests {
         #expect(redactedImage === image)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Returns placeholder with background color when image should not be sent")
     func returnsPlaceholderWithBackgroundColorWhenImageShouldNotBeSent() throws {
         // Given
@@ -52,7 +50,6 @@ struct ContentSnapshotRedactionTests {
         #expect(backgroundColor == .red)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not redact generic layer snapshots")
     func doesNotRedactGenericLayerSnapshots() {
         // Given
@@ -69,7 +66,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .none)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not redact non-layer semantic snapshots")
     func doesNotRedactNonLayerSemanticSnapshots() {
         // Given
@@ -87,7 +83,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .none)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts sensitive non-empty text input layout fragments when masking sensitive inputs")
     func redactsSensitiveNonEmptyTextInputLayoutFragmentsWhenMaskingSensitiveInputs() throws {
         // Given
@@ -108,7 +103,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not redact non-sensitive text input layout fragments when masking sensitive inputs")
     func doesNotRedactNonSensitiveTextInputLayoutFragmentsWhenMaskingSensitiveInputs() throws {
         // Given
@@ -129,7 +123,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .none)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts non-empty text input layout fragments when masking all inputs")
     func redactsNonEmptyTextInputLayoutFragmentsWhenMaskingAllInputs() throws {
         // Given
@@ -150,7 +143,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts text field canvas views when masking all inputs")
     func redactsTextFieldCanvasViewsWhenMaskingAllInputs() throws {
         // Given
@@ -171,7 +163,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not redact read-only text input layout fragments when masking all inputs")
     func doesNotRedactReadOnlyTextInputLayoutFragmentsWhenMaskingAllInputs() throws {
         // Given
@@ -192,7 +183,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .none)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts sensitive read-only text input layout fragments when masking all inputs")
     func redactsSensitiveReadOnlyTextInputLayoutFragmentsWhenMaskingAllInputs() throws {
         // Given
@@ -213,7 +203,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not redact empty text input descendants")
     func doesNotRedactEmptyTextInputDescendants() {
         // Given
@@ -231,7 +220,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .none)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts SwiftUI drawing layers when masking all text")
     func redactsSwiftUIDrawingLayersWhenMaskingAllText() {
         // Given
@@ -247,7 +235,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts SwiftUI drawing view delegates when masking all text")
     func redactsSwiftUIDrawingViewDelegatesWhenMaskingAllText() {
         // Given
@@ -263,7 +250,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts UILabel backed layers when masking all text")
     func redactsUILabelBackedLayersWhenMaskingAllText() {
         // Given
@@ -279,7 +265,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts UILabel subclass backed layers when masking all text")
     func redactsUILabelSubclassBackedLayersWhenMaskingAllText() {
         // Given
@@ -295,7 +280,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts UILabel layers when masking all text")
     func redactsUILabelLayersWhenMaskingAllText() {
         // Given
@@ -311,7 +295,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts CATextLayer when masking all text")
     func redactsCATextLayerWhenMaskingAllText() {
         // Given
@@ -327,7 +310,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Redacts CATextLayer subclasses when masking all text")
     func redactsCATextLayerSubclassesWhenMaskingAllText() {
         // Given
@@ -343,7 +325,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .redactText)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not redact static text candidates when only masking inputs")
     func doesNotRedactStaticTextCandidatesWhenOnlyMaskingInputs() {
         // Given
@@ -359,7 +340,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .none)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Uses placeholder for SwiftUI image layers when masking all images")
     func usesPlaceholderForSwiftUIImageLayersWhenMaskingAllImages() throws {
         // Given
@@ -375,7 +355,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .placeholder)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not redact SwiftUI image layers when image masking is disabled")
     func doesNotRedactSwiftUIImageLayersWhenImageMaskingIsDisabled() throws {
         // Given
@@ -391,7 +370,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .none)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not redact small SwiftUI image layers when masking non-bundled images")
     func doesNotRedactSmallSwiftUIImageLayersWhenMaskingNonBundledImages() throws {
         // Given
@@ -409,7 +387,6 @@ struct ContentSnapshotRedactionTests {
         #expect(action == .none)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Uses placeholder for large SwiftUI image layers when masking non-bundled images")
     func usesPlaceholderForLargeSwiftUIImageLayersWhenMaskingNonBundledImages() throws {
         // Given
@@ -428,22 +405,16 @@ struct ContentSnapshotRedactionTests {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private final class TestCGDrawingLayer: CALayer {}
 
-@available(iOS 13.0, tvOS 13.0, *)
 private final class TestUILabelLayer: CALayer {}
 
-@available(iOS 13.0, tvOS 13.0, *)
 private final class TestTextLayer: CATextLayer {}
 
-@available(iOS 13.0, tvOS 13.0, *)
 private final class TestLabel: UILabel {}
 
-@available(iOS 13.0, tvOS 13.0, *)
 private final class TestCGDrawingView: UIView {}
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension ImageRedactionResult {
     var image: UIImage? {
         guard case let .image(image) = self else {

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ContentSnapshotRequestTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ContentSnapshotRequestTests.swift
@@ -16,7 +16,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct ContentSnapshotRequestTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Throws when layer reference is deallocated")
     func throwsWhenLayerReferenceIsDeallocated() {
         // Given
@@ -33,7 +32,6 @@ struct ContentSnapshotRequestTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Throws when local rect is empty")
     func throwsWhenLocalRectIsEmpty() {
         // Given
@@ -49,7 +47,6 @@ struct ContentSnapshotRequestTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("New plain layer with contents needs snapshot")
     func newPlainLayerWithContentsNeedsSnapshot() throws {
         // Given
@@ -71,7 +68,6 @@ struct ContentSnapshotRequestTests {
         #expect(resolvedRequest.needsSnapshot)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Plain layer with contents does not need snapshot after first appearance")
     func plainLayerWithContentsDoesNotNeedSnapshotAfterFirstAppearance() throws {
         // Given
@@ -96,7 +92,6 @@ struct ContentSnapshotRequestTests {
         #expect(resolvedRequest.needsSnapshot == false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Layer with content changes needs snapshot")
     func layerWithContentChangesNeedsSnapshot() throws {
         // Given
@@ -121,7 +116,6 @@ struct ContentSnapshotRequestTests {
         #expect(resolvedRequest.needsSnapshot)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Layer subclass without changes does not need snapshot after first appearance")
     func layerSubclassWithoutChangesDoesNotNeedSnapshotAfterFirstAppearance() throws {
         // Given
@@ -145,7 +139,6 @@ struct ContentSnapshotRequestTests {
         #expect(resolvedRequest.needsSnapshot == false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Layer subclass needs snapshot when bounds change")
     func layerSubclassNeedsSnapshotWhenBoundsChange() throws {
         // Given
@@ -170,7 +163,6 @@ struct ContentSnapshotRequestTests {
         #expect(resolvedRequest.needsSnapshot)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Layer subclass with geometry animation does not need snapshot")
     func layerSubclassWithGeometryAnimationDoesNotNeedSnapshot() throws {
         // Given
@@ -195,7 +187,6 @@ struct ContentSnapshotRequestTests {
         #expect(resolvedRequest.needsSnapshot == false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Uses captured frame when live layer moves before resolution")
     func usesCapturedFrameWhenLiveLayerMovesBeforeResolution() throws {
         // Given
@@ -218,7 +209,6 @@ struct ContentSnapshotRequestTests {
         #expect(resolvedRequest.geometry.frame == capturedFrame)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Partial snapshot needs snapshot when local rect changes")
     func partialSnapshotNeedsSnapshotWhenLocalRectChanges() throws {
         // Given
@@ -249,7 +239,6 @@ struct ContentSnapshotRequestTests {
         #expect(resolvedRequest.needsSnapshot)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Partial snapshot does not need snapshot when local rect is unchanged")
     func partialSnapshotDoesNotNeedSnapshotWhenLocalRectIsUnchanged() throws {
         // Given
@@ -281,7 +270,6 @@ struct ContentSnapshotRequestTests {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ContentSnapshotRequest {
     @MainActor
     fileprivate static func mockAny(

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotCacheTests.swift
@@ -14,7 +14,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct ImageSnapshotCacheTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Returns stored snapshot data")
     func returnsStoredSnapshotData() throws {
         // Given
@@ -39,7 +38,6 @@ struct ImageSnapshotCacheTests {
         #expect(cachedSnapshotData.dependencies == snapshotData.dependencies)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes stored snapshot data")
     func removesStoredSnapshotData() {
         // Given
@@ -53,7 +51,6 @@ struct ImageSnapshotCacheTests {
         #expect(cache.contentSnapshotData(forReplayID: 1) == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Returns stored mask snapshot data")
     func returnsStoredMaskSnapshotData() throws {
         // Given
@@ -76,7 +73,6 @@ struct ImageSnapshotCacheTests {
         #expect(cachedSnapshotData.dependencies == snapshotData.dependencies)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes stored mask snapshot data")
     func removesStoredMaskSnapshotData() {
         // Given
@@ -90,7 +86,6 @@ struct ImageSnapshotCacheTests {
         #expect(cache.maskSnapshotData(forReplayID: 1) == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Drops snapshot data when cached image is evicted")
     func dropsSnapshotDataWhenCachedImageIsEvicted() {
         // Given
@@ -105,7 +100,6 @@ struct ImageSnapshotCacheTests {
         #expect(cache.contentSnapshotData(forReplayID: 1) == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes stored snapshot data for direct content changes")
     func removesStoredSnapshotDataForDirectContentChanges() {
         // Given
@@ -121,7 +115,6 @@ struct ImageSnapshotCacheTests {
         #expect(cache.contentSnapshotData(forReplayID: layer.replayID) == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes stored snapshot data when dependency changes")
     func removesStoredSnapshotDataWhenDependencyChanges() {
         // Given
@@ -141,7 +134,6 @@ struct ImageSnapshotCacheTests {
         #expect(cache.contentSnapshotData(forReplayID: owner.replayID) == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps stored snapshot data when owner only lays out")
     func keepsStoredSnapshotDataWhenOwnerOnlyLaysOut() {
         // Given
@@ -161,7 +153,6 @@ struct ImageSnapshotCacheTests {
         #expect(cache.contentSnapshotData(forReplayID: owner.replayID) != nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes stored mask snapshot data when dependency changes")
     func removesStoredMaskSnapshotDataWhenDependencyChanges() {
         // Given
@@ -181,7 +172,6 @@ struct ImageSnapshotCacheTests {
         #expect(cache.maskSnapshotData(forReplayID: mask.replayID) == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Expires snapshot data after unobserved frames")
     func expiresSnapshotDataAfterUnobservedFrames() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotMocks.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotMocks.swift
@@ -11,7 +11,6 @@ import UIKit
 
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ContentSnapshot {
     static func mockAny(
         image: UIImage = UIImage(),
@@ -34,7 +33,6 @@ extension ContentSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension ContentSnapshotData {
     static func mockAny(
         snapshot: ContentSnapshot = .mockAny(),
@@ -53,14 +51,12 @@ extension ContentSnapshotData {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension MaskSnapshot {
     static func mockAny(image: UIImage = UIImage()) -> MaskSnapshot {
         MaskSnapshot(image: image)
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension MaskSnapshotData {
     static func mockAny(
         snapshot: MaskSnapshot = .mockAny(),

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/ImageSnapshotterTests.swift
@@ -15,7 +15,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct ImageSnapshotterTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders image snapshot for layer subclass")
     func rendersImageSnapshotForLayerSubclass() async throws {
         // Given
@@ -39,7 +38,6 @@ struct ImageSnapshotterTests {
         #expect(imageSnapshot.hasLayerSemantics)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders ignored sublayer content outside its semantic owner bounds")
     func rendersIgnoredSublayerContentOutsideSemanticOwnerBounds() async throws {
         // Given
@@ -73,7 +71,6 @@ struct ImageSnapshotterTests {
         #expect(cornerImage.map { UIImage(cgImage: $0) }?.dominantColor == .red)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders and caches mask snapshot for container mask")
     func rendersAndCachesMaskSnapshotForContainerMask() async throws {
         // Given
@@ -108,7 +105,6 @@ struct ImageSnapshotterTests {
         #expect(changedMaskSnapshot.image.size == fixture.maskedLayer.bounds.size)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Times out unprocessed image requests")
     func timesOutUnprocessedImageRequests() async throws {
         // Given
@@ -127,7 +123,6 @@ struct ImageSnapshotterTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Removes cached image when changed request times out")
     func removesCachedImageWhenChangedRequestTimesOut() async throws {
         // Given
@@ -166,7 +161,6 @@ struct ImageSnapshotterTests {
         #expect(firstImageSnapshot.image !== nextImageSnapshot.image)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Reuses cached image when only frame changes")
     func reusesCachedImageWhenOnlyFrameChanges() async throws {
         // Given
@@ -197,7 +191,6 @@ struct ImageSnapshotterTests {
         #expect(secondImageSnapshot.frame == CGRect(x: 20, y: 15, width: 100, height: 40))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Refreshes snapshot metadata when cached image is reused")
     func refreshesSnapshotMetadataWhenCachedImageIsReused() async throws {
         // Given
@@ -244,7 +237,6 @@ struct ImageSnapshotterTests {
         #expect(secondImageSnapshot.hasLayerSemantics)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders new image when content changes")
     func rendersNewImageWhenContentChanges() async throws {
         // Given
@@ -276,7 +268,6 @@ struct ImageSnapshotterTests {
         #expect(secondImageSnapshot.frame == layer.frame)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Invalidates cached image when occluded layer content changes")
     func invalidatesCachedImageWhenOccludedLayerContentChanges() async throws {
         // Given
@@ -323,7 +314,6 @@ struct ImageSnapshotterTests {
         #expect(firstImageSnapshot.image !== revealedImageSnapshot.image)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Invalidates cached image when occluded ignored sublayer changes")
     func invalidatesCachedImageWhenOccludedIgnoredSublayerChanges() async throws {
         // Given
@@ -380,7 +370,6 @@ struct ImageSnapshotterTests {
         #expect(firstImageSnapshot.image !== revealedImageSnapshot.image)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders full layer image when clipped by ancestor")
     func rendersFullLayerImageWhenClippedByAncestor() async throws {
         // Given
@@ -411,7 +400,6 @@ struct ImageSnapshotterTests {
         #expect(imageSnapshot.image.size == CGSize(width: 40, height: 40))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Renders visible rect for oversized layer")
     func rendersVisibleRectForOversizedLayer() async throws {
         // Given
@@ -437,7 +425,6 @@ struct ImageSnapshotterTests {
         #expect(imageSnapshot.image.size == CGSize(width: 100, height: 100))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     private struct MaskFixture {
         let rootLayer: CALayer
         let maskedLayer: CALayer

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerRecordBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerRecordBuilderTests.swift
@@ -17,7 +17,6 @@ import TestUtilities
 
 @Suite(.datadogTesting)
 struct LayerRecordBuilderTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Meta record uses layer snapshot viewport and timestamp")
     func metaRecordUsesLayerSnapshotViewportAndTimestamp() throws {
         // Given
@@ -38,7 +37,6 @@ struct LayerRecordBuilderTests {
         #expect(metaRecord.slotId == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Focus record marks the mobile view as focused")
     func focusRecordMarksMobileViewAsFocused() throws {
         // Given
@@ -55,7 +53,6 @@ struct LayerRecordBuilderTests {
         #expect(focusRecord.slotId == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Full snapshot record includes composition tree and wireframes")
     func fullSnapshotRecordIncludesCompositionTreeAndWireframes() throws {
         // Given
@@ -84,7 +81,6 @@ struct LayerRecordBuilderTests {
         #expect(fullSnapshotRecord.data.wireframes.map { $0.id } == [42])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Wireframe mutation record is nil when wireframes are unchanged")
     func wireframeMutationRecordIsNilWhenWireframesAreUnchanged() throws {
         // Given
@@ -103,7 +99,6 @@ struct LayerRecordBuilderTests {
         #expect(record == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Wireframe mutation record includes additions, removals, and updates")
     func wireframeMutationRecordIncludesAdditionsRemovalsAndUpdates() throws {
         // Given
@@ -145,7 +140,6 @@ struct LayerRecordBuilderTests {
         #expect(shapeUpdate.width == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition tree mutation record is nil when the composition tree is unchanged")
     func compositionTreeMutationRecordIsNilWhenCompositionTreeIsUnchanged() throws {
         // Given
@@ -166,7 +160,6 @@ struct LayerRecordBuilderTests {
         #expect(record == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition tree mutation record includes composition tree mutation data")
     func compositionTreeMutationRecordIncludesCompositionTreeMutationData() throws {
         // Given
@@ -208,7 +201,6 @@ struct LayerRecordBuilderTests {
         #expect(mutationData.updates?.first?.children?.map { $0.id } == [42])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Touch records map touches to pointer interaction records")
     func touchRecordsMapTouchesToPointerInteractionRecords() throws {
         // Given
@@ -246,7 +238,6 @@ struct LayerRecordBuilderTests {
         #expect(pointerData.map { $0.y } == [21, 40, 61])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Viewport record follows aspect ratio changes")
     func viewportRecordFollowsAspectRatioChanges() throws {
         // Given
@@ -283,7 +274,6 @@ struct LayerRecordBuilderTests {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private extension SRCompositionLayer {
     static func mockWith(
         id: Int64,

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerSnapshotProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerSnapshotProcessorTests.swift
@@ -17,7 +17,6 @@ import UIKit
 
 @Suite(.datadogTesting)
 struct LayerSnapshotProcessorTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("First layer tree snapshot starts a segment and processes resources")
     func firstLayerTreeSnapshotStartsSegmentAndProcessesResources() throws {
         // Given
@@ -53,7 +52,6 @@ struct LayerSnapshotProcessorTests {
         #expect(fixture.core.recordsCountByViewID == ["view-id": 3])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Same context writes wireframe, composition tree, viewport, and touch records in order")
     func sameContextWritesMutationViewportAndTouchRecordsInOrder() throws {
         // Given
@@ -123,7 +121,6 @@ struct LayerSnapshotProcessorTests {
         #expect(fixture.core.recordsCountByViewID == ["view-id": 7])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("RUM context change starts a new segment")
     func rumContextChangeStartsNewSegment() throws {
         // Given
@@ -151,7 +148,6 @@ struct LayerSnapshotProcessorTests {
         #expect(fixture.core.recordsCountByViewID == ["view-1": 3, "view-2": 3])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Wireframe type changes use incremental mutations and update state")
     func wireframeTypeChangesUseIncrementalMutationsAndUpdateState() throws {
         // Given
@@ -216,7 +212,6 @@ struct LayerSnapshotProcessorTests {
 }
 
 private extension LayerSnapshotProcessorTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     final class Fixture {
         let core = PassthroughCoreMock()
         let recordWriter = RecordWriterMock()

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotBuilderTests.swift
@@ -17,7 +17,6 @@ import WebKit
 @Suite(.datadogTesting)
 @MainActor
 struct LayerTreeSnapshotBuilderTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     enum Fixtures {
         struct NOPTelemetry: Telemetry {
             func send(telemetry: TelemetryMessage) {}
@@ -45,7 +44,6 @@ struct LayerTreeSnapshotBuilderTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @MainActor
     private final class TestLayerProvider: LayerProvider {
         var rootLayer: CALayer?
@@ -55,7 +53,6 @@ struct LayerTreeSnapshotBuilderTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Returns nil when root layer is unavailable")
     func returnsNilWhenRootLayerIsUnavailable() {
         // Given
@@ -68,7 +65,6 @@ struct LayerTreeSnapshotBuilderTests {
         #expect(snapshot == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures snapshot with recording context")
     func capturesSnapshotWithRecordingContext() throws {
         // Given
@@ -103,7 +99,6 @@ struct LayerTreeSnapshotBuilderTests {
         #expect(snapshot.root.sublayers.first?.layer.matches(childLayer) == true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures web view slot IDs from layer tree")
     func capturesWebViewSlotIDsFromLayerTree() throws {
         // Given
@@ -130,7 +125,6 @@ struct LayerTreeSnapshotBuilderTests {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Keeps detached web view slot while web view is alive")
     func keepsDetachedWebViewSlotWhileWebViewIsAlive() throws {
         // Given
@@ -153,7 +147,6 @@ struct LayerTreeSnapshotBuilderTests {
         #expect(snapshot.webViewSlotIDs == expectedSlots)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Captures embedded content as a leaf and keeps its slot while detached")
     func capturesEmbeddedContentAsLeafAndKeepsItsSlotWhileDetached() throws {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotMocks.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerTreeSnapshotMocks.swift
@@ -13,7 +13,6 @@ import QuartzCore
 
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension LayerTreeSnapshot {
     static func mockWith(
         date: Date = Date(timeIntervalSince1970: 42),
@@ -47,7 +46,6 @@ extension LayerTreeSnapshot {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension CALayerSnapshot {
     static func mockRoot(
         absoluteFrame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 200),

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerWireframeBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/LayerWireframeBuilderTests.swift
@@ -15,7 +15,6 @@ import UIKit
 
 @MainActor
 struct LayerWireframeBuilderTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates shape wireframe for layer appearance")
     func buildCreatesShapeWireframeForLayerAppearance() throws {
         // Given
@@ -55,7 +54,6 @@ struct LayerWireframeBuilderTests {
         #expect(output.resource == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates text wireframe for label")
     func buildCreatesTextWireframeForLabel() throws {
         // Given
@@ -97,7 +95,6 @@ struct LayerWireframeBuilderTests {
         #expect(wireframe.shapeStyle?.backgroundColor == "#FF0000FF")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build masks label text for mask all privacy")
     func buildMasksLabelTextForMaskAllPrivacy() throws {
         // Given
@@ -130,7 +127,6 @@ struct LayerWireframeBuilderTests {
         #expect(wireframe.text == "xxxxx xxxxx")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build skips empty label without appearance")
     func buildSkipsEmptyLabelWithoutAppearance() {
         // Given
@@ -154,7 +150,6 @@ struct LayerWireframeBuilderTests {
         #expect(output == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates shape wireframe for linear gradient")
     func buildCreatesShapeWireframeForLinearGradient() throws {
         // Given
@@ -198,7 +193,6 @@ struct LayerWireframeBuilderTests {
         ])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates visual effect fallbacks")
     func buildCreatesVisualEffectFallbacks() throws {
         // Given
@@ -266,7 +260,6 @@ struct LayerWireframeBuilderTests {
         )
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates automatic capsule fallback")
     func buildCreatesAutomaticCapsuleFallback() throws {
         // Given
@@ -293,7 +286,6 @@ struct LayerWireframeBuilderTests {
         #expect(wireframe.shapeStyle?.cornerRadius == 20)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates hidden placeholder for private layer")
     func buildCreatesHiddenPlaceholderForPrivateLayer() throws {
         // Given
@@ -322,7 +314,6 @@ struct LayerWireframeBuilderTests {
         #expect(wireframe.label == "Hidden")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build hides embedded content for a private layer")
     func buildHidesEmbeddedContentForPrivateLayer() throws {
         // Given
@@ -355,7 +346,6 @@ struct LayerWireframeBuilderTests {
         #expect(hiddenWireframe.isVisible == false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build tracks visible and hidden webviews")
     func buildTracksVisibleAndHiddenWebViews() throws {
         // Given
@@ -396,7 +386,6 @@ struct LayerWireframeBuilderTests {
         #expect(hiddenWireframe.isVisible == false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build emits embedded content visibility state")
     func buildEmitsEmbeddedContentVisibilityState() throws {
         // Given
@@ -443,7 +432,6 @@ struct LayerWireframeBuilderTests {
         #expect(hiddenWireframe.isVisible == false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates image resource for content snapshot")
     func buildCreatesImageResourceForContentSnapshot() throws {
         // Given
@@ -484,7 +472,6 @@ struct LayerWireframeBuilderTests {
         #expect(resource.calculateData().isEmpty == false)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build creates shape wireframe when content redacts to placeholder")
     func buildCreatesShapeWireframeWhenContentRedactsToPlaceholder() throws {
         // Given
@@ -520,7 +507,6 @@ struct LayerWireframeBuilderTests {
         #expect(output.resource == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build handles image semantics without snapshot results")
     func buildHandlesImageSemanticsWithoutSnapshotResults() throws {
         // Given
@@ -553,7 +539,6 @@ struct LayerWireframeBuilderTests {
         #expect(emptyImageOutput == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Build handles failed content snapshots")
     func buildHandlesFailedContentSnapshots() throws {
         // Given
@@ -590,7 +575,6 @@ struct LayerWireframeBuilderTests {
         #expect(discardedOutput == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     private func backgroundColor(in output: LayerWireframeBuilder.Output?) throws -> String? {
         guard case .shapeWireframe(let wireframe) = try #require(output?.wireframe) else {
             Issue.record("Expected a shape wireframe")
@@ -599,7 +583,6 @@ struct LayerWireframeBuilderTests {
         return wireframe.shapeStyle?.backgroundColor
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     private func cornerRadius(in output: LayerWireframeBuilder.Output?) throws -> Double? {
         guard case .shapeWireframe(let wireframe) = try #require(output?.wireframe) else {
             Issue.record("Expected a shape wireframe")

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/NSObject+CAFilter.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/NSObject+CAFilter.swift
@@ -7,7 +7,6 @@
 #if os(iOS)
 import Foundation
 
-@available(iOS 13.0, tvOS 13.0, *)
 extension NSObject {
     static func makeCAFilter(type: String) throws -> NSObject {
         guard

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/OcclusionMapTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/OcclusionMapTests.swift
@@ -13,7 +13,6 @@ import Testing
 
 @Suite(.datadogTesting)
 struct OcclusionMapTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Reports nothing as covered when the map is empty")
     func emptyMapReportsNothingAsCovered() {
         // Given
@@ -27,7 +26,6 @@ struct OcclusionMapTests {
         #expect(!isCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Ignores inserts one pixel short of a tile")
     func ignoresInsertsOnePixelShortOfATile() {
         // Given
@@ -41,7 +39,6 @@ struct OcclusionMapTests {
         #expect(!isCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Does not cover a query that overlaps an unmarked tile")
     func doesNotCoverQueryOverlappingAnUnmarkedTile() {
         // Given
@@ -55,7 +52,6 @@ struct OcclusionMapTests {
         #expect(!isCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Covers a query that spans the union of adjacent inserts")
     func coversQuerySpanningUnionOfAdjacentInserts() {
         // Given
@@ -70,7 +66,6 @@ struct OcclusionMapTests {
         #expect(isCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test(
         "Does not cover an invalid candidate rect",
         arguments: [
@@ -92,7 +87,6 @@ struct OcclusionMapTests {
         #expect(!isCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test(
         "Treats invalid sizes as empty",
         arguments: [
@@ -112,7 +106,6 @@ struct OcclusionMapTests {
         #expect(!isCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Ignores partial tiles at the canvas edge")
     func ignoresPartialTilesAtCanvasEdge() {
         // Given
@@ -128,7 +121,6 @@ struct OcclusionMapTests {
         #expect(!partialTileCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Supports canvases wider than 64 tiles")
     func supportsCanvasesWiderThan64Tiles() {
         // Given
@@ -142,7 +134,6 @@ struct OcclusionMapTests {
         #expect(isCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Covers a query whose columns cross a word boundary")
     func coversQueryCrossingAWordBoundary() {
         // Given
@@ -160,7 +151,6 @@ struct OcclusionMapTests {
         #expect(!coveredJustAfterRange)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Covers a non-aligned query inside a marked region")
     func coversNonAlignedQueryInsideMarkedRegion() {
         // Given
@@ -174,7 +164,6 @@ struct OcclusionMapTests {
         #expect(isCovered)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Marks only fully-enclosed tiles when insert starts and ends mid-tile")
     func marksOnlyFullyEnclosedTilesWhenInsertStartsAndEndsMidTile() {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/PathCornerRadiiTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/PathCornerRadiiTests.swift
@@ -14,7 +14,6 @@ import Testing
 
 @Suite(.datadogTesting)
 struct PathCornerRadiiTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Creates path for elliptical corner radii")
     func createsPathForEllipticalCornerRadii() {
         // Given

--- a/DatadogSessionReplay/Tests/LayerTreeRecorder/SemanticObservationTests.swift
+++ b/DatadogSessionReplay/Tests/LayerTreeRecorder/SemanticObservationTests.swift
@@ -39,7 +39,6 @@ struct SemanticObservationTests {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records plain layer semantics")
     func recordsPlainLayerSemantics() {
         // Given
@@ -52,7 +51,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records linear gradient semantics")
     func recordsLinearGradientSemantics() throws {
         // Given
@@ -80,7 +78,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .gradient(gradient)))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records unsupported gradient as plain layer semantics")
     func recordsUnsupportedGradientAsPlainLayerSemantics() {
         // Given
@@ -95,7 +92,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records masked leaf gradient as plain layer semantics")
     func recordsMaskedLeafGradientAsPlainLayerSemantics() {
         // Given
@@ -110,7 +106,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records visual effect backdrop semantics and ignores sublayers")
     func recordsVisualEffectBackdropSemanticsAndIgnoresSublayers() throws {
         // Given
@@ -398,7 +393,6 @@ struct SemanticObservationTests {
         ))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records application DestOutView as plain layer semantics")
     func recordsApplicationDestOutViewAsPlainLayerSemantics() {
         // Given
@@ -411,7 +405,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Rejects gradient semantics with fewer than two colors")
     func rejectsGradientSemanticsWithFewerThanTwoColors() {
         // Given
@@ -430,7 +423,6 @@ struct SemanticObservationTests {
         #expect(gradient == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Rejects gradient semantics with mismatched locations")
     func rejectsGradientSemanticsWithMismatchedLocations() {
         // Given
@@ -449,7 +441,6 @@ struct SemanticObservationTests {
         #expect(gradient == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records activity indicators as plain layers and ignores sublayers")
     func recordsActivityIndicatorsAsPlainLayersAndIgnoresSublayers() {
         // Given
@@ -462,7 +453,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer, ignoresSublayers: true))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records label semantics and ignores sublayers")
     func recordsLabelSemanticsAndIgnoresSublayers() {
         // Given
@@ -494,7 +484,6 @@ struct SemanticObservationTests {
         ))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records single run attributed label semantics")
     func recordsSingleRunAttributedLabelSemantics() {
         // Given
@@ -526,7 +515,6 @@ struct SemanticObservationTests {
         ))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records bold labels as layer semantics")
     func recordsBoldLabelsAsLayerSemantics() {
         // Given
@@ -541,7 +529,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records non-regular system font labels as layer semantics")
     func recordsNonRegularSystemFontLabelsAsLayerSemantics() {
         // Given
@@ -556,7 +543,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records italic labels as layer semantics")
     func recordsItalicLabelsAsLayerSemantics() {
         // Given
@@ -571,7 +557,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records non-system font labels as layer semantics")
     func recordsNonSystemFontLabelsAsLayerSemantics() {
         // Given
@@ -586,7 +571,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records underlined single run attributed labels as layer semantics")
     func recordsUnderlinedSingleRunAttributedLabelsAsLayerSemantics() {
         // Given
@@ -606,7 +590,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records multi run attributed label as layer semantics")
     func recordsMultiRunAttributedLabelAsLayerSemantics() {
         // Given
@@ -623,7 +606,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records image semantics and ignores sublayers")
     func recordsImageSemanticsAndIgnoresSublayers() {
         // Given
@@ -642,7 +624,6 @@ struct SemanticObservationTests {
         ))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records progress view as layer semantics ignoring image privacy")
     func recordsProgressViewAsLayerSemanticsIgnoringImagePrivacy() {
         // Given
@@ -656,7 +637,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer, ignoresImagePrivacy: true))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records slider as layer semantics ignoring image privacy")
     func recordsSliderAsLayerSemanticsIgnoringImagePrivacy() {
         // Given
@@ -674,7 +654,6 @@ struct SemanticObservationTests {
         #expect(observation == expected)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records button as layer semantics ignoring image privacy")
     func recordsButtonAsLayerSemanticsIgnoringImagePrivacy() {
         // Given
@@ -687,7 +666,6 @@ struct SemanticObservationTests {
         #expect(observation == .init(semantics: .layer, ignoresImagePrivacy: true))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records stepper as layer semantics ignoring image privacy")
     func recordsStepperAsLayerSemanticsIgnoringImagePrivacy() {
         // Given
@@ -703,7 +681,6 @@ struct SemanticObservationTests {
         ))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records text view input semantics and records sublayers")
     func recordsTextViewInputSemanticsAndRecordsSublayers() {
         // Given
@@ -725,7 +702,6 @@ struct SemanticObservationTests {
         )))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records empty text view input semantics")
     func recordsEmptyTextViewInputSemantics() {
         // Given
@@ -744,7 +720,6 @@ struct SemanticObservationTests {
         )))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records nil text view input semantics")
     func recordsNilTextViewInputSemantics() {
         // Given
@@ -764,7 +739,6 @@ struct SemanticObservationTests {
         )))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records text field input semantics and records sublayers")
     func recordsTextFieldInputSemanticsAndRecordsSublayers() {
         // Given
@@ -789,7 +763,6 @@ struct SemanticObservationTests {
         ))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records empty text field input semantics")
     func recordsEmptyTextFieldInputSemantics() {
         // Given
@@ -812,7 +785,6 @@ struct SemanticObservationTests {
         ))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records switch as layer semantics")
     func recordsSwitchAsLayerSemantics() {
         // Given
@@ -830,7 +802,6 @@ struct SemanticObservationTests {
         #expect(observation == expected)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Records web view semantics and caches web view")
     func recordsWebViewSemanticsAndCachesWebView() {
         // Given

--- a/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRCompositionTreeTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Diffing/Diff+SRCompositionTreeTests.swift
@@ -12,7 +12,6 @@ import Testing
 
 @Suite(.datadogTesting)
 struct DiffSRCompositionTreeTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition tree mutation is nil when unchanged")
     func compositionTreeMutationIsNilWhenUnchanged() throws {
         // Given
@@ -30,7 +29,6 @@ struct DiffSRCompositionTreeTests {
         #expect(mutation == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition tree mutation replaces root when root changes")
     func compositionTreeMutationReplacesRootWhenRootChanges() throws {
         // Given
@@ -53,7 +51,6 @@ struct DiffSRCompositionTreeTests {
         #expect(mutation.updates == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition tree mutation includes layer additions, removals, and updates")
     func compositionTreeMutationIncludesLayerAdditionsRemovalsAndUpdates() throws {
         // Given
@@ -97,7 +94,6 @@ struct DiffSRCompositionTreeTests {
         #expect(update.y == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition tree mutation ignores non-root layer list order")
     func compositionTreeMutationIgnoresNonRootLayerListOrder() throws {
         // Given
@@ -122,7 +118,6 @@ struct DiffSRCompositionTreeTests {
         #expect(mutation == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition layer mutation skips unchanged fields")
     func compositionLayerMutationSkipsUnchangedFields() throws {
         // Given
@@ -151,7 +146,6 @@ struct DiffSRCompositionTreeTests {
         #expect(mutation.y == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition layer mutation includes changed fields")
     func compositionLayerMutationIncludesChangedFields() throws {
         // Given
@@ -190,7 +184,6 @@ struct DiffSRCompositionTreeTests {
         #expect(mutation.y == 25)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition layer mutation clears children with empty array")
     func compositionLayerMutationClearsChildrenWithEmptyArray() throws {
         // Given
@@ -219,7 +212,6 @@ struct DiffSRCompositionTreeTests {
         #expect(mutation.children?.isEmpty == true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition layer mutation clears modifiers with empty array")
     func compositionLayerMutationClearsModifiersWithEmptyArray() throws {
         // Given
@@ -249,7 +241,6 @@ struct DiffSRCompositionTreeTests {
         #expect(mutation.modifiers?.isEmpty == true)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition layer mutation clears composite operation with source-over")
     func compositionLayerMutationClearsCompositeOperationWithSourceOver() throws {
         // Given
@@ -279,7 +270,6 @@ struct DiffSRCompositionTreeTests {
         #expect(mutation.compositeOperation == .sourceOver)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Composition layer mutation throws when IDs differ")
     func compositionLayerMutationThrowsWhenIDsDiffer() {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangesetTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ScreenChangeMonitor/CALayerChangesetTests.swift
@@ -13,7 +13,6 @@ import Testing
 
 @Suite(.datadogTesting)
 struct CALayerChangesetTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Display and draw changes are content changes")
     func hasContentChanges() {
         // Given
@@ -35,7 +34,6 @@ struct CALayerChangesetTests {
         #expect(!changeset.hasContentChanges(for: .init(layoutLayer)))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Display, draw, and layout changes are tracked changes")
     func hasChanges() {
         // Given
@@ -59,7 +57,6 @@ struct CALayerChangesetTests {
         #expect(!changeset.hasChanges(for: .init(unchangedLayer)))
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Deallocated layers do not return stale aspects")
     func deallocatedLayerDoesNotReturnStaleAspects() {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/Path+SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/Path+SessionReplayTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import SwiftUI
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 final class PathSessionReplayTests: XCTestCase {
     func testEmptyPath() {
         let path = Path()

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/UIView+SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/UIView+SessionReplayTests.swift
@@ -13,10 +13,6 @@ import TestUtilities
 
 class UIViewSessionReplayTests: XCTestCase {
     func testUsesDarkMode() {
-        guard #available(iOS 13.0, *) else {
-            XCTAssertFalse(UIView().dd.usesDarkMode) // always false prior to iOS 13.x
-            return
-        }
         class MockView: NSObject, DatadogExtended, UITraitEnvironment {
             var traitCollection: UITraitCollection = .init(userInterfaceStyle: .unspecified)
             func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {}

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
@@ -18,7 +18,6 @@ import DatadogInternal
 @Suite(.datadogTesting)
 @MainActor
 struct HeatmapIdentifierComputationTests {
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Uses accessibility identifier as path component when set")
     func accessibilityIdentifierComponent() {
         // Given
@@ -47,7 +46,6 @@ struct HeatmapIdentifierComputationTests {
         #expect(nodes.first?.heatmapIdentifier == expected)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Uses cls:ClassName#typeIndex when accessibility identifier is not set")
     func classNameComponent() {
         // Given
@@ -75,7 +73,6 @@ struct HeatmapIdentifierComputationTests {
         #expect(nodes.first?.heatmapIdentifier == expected)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Computes correct type indices for same-type siblings")
     func sameTypeSiblingTypeIndices() {
         // Given
@@ -127,7 +124,6 @@ struct HeatmapIdentifierComputationTests {
         #expect(firstButtonIdentifier != secondButtonIdentifier)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Populates heatmap cache during traversal")
     func registryPopulation() {
         // Given
@@ -157,7 +153,6 @@ struct HeatmapIdentifierComputationTests {
         #expect(heatmapCache.identifiers[ObjectIdentifier(parent)] != heatmapCache.identifiers[ObjectIdentifier(child)])
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips heatmap cache write for views that produce no rendered nodes")
     func skipsCacheForViewsWithEmptySemantics() {
         // Given
@@ -185,7 +180,6 @@ struct HeatmapIdentifierComputationTests {
         #expect(heatmapCache.identifiers[ObjectIdentifier(child)] != nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips heatmap computation when viewPath is nil")
     func noViewPath() {
         // Given
@@ -210,7 +204,6 @@ struct HeatmapIdentifierComputationTests {
         #expect(heatmapCache.identifiers.isEmpty)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Wireframes carry permanentId from their node")
     func wireframePermanentId() {
         // Given
@@ -246,7 +239,6 @@ struct HeatmapIdentifierComputationTests {
         #expect(permanentId == "abc123")
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Skips heatmap computation when heatmapCache is nil")
     func heatmapsDisabled() {
         // Given
@@ -269,7 +261,6 @@ struct HeatmapIdentifierComputationTests {
         #expect(nodes.first?.heatmapIdentifier == nil)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     @Test("Wireframes have nil permanentId when no heatmap identifier")
     func wireframeNoPermanentId() {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/EmbeddedContentViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/EmbeddedContentViewRecorderTests.swift
@@ -18,7 +18,6 @@ import UIKit
 @Suite(.datadogTesting)
 @MainActor
 struct EmbeddedContentViewRecorderTests {
-    @available(iOS 13.0, *)
     @Test("Leaves views without a slot ID to other recorders")
     func viewsWithoutSlotIDAreNotRecorded() {
         // Given
@@ -38,7 +37,6 @@ struct EmbeddedContentViewRecorderTests {
         #expect(context.embeddedContentViewCache.count == 0)
     }
 
-    @available(iOS 13.0, *)
     @Test("Uses the opaque slot ID independently from the generated wireframe ID")
     func embeddedContentViewsUseIndependentSlotAndWireframeIDs() throws {
         // Given
@@ -82,7 +80,6 @@ struct EmbeddedContentViewRecorderTests {
         }
     }
 
-    @available(iOS 13.0, *)
     @Test("Stops traversal below embedded content views")
     func embeddedContentViewSubtreesAreIgnored() {
         // Given
@@ -107,7 +104,6 @@ struct EmbeddedContentViewRecorderTests {
         #expect(fallbackRecorder.queriedViews.isEmpty)
     }
 
-    @available(iOS 13.0, *)
     @Test("Uses the native hidden placeholder without discarding a previously recorded embedded slot")
     func hiddenEmbeddedContentViewsUseNativePlaceholderAndKeepCachedSlot() throws {
         // Given
@@ -148,7 +144,6 @@ struct EmbeddedContentViewRecorderTests {
         )
     }
 
-    @available(iOS 13.0, *)
     @Test("Produces no visible wireframe for invisible embedded content views")
     func invisibleEmbeddedContentViewsProduceNoVisibleWireframe() throws {
         // Given
@@ -180,7 +175,6 @@ struct EmbeddedContentViewRecorderTests {
         )
     }
 
-    @available(iOS 13.0, *)
     @Test("Keeps slots independent for multiple embedded content views")
     func embeddedContentViewsKeepIndependentSlots() throws {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ColorReflectionTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ColorReflectionTests.swift
@@ -11,7 +11,6 @@ import CoreGraphics
 import SwiftUI
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 class ColorReflectionTests: XCTestCase {
     func testColorResolvedReflection() throws {
         let color: SwiftUI.Color._Resolved = .mockRandom()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayListReflectionTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/DisplayListReflectionTests.swift
@@ -11,7 +11,6 @@ import DatadogInternal
 import TestUtilities
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 class DisplayListReflectionTests: XCTestCase {
     // MARK: Text
     func testDisplayList_withTextContent() throws {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicImagePrivacyTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicImagePrivacyTests.swift
@@ -10,7 +10,6 @@ import TestUtilities
 import XCTest
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 class ImagePrivacyTests: XCTestCase {
     func testShouldRecordImagePredicate() {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImageReflectionTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/GraphicsImageReflectionTests.swift
@@ -12,7 +12,6 @@ import SwiftUI
 import TestUtilities
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 class GraphicsImageReflectionTests: XCTestCase {
     // MARK: Object Behavior tests
     func testGraphicsImageContentsEquality() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ImageRendererTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ImageRendererTests.swift
@@ -12,7 +12,6 @@ import UIKit
 @testable import TestUtilities
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 final class ImageRendererTests: XCTestCase {
     func testCacheHitReturnsCachedImage() {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResourceBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/ShapeResourceBuilderTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import SwiftUI
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 final class ShapeResourceBuilderTests: XCTestCase {
     private enum Fixtures {
         static let path = SwiftUI.Path {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/SwiftUIWireframesBuilderTests.swift
@@ -15,7 +15,6 @@ import TestUtilities
 @testable import DatadogSessionReplay
 @testable import DatadogInternal
 
-@available(iOS 13.0, tvOS 13.0, *)
 class SwiftUIWireframesBuilderTests: XCTestCase {
     func testDisplayListWithUnknownContent_itReturnsAPlaceholder() throws {
         // Given

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/TextReflectionTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/SwiftUI/TextReflectionTests.swift
@@ -11,7 +11,6 @@ import CoreGraphics
 import SwiftUI
 @testable import DatadogSessionReplay
 
-@available(iOS 13.0, tvOS 13.0, *)
 class TextReflectionTests: XCTestCase {
     func testStyledTextContentViewReflection() throws {
         let styledTextContent: StyledTextContentView = .mockRandom()

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIHostingViewRecorderTests.swift
@@ -12,7 +12,6 @@ import SwiftUI
 @_spi(Internal)
 @testable import TestUtilities
 
-@available(iOS 13.0, tvOS 13.0, *)
 class UIHostingViewRecorderTests: XCTestCase {
     private enum Constants {
         static let bundledImageName = "dd_logo"
@@ -256,7 +255,6 @@ class UIHostingViewRecorderTests: XCTestCase {
 ///   - attributes: Optional host view attributes.
 ///   - context: Optional host view context.
 /// - Returns: The SessionReplay wireframes representing the view.
-@available(iOS 13.0, tvOS 13.0, *)
 private func render<V>(
     _ view: V,
     size: CGSize = CGSize(width: 300, height: 300),
@@ -279,7 +277,6 @@ private func render<V>(
     return wireframes
 }
 
-@available(iOS 13.0, *)
 private struct MockImageView: View {
     static let bundle = Bundle(for: UIHostingViewRecorderTests.self)
     let imageName: String
@@ -293,7 +290,6 @@ private struct MockImageView: View {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, *)
 private struct MockTextView: View {
     var body: some View {
         Text("Hello, World!")

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResourceTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageResourceTests.swift
@@ -36,7 +36,6 @@ final class UIImageResourceTests: XCTestCase {
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
-    @available(iOS 13.0, *)
     func testWhenUIImageResourceIsInitializedWithSystemIconWithoutTintColor() {
         let image = UIImage(systemName: "circle.fill")!
         let imageResource = UIImageResource(image: image, tintColor: nil)
@@ -45,7 +44,6 @@ final class UIImageResourceTests: XCTestCase {
         XCTAssertGreaterThan(imageResource.calculateData().count, 0)
     }
 
-    @available(iOS 13.0, *)
     func testWhenUIImageResourceIsInitializedWithSystemIconWithTintColor() {
         let image = UIImage(systemName: "circle.fill")!
         let tintColor = UIColor.red

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -136,9 +136,7 @@ class UIImageViewRecorderTests: XCTestCase {
 
         // When
         let recorder = UIImageViewRecorder(identifier: UUID())
-        if #available(iOS 13.0, *) {
-            imageView.image = UIImage(systemName: "star")
-        }
+        imageView.image = UIImage(systemName: "star")
         viewAttributes = .mock(fixture: .visible())
 
         // Then

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -28,9 +28,7 @@ class UISegmentRecorderTests: XCTestCase {
     func testWhenSegmentIsVisible() throws {
         // Given
         segment.selectedSegmentIndex = 2
-        if #available(iOS 13.0, *) {
-            segment.selectedSegmentTintColor = .mockRandom()
-        }
+        segment.selectedSegmentTintColor = .mockRandom()
 
         // When
         viewAttributes = .mock(fixture: .visible(.someAppearance))
@@ -44,9 +42,7 @@ class UISegmentRecorderTests: XCTestCase {
         XCTAssertEqual(builder.attributes, viewAttributes)
         XCTAssertEqual(builder.segmentTitles, ["first", "second", "third"])
         XCTAssertEqual(builder.selectedSegmentIndex, 2)
-        if #available(iOS 13.0, *) {
-            XCTAssertEqual(builder.selectedSegmentTintColor, segment.selectedSegmentTintColor)
-        }
+        XCTAssertEqual(builder.selectedSegmentTintColor, segment.selectedSegmentTintColor)
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -15,7 +15,6 @@ import TestUtilities
 @testable import DatadogSessionReplay
 @testable import DatadogInternal
 
-@available(iOS 13.0, *)
 class UnsupportedViewRecorderTests: XCTestCase {
     func testWhenViewIsUnsupportedViewControllersRootView() throws {
         let recorder = UnsupportedViewRecorder(identifier: UUID(), featureFlags: .defaults)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -299,23 +299,21 @@ class ViewTreeRecorderTests: XCTestCase {
         XCTAssertEqual(context?.viewControllerContext.isRootView, false)
         XCTAssertEqual(context?.viewControllerContext.parentType, .activity)
 
-        if #available(iOS 13, *) {
-            // Given
-            let swiftUI = UIHostingController(rootView: EmptyView())
-            swiftUI.view.addSubview(subview)
-            window.rootViewController?.present(swiftUI, animated: false)
+        // Given
+        let swiftUI = UIHostingController(rootView: EmptyView())
+        swiftUI.view.addSubview(subview)
+        window.rootViewController?.present(swiftUI, animated: false)
 
-            // When
-            _ = recorder.record(swiftUI.view, in: .mockRandom())
+        // When
+        _ = recorder.record(swiftUI.view, in: .mockRandom())
 
-            context = nodeRecorder.queryContextsByView[swiftUI.view]
-            XCTAssertEqual(context?.viewControllerContext.isRootView, true)
-            XCTAssertEqual(context?.viewControllerContext.parentType, .swiftUI)
+        context = nodeRecorder.queryContextsByView[swiftUI.view]
+        XCTAssertEqual(context?.viewControllerContext.isRootView, true)
+        XCTAssertEqual(context?.viewControllerContext.parentType, .swiftUI)
 
-            context = nodeRecorder.queryContextsByView[subview]
-            XCTAssertEqual(context?.viewControllerContext.isRootView, false)
-            XCTAssertEqual(context?.viewControllerContext.parentType, .swiftUI)
-        }
+        context = nodeRecorder.queryContextsByView[subview]
+        XCTAssertEqual(context?.viewControllerContext.isRootView, false)
+        XCTAssertEqual(context?.viewControllerContext.parentType, .swiftUI)
 
         window.rootViewController?.dismiss(animated: false)
     }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContextTests.swift
@@ -13,7 +13,6 @@ import SwiftUI
 @testable import DatadogSessionReplay
 
 class ViewTreeRecordingContextTests: XCTestCase {
-    @available(iOS 13, tvOS 13, *)
     func testViewControllerTypeInit() {
         let alertVC = UIAlertController()
         let activityVC = UIActivityViewController(activityItems: [], applicationActivities: nil)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -161,7 +161,6 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         XCTAssertTrue(registry.identifiers.isEmpty)
     }
 
-    @available(iOS 13.0, *)
     func testSnapshotIncludesEveryEmbeddedContentSlot() {
         // Given
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
@@ -185,7 +184,6 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         XCTAssertEqual(snapshot.embeddedContentSlots.count, 2)
     }
 
-    @available(iOS 13.0, *)
     func testWhenUIKitViewHasSessionReplaySlotID_itIsRecordedAsEmbeddedContent() {
         // Given
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
@@ -208,7 +206,6 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         XCTAssertFalse(snapshot.nodes.contains { $0.wireframesBuilder is UILabelWireframesBuilder })
     }
 
-    @available(iOS 13.0, *)
     func testDetachedEmbeddedContentViewRemainsCachedWhileAlive() {
         // Given
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
@@ -231,7 +228,6 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         withExtendedLifetime(embeddedContentView) {}
     }
 
-    @available(iOS 13.0, *)
     func testSnapshotExcludesDeallocatedEmbeddedContentViews() {
         // Given
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))

--- a/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayConfigurationTests.swift
@@ -30,7 +30,6 @@ class SessionReplayConfigurationTests: XCTestCase {
         XCTAssertEqual(config._additionalNodeRecorders.count, 0)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     func testDefaultConfigurationDisablesCompositionTreeRecordingFeatureFlag() {
         // When
         let config = SessionReplay.Configuration()

--- a/DatadogSessionReplay/Tests/SessionReplayTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayTests.swift
@@ -142,7 +142,6 @@ class SessionReplayTests: XCTestCase {
         XCTAssertEqual(config.startRecordingManually, !startRecordingImmediately)
     }
 
-    @available(iOS 13.0, tvOS 13.0, *)
     func testWhenEnabled_itUpdatesCoreContextWithEnabledFeatureFlags() throws {
         let core = PassthroughCoreMock()
         config.featureFlags[.swiftui] = true
@@ -196,7 +195,6 @@ class SessionReplayTests: XCTestCase {
         XCTAssertEqual(sr.recordingCoordinator.replaySampleRate, random)
     }
 
-    @available(iOS 13.0, *)
     func testWhenEnabledWithCompositionTreeRecordingFeatureFlag_itUsesLayerTreeRecordingCoordinator() throws {
         // Given
         config.featureFlags[.compositionTreeRecording] = true


### PR DESCRIPTION
### What and why?

Removes @available/#available checks that are now dead following the minimum deployment target bump in #3155 (iOS 15.0 / tvOS 15.0 / watchOS 9.0). Part of the RUM-16719 cleanup, split per module.

### How?

Deletes availability branches whose guarded platform versions are all ≤ the new floors, keeping only the code path that is now always available. No behavior change.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs