### PR TITLE
[RUM-18105] Add Objective-C bridge for timeseries configuration

### DIFF
--- a/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
@@ -215,11 +215,12 @@ class DDRUMConfigurationTests: XCTestCase {
         XCTAssertNil(swift.vitalsUpdateFrequency)
     }
 
-    func testTimeseriesConfigurationWithAllTypes() {
-        objc.setTimeseriesConfiguration(.init(collectTypes: nil))
+func testTimeseriesConfigurationWithAllTypes() {
+    objc.setTimeseriesConfiguration(.init(collectTypes: nil))
 
-        XCTAssertNil(swift.timeseries?.collectTypes)
-    }
+    XCTAssertNotNil(swift.timeseries)
+    XCTAssertNil(swift.timeseries?.collectTypes)
+}
 
     func testTimeseriesConfigurationWithMemoryType() {
         objc.setTimeseriesConfiguration(.init(collectTypes: [.memory]))

--- a/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
@@ -8,6 +8,7 @@ import XCTest
 import TestUtilities
 import DatadogInternal
 @_spi(objc)
+@_spi(Experimental)
 @testable import DatadogRUM
 
 class DDRUMConfigurationTests: XCTestCase {
@@ -212,6 +213,30 @@ class DDRUMConfigurationTests: XCTestCase {
 
         objc.vitalsUpdateFrequency = .never
         XCTAssertNil(swift.vitalsUpdateFrequency)
+    }
+
+    func testTimeseriesConfigurationWithAllTypes() {
+        objc.setTimeseriesConfiguration(.init(collectTypes: nil))
+
+        XCTAssertNil(swift.timeseries?.collectTypes)
+    }
+
+    func testTimeseriesConfigurationWithMemoryType() {
+        objc.setTimeseriesConfiguration(.init(collectTypes: [.memory]))
+
+        XCTAssertEqual(swift.timeseries?.collectTypes, [.memory])
+    }
+
+    func testTimeseriesConfigurationWithCPUType() {
+        objc.setTimeseriesConfiguration(.init(collectTypes: [.cpu]))
+
+        XCTAssertEqual(swift.timeseries?.collectTypes, [.cpu])
+    }
+
+    func testTimeseriesConfigurationWithMemoryAndCPUTypes() {
+        objc.setTimeseriesConfiguration(.init(collectTypes: [.memory, .cpu]))
+
+        XCTAssertEqual(swift.timeseries?.collectTypes, [.memory, .cpu])
     }
 
     func testEventMappers() {

--- a/DatadogCore/Tests/Objc/ObjcAPITests/DDRUM+apiTests.m
+++ b/DatadogCore/Tests/Objc/ObjcAPITests/DDRUM+apiTests.m
@@ -176,6 +176,10 @@
     config.vitalsUpdateFrequency = DDRUMVitalsFrequencyNever;
     XCTAssertEqual(config.vitalsUpdateFrequency, DDRUMVitalsFrequencyNever);
 
+    DDRUMTimeseriesConfiguration *timeseriesConfiguration = [[DDRUMTimeseriesConfiguration alloc]
+        initWithCollectTypes:@[DDRUMTimeseriesType.memory, DDRUMTimeseriesType.cpu]];
+    [config setTimeseriesConfiguration:timeseriesConfiguration];
+
     [config setViewEventMapper:^DDRUMViewEvent * _Nonnull(DDRUMViewEvent * _Nonnull viewEvent) {
         viewEvent.view.url = @"";
         return viewEvent;

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -458,6 +458,31 @@ public enum objc_RUMFeatureOperationFailureReason: Int {
     }
 }
 
+@objc(DDRUMTimeseriesType)
+@objcMembers
+@_spi(objc)
+public final class objc_RUMTimeseriesType: NSObject {
+    internal let swiftType: RUM.Configuration.TimeseriesType
+
+    private init(_ swiftType: RUM.Configuration.TimeseriesType) {
+        self.swiftType = swiftType
+    }
+
+    public static let memory = objc_RUMTimeseriesType(.memory)
+    public static let cpu = objc_RUMTimeseriesType(.cpu)
+}
+
+@objc(DDRUMTimeseriesConfiguration)
+@objcMembers
+@_spi(objc)
+public final class objc_RUMTimeseriesConfiguration: NSObject {
+    internal let swiftConfig: RUM.Configuration.Timeseries
+
+    public init(collectTypes: [objc_RUMTimeseriesType]?) {
+        swiftConfig = .init(collectTypes: collectTypes?.map(\.swiftType))
+    }
+}
+
 @objc(DDOperationOptions)
 @objcMembers
 @_spi(objc)
@@ -676,6 +701,10 @@ public class objc_RUMConfiguration: NSObject {
     public var vitalsUpdateFrequency: objc_VitalsFrequency {
         set { swiftConfig.vitalsUpdateFrequency = newValue.swiftType }
         get { objc_VitalsFrequency(swiftType: swiftConfig.vitalsUpdateFrequency) }
+    }
+
+    public func setTimeseriesConfiguration(_ configuration: objc_RUMTimeseriesConfiguration) {
+        swiftConfig.timeseries = configuration.swiftConfig
     }
 
     public func setViewEventMapper(_ mapper: @escaping (objc_RUMViewEvent) -> objc_RUMViewEvent) {

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3930,6 +3930,11 @@ public enum objc_RUMFeatureOperationFailureReason: Int
     case error
     case abandoned
     case other
+public final class objc_RUMTimeseriesType: NSObject
+    public static let memory = objc_RUMTimeseriesType(.memory)
+    public static let cpu = objc_RUMTimeseriesType(.cpu)
+public final class objc_RUMTimeseriesConfiguration: NSObject
+    public init(collectTypes: [objc_RUMTimeseriesType]?)
 public class objc_OperationOptions: NSObject
 public final class objc_ProfilingOptions: objc_OperationOptions
     public init(sampleRate: Float)
@@ -3971,6 +3976,7 @@ public class objc_RUMConfiguration: NSObject
     public var longTaskThreshold: TimeInterval
     public var appHangThreshold: TimeInterval
     public var vitalsUpdateFrequency: objc_VitalsFrequency
+    public func setTimeseriesConfiguration(_ configuration: objc_RUMTimeseriesConfiguration)
     public func setViewEventMapper(_ mapper: @escaping (objc_RUMViewEvent) -> objc_RUMViewEvent)
     public func setResourceEventMapper(_ mapper: @escaping (objc_RUMResourceEvent) -> objc_RUMResourceEvent?)
     public func setActionEventMapper(_ mapper: @escaping (objc_RUMActionEvent) -> objc_RUMActionEvent?)


### PR DESCRIPTION
### What and why?

Add Objective-C interoperability for the experimental RUM timeseries configuration so Kotlin Multiplatform can enable memory and CPU timeseries collection through generated iOS headers.

### How?

- Expose `DDRUMTimeseriesType` as Objective-C-compatible object values so types can be passed in an `NSArray`.
- Add `DDRUMTimeseriesConfiguration` and `setTimeseriesConfiguration:`.
- Add Swift mapping tests and Objective-C API smoke coverage.
- Regenerate the Objective-C API surface.

### Testing

- `make api-surface`
- `make api-surface-verify`
- `./tools/lint/run-linter.sh`
- `make license-check`
- `make feature-docs-verify`
- Compile `DDRUM+apiTests.m` against the generated `DatadogRUM-Swift.h`

Full XCTest execution is locally blocked by pre-existing Xcode 26.4 / Swift 6 compatibility failures in unchanged OpenTelemetry sources. CI uses Xcode 26.0.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes — not applicable to this experimental SPI bridge
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal)
- [x] Run `make api-surface` when adding new APIs