### PR TITLE
RUM-8099 Support view instrumentation types for cross-platform SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [FEATURE] Add `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled. See [#3136][]
+- [IMPROVEMENT] Report cross-platform-specific instrumentation types (Flutter, React Native, Unity, Kotlin Multiplatform) for RUM views in SDK telemetry. See [#3165][]
 
 # 3.16.0 / 19-08-2026
 
@@ -1232,6 +1233,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3097]: https://github.com/DataDog/dd-sdk-ios/pull/3097
 [#3134]: https://github.com/DataDog/dd-sdk-ios/pull/3134
 [#3136]: https://github.com/DataDog/dd-sdk-ios/pull/3136
+[#3165]: https://github.com/DataDog/dd-sdk-ios/pull/3165
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMViewEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMViewEndedMetricIntegrationTests.swift
@@ -108,7 +108,7 @@ class RUMViewEndedMetricIntegrationTests: XCTestCase {
         // Then
         let metrics = try XCTUnwrap(core.waitAndReturnViewEndedMetricEvents())
         XCTAssertEqual(metrics.count, 2)
-        XCTAssertEqual(metrics[1].attributes?.instrumentationType, .flutter)
+        XCTAssertEqual(metrics[1].attributes?.instrumentationType, .crossPlatform("flutter"))
     }
 
     func testReportingTNSValue() throws {

--- a/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMViewEndedMetricIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/SDKMetrics/RUMViewEndedMetricIntegrationTests.swift
@@ -95,6 +95,22 @@ class RUMViewEndedMetricIntegrationTests: XCTestCase {
         XCTAssertEqual(metrics[1].attributes?.duration.nanosecondsToSeconds, 3)
     }
 
+    func testReportingInstrumentationTypeForCrossPlatformView() throws {
+        RUM.enable(with: rumConfig, in: core)
+
+        // Given
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(key: "key1", name: "View1", attributes: [CrossPlatformAttributes.instrumentationType: "flutter"])
+        monitor.startView(key: "key2", name: "View2")
+
+        // Then
+        let metrics = try XCTUnwrap(core.waitAndReturnViewEndedMetricEvents())
+        XCTAssertEqual(metrics.count, 2)
+        XCTAssertEqual(metrics[1].attributes?.instrumentationType, .flutter)
+    }
+
     func testReportingTNSValue() throws {
         rumConfig.networkSettledResourcePredicate = TimeBasedTNSResourcePredicate(threshold: 2)
         RUM.enable(with: rumConfig, in: core)

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -183,6 +183,11 @@ public struct CrossPlatformAttributes {
     /// Indicates whether the resource was served from the device's local cache, captured from native URLSession interception.
     /// Expects `Bool` value.
     public static let localCacheHit = "_dd.local_cache_hit"
+
+    /// Instrumentation type passed from a CP SDK to identify which cross-platform framework started this view (e.g. `"flutter"`, `"react-native"`).
+    /// Used internally to report a more specific instrumentation type in "RUM Session Ended" / "RUM View Ended" SDK telemetry.
+    /// Expects `String` value.
+    public static let instrumentationType = "_dd.instrumentation_type"
 }
 
 /// HTTP header names used to pass GraphQL metadata from the application to the SDK.

--- a/DatadogInternal/Sources/Attributes/Attributes.swift
+++ b/DatadogInternal/Sources/Attributes/Attributes.swift
@@ -185,7 +185,6 @@ public struct CrossPlatformAttributes {
     public static let localCacheHit = "_dd.local_cache_hit"
 
     /// Instrumentation type passed from a CP SDK to identify which cross-platform framework started this view (e.g. `"flutter"`, `"react-native"`).
-    /// Used internally to report a more specific instrumentation type in "RUM Session Ended" / "RUM View Ended" SDK telemetry.
     /// Expects `String` value.
     public static let instrumentationType = "_dd.instrumentation_type"
 }

--- a/DatadogRUM/Sources/Instrumentation/RUMCommandSubscriber.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMCommandSubscriber.swift
@@ -30,7 +30,7 @@ internal protocol RUMCommandPublisher: AnyObject {
 }
 
 /// Represents the type of instrumentation used to create different RUM commands.
-internal enum InstrumentationType: Int {
+internal enum InstrumentationType: Equatable {
     /// Command issued through UIKit predicate-based instrumentation.
     case uikit
     /// Command issued through SwiftUI predicate-based instrumentation.
@@ -39,18 +39,22 @@ internal enum InstrumentationType: Int {
     case swiftui
     /// Command issued through manual instrumentation, originating from the `RUMMonitor` API.
     case manual
-    /// Command issued through a Flutter-originated view, resolved from the `_dd.instrumentation_type` cross-platform attribute.
-    case flutter
-    /// Command issued through a React Native-originated view, resolved from the `_dd.instrumentation_type` cross-platform attribute.
-    case reactNative
-    /// Command issued through a Unity-originated view, resolved from the `_dd.instrumentation_type` cross-platform attribute.
-    case unity
-    /// Command issued through a Kotlin Multiplatform-originated view, resolved from the `_dd.instrumentation_type` cross-platform attribute.
-    case kotlinMultiplatform
+    /// Command issued through a cross-platform SDK-originated view (e.g. Flutter, React Native, Unity, Kotlin Multiplatform),
+    /// resolved from the `_dd.instrumentation_type` cross-platform attribute. The associated value is the raw string reported
+    /// by the cross-platform SDK, forwarded verbatim - any non-empty value is accepted, there is no fixed set of recognized values.
+    case crossPlatform(String)
 
     /// The priority of this instrumentation. Higher values take precedence, allowing actions from one type to overwrite those
     /// from a lower-priority type (e.g., a SwiftUI button tap takes precedence over the touch on its containing UIKit table view cell).
-    var priority: Int { rawValue }
+    var priority: Int {
+        switch self {
+        case .uikit: return 0
+        case .swiftuiAutomatic: return 1
+        case .swiftui: return 2
+        case .manual: return 3
+        case .crossPlatform: return 4
+        }
+    }
 }
 
 internal extension InstrumentationType {
@@ -58,18 +62,16 @@ internal extension InstrumentationType {
     /// `attributes` so it never leaks into customer-visible view attributes.
     ///
     /// - Parameter attributes: The attributes to extract the value from.
-    /// - Returns: The resolved `InstrumentationType`, or `nil` if the attribute is missing or holds an unrecognized value.
+    /// - Returns: The resolved `InstrumentationType`, or `nil` if the attribute is missing or empty.
     static func extract(from attributes: inout [AttributeKey: AttributeValue]) -> InstrumentationType? {
         let rawValue: String? = attributes
             .removeValue(forKey: CrossPlatformAttributes.instrumentationType)?
             .dd.decode()
 
-        switch rawValue {
-        case "flutter": return .flutter
-        case "react-native": return .reactNative
-        case "unity": return .unity
-        case "kotlin-multiplatform": return .kotlinMultiplatform
-        default: return nil
+        guard let rawValue = rawValue, !rawValue.isEmpty else {
+            return nil
         }
+
+        return .crossPlatform(rawValue)
     }
 }

--- a/DatadogRUM/Sources/Instrumentation/RUMCommandSubscriber.swift
+++ b/DatadogRUM/Sources/Instrumentation/RUMCommandSubscriber.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 /// The Command Subscriber is able to process RUM Commands.
 ///
@@ -38,8 +39,37 @@ internal enum InstrumentationType: Int {
     case swiftui
     /// Command issued through manual instrumentation, originating from the `RUMMonitor` API.
     case manual
+    /// Command issued through a Flutter-originated view, resolved from the `_dd.instrumentation_type` cross-platform attribute.
+    case flutter
+    /// Command issued through a React Native-originated view, resolved from the `_dd.instrumentation_type` cross-platform attribute.
+    case reactNative
+    /// Command issued through a Unity-originated view, resolved from the `_dd.instrumentation_type` cross-platform attribute.
+    case unity
+    /// Command issued through a Kotlin Multiplatform-originated view, resolved from the `_dd.instrumentation_type` cross-platform attribute.
+    case kotlinMultiplatform
 
     /// The priority of this instrumentation. Higher values take precedence, allowing actions from one type to overwrite those
     /// from a lower-priority type (e.g., a SwiftUI button tap takes precedence over the touch on its containing UIKit table view cell).
     var priority: Int { rawValue }
+}
+
+internal extension InstrumentationType {
+    /// Extracts the cross-platform instrumentation type from the `_dd.instrumentation_type` attribute, removing it from
+    /// `attributes` so it never leaks into customer-visible view attributes.
+    ///
+    /// - Parameter attributes: The attributes to extract the value from.
+    /// - Returns: The resolved `InstrumentationType`, or `nil` if the attribute is missing or holds an unrecognized value.
+    static func extract(from attributes: inout [AttributeKey: AttributeValue]) -> InstrumentationType? {
+        let rawValue: String? = attributes
+            .removeValue(forKey: CrossPlatformAttributes.instrumentationType)?
+            .dd.decode()
+
+        switch rawValue {
+        case "flutter": return .flutter
+        case "react-native": return .reactNative
+        case "unity": return .unity
+        case "kotlin-multiplatform": return .kotlinMultiplatform
+        default: return nil
+        }
+    }
 }

--- a/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
+++ b/DatadogRUM/Sources/RUMMonitor/RUMCommand.swift
@@ -199,7 +199,7 @@ internal struct RUMStartViewCommand: RUMCommand {
         self.identity = identity
         self.name = name
         self.path = path
-        self.instrumentationType = instrumentationType
+        self.instrumentationType = InstrumentationType.extract(from: &self.attributes) ?? instrumentationType
     }
 }
 

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -604,16 +604,18 @@ private extension Int64 {
 }
 
 extension InstrumentationType: Encodable {
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(metricKey)
+    }
+
     var metricKey: String {
         switch self {
         case .uikit: return "uikit"
         case .swiftuiAutomatic: return "swiftuiAutomatic"
         case .swiftui: return "swiftui"
         case .manual: return "manual"
-        case .flutter: return "flutter"
-        case .reactNative: return "react-native"
-        case .unity: return "unity"
-        case .kotlinMultiplatform: return "kotlin-multiplatform"
+        case .crossPlatform(let value): return value
         }
     }
 }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -610,6 +610,10 @@ extension InstrumentationType: Encodable {
         case .swiftuiAutomatic: return "swiftuiAutomatic"
         case .swiftui: return "swiftui"
         case .manual: return "manual"
+        case .flutter: return "flutter"
+        case .reactNative: return "react-native"
+        case .unity: return "unity"
+        case .kotlinMultiplatform: return "kotlin-multiplatform"
         }
     }
 }

--- a/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
+++ b/DatadogRUM/Sources/SDKMetrics/SessionEndedMetric.swift
@@ -604,9 +604,17 @@ private extension Int64 {
 }
 
 extension InstrumentationType: Encodable {
+    /// Native instrumentation types keep encoding as their original `Int` wire values for backward compatibility
+    /// with existing telemetry consumers; only cross-platform types are encoded as their raw string value.
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(metricKey)
+        switch self {
+        case .uikit: try container.encode(0)
+        case .swiftuiAutomatic: try container.encode(1)
+        case .swiftui: try container.encode(2)
+        case .manual: try container.encode(3)
+        case .crossPlatform(let value): try container.encode(value)
+        }
     }
 
     var metricKey: String {

--- a/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
@@ -90,24 +90,16 @@ class RUMCommandTests: XCTestCase {
 
     func testWhenRUMStartViewCommand_isPassedInstrumentationTypeAttribute() {
         let flutter: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "flutter"])
-        XCTAssertEqual(flutter.instrumentationType, .flutter)
+        XCTAssertEqual(flutter.instrumentationType, .crossPlatform("flutter"))
         XCTAssertTrue(flutter.attributes.isEmpty)
 
-        let reactNative: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "react-native"])
-        XCTAssertEqual(reactNative.instrumentationType, .reactNative)
-        XCTAssertTrue(reactNative.attributes.isEmpty)
+        let anyFutureCPSDK: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "some-future-cp-sdk"])
+        XCTAssertEqual(anyFutureCPSDK.instrumentationType, .crossPlatform("some-future-cp-sdk"))
+        XCTAssertTrue(anyFutureCPSDK.attributes.isEmpty)
 
-        let unity: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "unity"])
-        XCTAssertEqual(unity.instrumentationType, .unity)
-        XCTAssertTrue(unity.attributes.isEmpty)
-
-        let kmp: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "kotlin-multiplatform"])
-        XCTAssertEqual(kmp.instrumentationType, .kotlinMultiplatform)
-        XCTAssertTrue(kmp.attributes.isEmpty)
-
-        let unknown: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "some-future-cp-sdk"], instrumentationType: .manual)
-        XCTAssertEqual(unknown.instrumentationType, .manual)
-        XCTAssertTrue(unknown.attributes.isEmpty)
+        let empty: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: ""], instrumentationType: .manual)
+        XCTAssertEqual(empty.instrumentationType, .manual)
+        XCTAssertTrue(empty.attributes.isEmpty)
 
         let missing: RUMStartViewCommand = .mockWith(attributes: [:], instrumentationType: .manual)
         XCTAssertEqual(missing.instrumentationType, .manual)

--- a/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/RUMCommandTests.swift
@@ -88,6 +88,34 @@ class RUMCommandTests: XCTestCase {
         XCTAssertEqual(defaultCommand2.errorSourceType, .ios)
     }
 
+    func testWhenRUMStartViewCommand_isPassedInstrumentationTypeAttribute() {
+        let flutter: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "flutter"])
+        XCTAssertEqual(flutter.instrumentationType, .flutter)
+        XCTAssertTrue(flutter.attributes.isEmpty)
+
+        let reactNative: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "react-native"])
+        XCTAssertEqual(reactNative.instrumentationType, .reactNative)
+        XCTAssertTrue(reactNative.attributes.isEmpty)
+
+        let unity: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "unity"])
+        XCTAssertEqual(unity.instrumentationType, .unity)
+        XCTAssertTrue(unity.attributes.isEmpty)
+
+        let kmp: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "kotlin-multiplatform"])
+        XCTAssertEqual(kmp.instrumentationType, .kotlinMultiplatform)
+        XCTAssertTrue(kmp.attributes.isEmpty)
+
+        let unknown: RUMStartViewCommand = .mockWith(attributes: [CrossPlatformAttributes.instrumentationType: "some-future-cp-sdk"], instrumentationType: .manual)
+        XCTAssertEqual(unknown.instrumentationType, .manual)
+        XCTAssertTrue(unknown.attributes.isEmpty)
+
+        let missing: RUMStartViewCommand = .mockWith(attributes: [:], instrumentationType: .manual)
+        XCTAssertEqual(missing.instrumentationType, .manual)
+
+        let uikit: RUMStartViewCommand = .mockWith(attributes: [:], instrumentationType: .uikit)
+        XCTAssertEqual(uikit.instrumentationType, .uikit)
+    }
+
     func testWhenRUMAddCurrentViewErrorCommand_isPassedErrorIsCrashAttribute() {
         let command1: RUMAddCurrentViewErrorCommand = .mockWithErrorObject(attributes: [CrossPlatformAttributes.errorIsCrash: true])
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2050,10 +2050,7 @@ class RUMViewScopeTests: XCTestCase {
             case .uikit: return "UIKit action"
             case .swiftuiAutomatic: return "Automatic SwiftUI action"
             case .swiftui: return "SwiftUI action"
-            case .flutter: return "Flutter action"
-            case .reactNative: return "React Native action"
-            case .unity: return "Unity action"
-            case .kotlinMultiplatform: return "Kotlin Multiplatform action"
+            case .crossPlatform(let value): return "\(value) action"
             }
         }
 

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -2050,6 +2050,10 @@ class RUMViewScopeTests: XCTestCase {
             case .uikit: return "UIKit action"
             case .swiftuiAutomatic: return "Automatic SwiftUI action"
             case .swiftui: return "SwiftUI action"
+            case .flutter: return "Flutter action"
+            case .reactNative: return "React Native action"
+            case .unity: return "Unity action"
+            case .kotlinMultiplatform: return "Kotlin Multiplatform action"
             }
         }
 

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -322,6 +322,7 @@ class SessionEndedMetricTests: XCTestCase {
         let swiftuiViewsCount: Int = .mockRandom(min: 1, max: 10)
         let uikitPredicateViewsCount: Int = .mockRandom(min: 1, max: 10)
         let swiftuiAutomaticPredicateViewsCount: Int = .mockRandom(min: 1, max: 10)
+        let flutterViewsCount: Int = .mockRandom(min: 1, max: 10)
         let unknownViewsCount: Int = .mockRandom(min: 1, max: 10)
 
         // Given
@@ -340,6 +341,9 @@ class SessionEndedMetricTests: XCTestCase {
         try (0..<swiftuiAutomaticPredicateViewsCount).forEach { idx in
             try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "swiftuiAutomatic\(idx)"), instrumentationType: .swiftuiAutomatic)
         }
+        try (0..<flutterViewsCount).forEach { idx in
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "flutter\(idx)"), instrumentationType: .flutter)
+        }
         try (0..<unknownViewsCount).forEach { idx in
             try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "unknown\(idx)"), instrumentationType: nil)
         }
@@ -347,14 +351,18 @@ class SessionEndedMetricTests: XCTestCase {
 
         // Then
         let rse = try XCTUnwrap(attributes[Constants.rseKey] as? SessionEndedAttributes)
-        XCTAssertEqual(rse.viewsCount.total, manualViewsCount + swiftuiViewsCount + uikitPredicateViewsCount + swiftuiAutomaticPredicateViewsCount + unknownViewsCount)
+        XCTAssertEqual(
+            rse.viewsCount.total,
+            manualViewsCount + swiftuiViewsCount + uikitPredicateViewsCount + swiftuiAutomaticPredicateViewsCount + flutterViewsCount + unknownViewsCount
+        )
         XCTAssertEqual(
             rse.viewsCount.byInstrumentation,
             [
                 "manual": manualViewsCount,
                 "swiftui": swiftuiViewsCount,
                 "uikit": uikitPredicateViewsCount,
-                "swiftuiAutomatic": swiftuiAutomaticPredicateViewsCount
+                "swiftuiAutomatic": swiftuiAutomaticPredicateViewsCount,
+                "flutter": flutterViewsCount
             ]
         )
     }

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -342,7 +342,7 @@ class SessionEndedMetricTests: XCTestCase {
             try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "swiftuiAutomatic\(idx)"), instrumentationType: .swiftuiAutomatic)
         }
         try (0..<flutterViewsCount).forEach { idx in
-            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "flutter\(idx)"), instrumentationType: .flutter)
+            try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "flutter\(idx)"), instrumentationType: .crossPlatform("flutter"))
         }
         try (0..<unknownViewsCount).forEach { idx in
             try metric.track(view: .mockRandomWith(sessionID: sessionID.rawValue, viewID: "unknown\(idx)"), instrumentationType: nil)

--- a/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
+++ b/DatadogRUM/Tests/SDKMetrics/SessionEndedMetricTests.swift
@@ -317,6 +317,21 @@ class SessionEndedMetricTests: XCTestCase {
         XCTAssertEqual(rse.viewsCount.applicationLaunch, appLaunchViewIDs.count)
     }
 
+    func testInstrumentationTypeEncoding() throws {
+        func encodedValue(_ type: InstrumentationType) throws -> Any {
+            let data = try JSONEncoder().encode(type)
+            return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        }
+
+        // native instrumentation types must keep encoding as their original Int wire values
+        XCTAssertEqual(try encodedValue(.uikit) as? Int, 0)
+        XCTAssertEqual(try encodedValue(.swiftuiAutomatic) as? Int, 1)
+        XCTAssertEqual(try encodedValue(.swiftui) as? Int, 2)
+        XCTAssertEqual(try encodedValue(.manual) as? Int, 3)
+        // cross-platform instrumentation types encode as the raw string reported by the CP SDK
+        XCTAssertEqual(try encodedValue(.crossPlatform("flutter")) as? String, "flutter")
+    }
+
     func testReportingViewsCountByInstrumentationType() throws {
         let manualViewsCount: Int = .mockRandom(min: 1, max: 10)
         let swiftuiViewsCount: Int = .mockRandom(min: 1, max: 10)


### PR DESCRIPTION
### What and why?

Adds support for cross-platform (CP) SDK-originated RUM views (Flutter, React Native, Unity, Kotlin Multiplatform) to be tagged with a specific `InstrumentationType`, instead of falling back to `.manual`. CP SDKs now pass an internal `_dd.instrumentation_type` attribute when starting a view, which the native SDK extracts and strips before it reaches customer-visible view attributes. The extracted value is accepted verbatim (any non-empty string) rather than matched against a fixed list, mirroring the existing cross-platform contract already implemented in dd-sdk-android's `ViewScopeInstrumentationType`. This gives "RUM Session Ended" / "RUM View Ended" SDK telemetry a more accurate breakdown of which cross-platform framework started a given view, improving our visibility into CP SDK adoption and behavior.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) — n/a, no new public API
- [ ] Run `make api-surface` when adding new APIs — n/a, no new public API