### PR TITLE
RUM-3851 Return nil carrier info on iOS 16+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled. See [#3136][]
+- [IMPROVEMENT] Return `nil` carrier info on iOS 16+ since `CTCarrier` is deprecated with no replacement. See [#3164][]
 
 # 3.16.0 / 19-08-2026
 
@@ -1232,6 +1233,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3097]: https://github.com/DataDog/dd-sdk-ios/pull/3097
 [#3134]: https://github.com/DataDog/dd-sdk-ios/pull/3134
 [#3136]: https://github.com/DataDog/dd-sdk-ios/pull/3136
+[#3164]: https://github.com/DataDog/dd-sdk-ios/pull/3164
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogCore/Sources/Core/Context/CarrierInfoPublisher.swift
+++ b/DatadogCore/Sources/Core/Context/CarrierInfoPublisher.swift
@@ -19,19 +19,33 @@ internal struct CarrierInfoPublisher: ContextValuePublisher {
 
     init(networkInfo: CTTelephonyNetworkInfo = .init()) {
         self.networkInfo = networkInfo
-        self.initialValue = CarrierInfo(networkInfo, service: networkInfo.serviceCurrentRadioAccessTechnology?.keys.first)
+
+        guard #available(iOS 16, *) else {
+            self.initialValue = CarrierInfo(networkInfo, service: networkInfo.serviceCurrentRadioAccessTechnology?.keys.first)
+            return
+        }
+
+        // `CTCarrier` and related APIs are deprecated in iOS 16 with no replacement. Apple confirmed
+        // they always return placeholder ("--") or empty values from iOS 16 onward, so there is nothing
+        // meaningful left to report. ref.: https://forums.developer.apple.com/forums/thread/714876
+        self.initialValue = nil
     }
 
     func publish(to receiver: @escaping ContextValueReceiver<CarrierInfo?>) {
-        // The `serviceSubscriberCellularProvidersDidUpdateNotifier` block object executes on the default priority
-        // global dispatch queue when the user’s cellular provider information changes.
-        // This occurs, for example, if a user swaps the device’s SIM card with one from another provider, while the app is running.
-        // ref.: https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024512-servicesubscribercellularprovide
-        networkInfo.serviceSubscriberCellularProvidersDidUpdateNotifier = { key in
-            // On iOS12+ `CarrierInfo` subscribers are notified on actual change to cellular provider.
-            let info = CarrierInfo(self.networkInfo, service: key)
-            receiver(info)
+        guard #available(iOS 16, *) else {
+            // The `serviceSubscriberCellularProvidersDidUpdateNotifier` block object executes on the default priority
+            // global dispatch queue when the user’s cellular provider information changes.
+            // This occurs, for example, if a user swaps the device’s SIM card with one from another provider, while the app is running.
+            // ref.: https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024512-servicesubscribercellularprovide
+            networkInfo.serviceSubscriberCellularProvidersDidUpdateNotifier = { key in
+                // On iOS12+ `CarrierInfo` subscribers are notified on actual change to cellular provider.
+                let info = CarrierInfo(self.networkInfo, service: key)
+                receiver(info)
+            }
+            return
         }
+
+        // Nothing meaningful to subscribe to on iOS 16+ — `initialValue` (`nil`) is final.
     }
 
     func cancel() {

--- a/DatadogCore/Sources/Core/Context/CarrierInfoPublisher.swift
+++ b/DatadogCore/Sources/Core/Context/CarrierInfoPublisher.swift
@@ -44,8 +44,6 @@ internal struct CarrierInfoPublisher: ContextValuePublisher {
             }
             return
         }
-
-        // Nothing meaningful to subscribe to on iOS 16+ — `initialValue` (`nil`) is final.
     }
 
     func cancel() {

--- a/DatadogCore/Tests/Datadog/DatadogCore/Context/CarrierInfoPublisherTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/Context/CarrierInfoPublisherTests.swift
@@ -25,7 +25,16 @@ class CarrierInfoPublisherTests: XCTestCase {
         serviceSubscriberCellularProviders: [:]
     )
 
-    func testGivenCellularServiceAvailable_itProvidesInitialValue() {
+    private var isIOS16OrAbove: Bool {
+        if #available(iOS 16, *) {
+            return true
+        }
+        return false
+    }
+
+    func testGivenCellularServiceAvailable_itProvidesInitialValue() throws {
+        try XCTSkipIf(isIOS16OrAbove, "`CarrierInfo` is always nil on iOS 16+ — see testGivenIOS16OrAbove_itProvidesNoInitialValue")
+
         // Given
         let publisher = CarrierInfoPublisher(networkInfo: availableCTTelephonyNetworkInfo)
 
@@ -35,7 +44,9 @@ class CarrierInfoPublisherTests: XCTestCase {
         XCTAssertEqual(publisher.initialValue?.carrierAllowsVOIP, true)
     }
 
-    func testGivenCellularServiceUnAvailable_itProvidesNoInitialValue() {
+    func testGivenCellularServiceUnAvailable_itProvidesNoInitialValue() throws {
+        try XCTSkipIf(isIOS16OrAbove, "`CarrierInfo` is always nil on iOS 16+ — see testGivenIOS16OrAbove_itProvidesNoInitialValue")
+
         // Given
         let publisher = CarrierInfoPublisher(networkInfo: unavailableCTTelephonyNetworkInfo)
 
@@ -44,6 +55,8 @@ class CarrierInfoPublisherTests: XCTestCase {
     }
 
     func testGivenSubscribedInfoProvider_whenCarrierInfoChanges_itNotifiesSubscriber() throws {
+        try XCTSkipIf(isIOS16OrAbove, "`CarrierInfo` is always nil on iOS 16+ — see testGivenIOS16OrAbove_itNeverNotifiesSubscriber")
+
         let expectation = expectation(description: "Notify `CarrierInfo` change")
         var info: CarrierInfo? = nil
         let publisher = CarrierInfoPublisher(networkInfo: availableCTTelephonyNetworkInfo)
@@ -74,6 +87,37 @@ class CarrierInfoPublisherTests: XCTestCase {
         XCTAssertEqual(info?.carrierISOCountryCode, newISOCountryCode)
         XCTAssertEqual(info?.carrierAllowsVOIP, newAllowsVOIP)
         XCTAssertEqual(info?.radioAccessTechnology, .init(newRadioAccessTechnology))
+    }
+
+    func testGivenIOS16OrAbove_itProvidesNoInitialValue() throws {
+        try XCTSkipIf(!isIOS16OrAbove, "This behavior only applies from iOS 16 onward")
+
+        // Given
+        let publisher = CarrierInfoPublisher(networkInfo: availableCTTelephonyNetworkInfo)
+
+        // Then
+        XCTAssertNil(publisher.initialValue, "`CarrierInfo` must be nil on iOS 16+ since `CTCarrier` is deprecated with no replacement")
+    }
+
+    func testGivenIOS16OrAbove_itNeverNotifiesSubscriber() throws {
+        try XCTSkipIf(!isIOS16OrAbove, "This behavior only applies from iOS 16 onward")
+
+        var receivedUpdate = false
+        let publisher = CarrierInfoPublisher(networkInfo: availableCTTelephonyNetworkInfo)
+
+        // Given
+        publisher.publish { _ in receivedUpdate = true }
+
+        // When
+        availableCTTelephonyNetworkInfo.changeCarrier(
+            newCarrierName: .mockRandom(),
+            newISOCountryCode: .mockRandom(),
+            newAllowsVOIP: .mockRandom(),
+            newRadioAccessTechnology: CTRadioAccessTechnologyLTE
+        )
+
+        // Then
+        XCTAssertFalse(receivedUpdate, "No update should be received on iOS 16+ as there is no subscription set up")
     }
 
     func testDifferentCarrierInfoRadioAccessTechnologies() {

--- a/DatadogInternal/Sources/Context/CarrierInfo.swift
+++ b/DatadogInternal/Sources/Context/CarrierInfo.swift
@@ -7,6 +7,11 @@
 import Foundation
 
 /// Carrier details specific to cellular radio access.
+///
+/// - Note: Only available on iOS versions below 16. Apple deprecated the underlying Core Telephony
+///   APIs (`CTCarrier`) in iOS 16 with no replacement and confirmed they always return placeholder
+///   ("--") or empty values from that version onward, so `CarrierInfo` is never published on iOS 16+.
+///   ref.: https://forums.developer.apple.com/forums/thread/714876
 public struct CarrierInfo: Codable, Equatable {
     // swiftlint:disable identifier_name
     public enum RadioAccessTechnology: String, Codable, CaseIterable {

--- a/DatadogInternal/Sources/Context/CarrierInfo.swift
+++ b/DatadogInternal/Sources/Context/CarrierInfo.swift
@@ -8,9 +8,10 @@ import Foundation
 
 /// Carrier details specific to cellular radio access.
 ///
-/// - Note: Only available on iOS versions below 16. Apple deprecated the underlying Core Telephony
-///   APIs (`CTCarrier`) in iOS 16 with no replacement and confirmed they always return placeholder
-///   ("--") or empty values from that version onward, so `CarrierInfo` is never published on iOS 16+.
+/// - Note: Automatically collected only on iOS versions below 16. Apple deprecated the underlying
+///   Core Telephony APIs (`CTCarrier`) in iOS 16 with no replacement and confirmed they always return
+///   placeholder ("--") or empty values from that version onward, so `CarrierInfoPublisher` never
+///   publishes a non-nil `CarrierInfo` on iOS 16+.
 ///   ref.: https://forums.developer.apple.com/forums/thread/714876
 public struct CarrierInfo: Codable, Equatable {
     // swiftlint:disable identifier_name

--- a/DatadogLogs/LOGS_FEATURE.md
+++ b/DatadogLogs/LOGS_FEATURE.md
@@ -161,7 +161,7 @@ logger.error(
 ### Logger Enrichment
 - **Service**: `service` (default: SDK service value) — overrides `service` on log events.
 - **Logger name**: `name` — reported as `logger.name` on log events.
-- **Network info**: `networkInfoEnabled` (default: `false`) — attaches reachability, connection type, mobile carrier to every log.
+- **Network info**: `networkInfoEnabled` (default: `false`) — attaches reachability, connection type, mobile carrier to every log. Mobile carrier info is only available on iOS versions below 16, since Apple deprecated the required Core Telephony APIs (`CTCarrier`) without a replacement.
 - **RUM bundling**: `bundleWithRumEnabled` (default: `true`) — attaches `application_id`, `session_id`, `view.id`, `user_action.id` when a sampled-in RUM session is active.
 - **Trace bundling**: `bundleWithTraceEnabled` (default: `true`) — attaches `dd.trace_id` and `dd.span_id` when a Datadog span is active (via `span.setActive()` from `Tracer.shared()`). OTel spans activated through `withActiveSpan` do not propagate through this path.
 

--- a/DatadogTrace/TRACE_FEATURE.md
+++ b/DatadogTrace/TRACE_FEATURE.md
@@ -245,7 +245,7 @@ Set `urlSessionTracking` to connect Trace to the shared automatic `URLSession` n
 - **Service**: `service` (default: SDK service value) — overrides the `service.name` tag.
 - **Global tags**: `tags: [String: OTTagValue]?` — applied to every span from the default tracer. `OTTagValue` is `Encodable & Sendable`; any custom tag type must conform to both.
 - **RUM bundling**: `bundleWithRumEnabled` (default: `true`) — adds `_dd.application.id`, `_dd.session.id`, `_dd.view.id`, `_dd.action.id` tags only when a RUM context exists and the RUM session is sampled in. Trace spans from sampled-out RUM sessions can still be sent according to Trace sampling, but they are not linked to RUM.
-- **Network info**: `networkInfoEnabled` (default: `false`) — adds reachability, connection type, mobile carrier, etc. to every span and span log.
+- **Network info**: `networkInfoEnabled` (default: `false`) — adds reachability, connection type, mobile carrier, etc. to every span and span log. Mobile carrier info is only available on iOS versions below 16, since Apple deprecated the required Core Telephony APIs (`CTCarrier`) without a replacement.
 
 ### Event Modification
 - **`eventMapper`** — `@Sendable (SpanEvent) -> SpanEvent`. Modify spans before upload (e.g. scrub sensitive data, override tags). Cannot drop spans — must return an event. Runs on a background thread; keep it fast and `Sendable`-safe.


### PR DESCRIPTION
### What and why?

`CTCarrier` and related Core Telephony APIs (`carrierName`, `isoCountryCode`, `allowsVOIP`, `serviceSubscriberCellularProviders`) are deprecated starting iOS 16 with no replacement. Apple confirmed ([forum thread](https://forums.developer.apple.com/forums/thread/714876)) they now always return `"--"`/empty values, so on org2 99% of `carrierName` values were already meaningless `"--"`. 
This PR makes `CarrierInfoPublisher` return `nil` on iOS 16+ instead of publishing garbage data, while keeping the existing collection behavior for iOS <16.


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs — N/A, no new public API surface
- [ ] Run `make api-surface` when adding new APIs — N/A, no API surface change (still `CarrierInfo?`)

RUM-3851