### PR TITLE
[FFL-2891] Add Flags initialization timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- [FEATURE] Add a configurable initialization timeout for the first Datadog Flags evaluation context. See [#3167][]
 - [FEATURE] Add `remoteConfiguration` to `Datadog.Configuration`, set with `RemoteConfiguration(id:)`, to fetch and cache the remote configuration document from the Datadog CDN at SDK startup. See [#2919][]
 - [IMPROVEMENT] Bump minimum deployment targets to iOS 15.0, tvOS 15.0, and watchOS 9.0. See [#3155][]
 - [FEATURE] Add `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled. See [#3136][]
@@ -1240,6 +1241,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3136]: https://github.com/DataDog/dd-sdk-ios/pull/3136
 [#3165]: https://github.com/DataDog/dd-sdk-ios/pull/3165
 [#3164]: https://github.com/DataDog/dd-sdk-ios/pull/3164
+[#3167]: https://github.com/DataDog/dd-sdk-ios/pull/3167
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/DatadogFlags/Sources/Client/FlagsClient.swift
+++ b/DatadogFlags/Sources/Client/FlagsClient.swift
@@ -185,7 +185,8 @@ public final class FlagsClient {
                 clientName: name,
                 flagAssignmentsFetcher: feature.flagAssignmentsFetcher,
                 dateProvider: SystemDateProvider(),
-                featureScope: featureScope
+                featureScope: featureScope,
+                initializationTimeout: feature.initializationTimeout
             ),
             exposureLogger: feature.makeExposureLogger(featureScope),
             evaluationLogger: feature.makeEvaluationLogger(featureScope),

--- a/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
+++ b/DatadogFlags/Sources/Client/FlagsClientProtocol.swift
@@ -26,6 +26,9 @@ public protocol FlagsClientProtocol: AnyObject {
     ///
     /// This method fetches flag assignments from the server asynchronously. The completion handler
     /// is called when the operation completes or fails.
+    /// For the first context, the configured initialization timeout bounds this wait. If it elapses,
+    /// the completion handler receives ``FlagsError/initializationTimedOut`` while the operation
+    /// continues and can update the client to ``FlagsClientState/ready`` later.
     ///
     /// ```swift
     /// client.setEvaluationContext(
@@ -130,7 +133,9 @@ extension FlagsClientProtocol {
     ///
     /// - Parameter context: The evaluation context containing targeting key and custom attributes.
     ///
-    /// - Throws: ``FlagsError`` if the operation fails.
+    /// - Throws: ``FlagsError`` if the operation fails. The first call throws
+    ///   ``FlagsError/initializationTimedOut`` if the configured initialization timeout elapses;
+    ///   the underlying operation continues and can make the client ready later.
     public func setEvaluationContext(_ context: FlagsEvaluationContext) async throws {
         try await withCheckedThrowingContinuation { continuation in
             setEvaluationContext(context) { result in

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -176,13 +176,18 @@ internal final class FlagsRepository {
             guard let completion = initializationCompletion.take() else {
                 return
             }
-            if self?.stateManager.currentState != .ready,
-               self?.stateManager.currentState != .stale {
-                let timeoutState: FlagsClientState = self?.flagsData?.context == context ? .stale : .error
-                self?.stateManager.updateState(timeoutState) {
-                    completion(.failure(.initializationTimedOut))
-                }
-            } else {
+            guard let self else {
+                completion(.failure(.clientNotInitialized))
+                return
+            }
+            let timeoutState: FlagsClientState = self.flagsData?.context == context ? .stale : .error
+            let accepted = self.stateManager.updateState(
+                timeoutState,
+                unlessCurrentStateIs: [.ready, .stale]
+            ) {
+                completion(.failure(.initializationTimedOut))
+            }
+            if !accepted {
                 completion(.failure(.initializationTimedOut))
             }
         }

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -150,7 +150,8 @@ internal final class FlagsRepository {
     }
 
     private func makeInitializationCompletion(
-        _ completion: @escaping (Result<Void, FlagsError>) -> Void
+        _ completion: @escaping (Result<Void, FlagsError>) -> Void,
+        beforeScheduling: () -> Void
     ) -> InitializationCompletion? {
         initializationLock.lock()
         guard !didStartInitialization else {
@@ -164,6 +165,7 @@ internal final class FlagsRepository {
             return nil
         }
 
+        beforeScheduling()
         let initializationCompletion = InitializationCompletion(completion: completion)
         let cancelTimeout = scheduleInitializationTimeout(initializationTimeout) { [weak self, initializationCompletion] in
             guard let completion = initializationCompletion.take() else {
@@ -171,9 +173,12 @@ internal final class FlagsRepository {
             }
             if self?.stateManager.currentState != .ready,
                self?.stateManager.currentState != .stale {
-                self?.stateManager.updateState(.error)
+                self?.stateManager.updateState(.error) {
+                    completion(.failure(.initializationTimedOut))
+                }
+            } else {
+                completion(.failure(.initializationTimedOut))
             }
-            completion(.failure(.initializationTimedOut))
         }
         initializationCompletion.armTimeoutCancellation(cancelTimeout)
         return initializationCompletion
@@ -266,7 +271,9 @@ extension FlagsRepository: FlagsRepositoryProtocol {
         _ context: FlagsEvaluationContext,
         completion: @escaping (Result<Void, FlagsError>) -> Void
     ) {
-        let initializationCompletion = makeInitializationCompletion(completion)
+        let initializationCompletion = makeInitializationCompletion(completion) {
+            stateManager.updateState(.reconciling)
+        }
         let takeCompletion: () -> ((Result<Void, FlagsError>) -> Void)? = {
             initializationCompletion?.take()
                 ?? (initializationCompletion == nil ? completion : nil)
@@ -282,7 +289,9 @@ extension FlagsRepository: FlagsRepositoryProtocol {
             let hadFlags = self.flagsData != nil
             let cachedContext = self.flagsData?.context
             let versionAtStart = self.flagsDataVersion
-            self.stateManager.updateState(.reconciling)
+            if initializationCompletion == nil {
+                self.stateManager.updateState(.reconciling)
+            }
 
             self.flagAssignmentsFetcher.flagAssignments(for: context) { [weak self] result in
                 switch result {
@@ -298,8 +307,15 @@ extension FlagsRepository: FlagsRepositoryProtocol {
                     )
                     self._flagsDataVersion.mutate { $0 += 1 }
                     self.writeState()
-                    self.stateManager.updateState(.ready)
-                    takeCompletion()?(.success(()))
+                    let operationCompletion = takeCompletion()
+                    if initializationCompletion != nil {
+                        self.stateManager.updateState(.ready) {
+                            operationCompletion?(.success(()))
+                        }
+                    } else {
+                        self.stateManager.updateState(.ready)
+                        operationCompletion?(.success(()))
+                    }
                 case .failure(let error):
                     // Only update state if no newer request has succeeded.
                     // This prevents an older failing request from clearing data
@@ -312,16 +328,25 @@ extension FlagsRepository: FlagsRepositoryProtocol {
                     // dd-openfeature-provider-swift checks currentState in the callback.
                     // Only use cached flags if they match the requested context to avoid
                     // serving flags from a different user/context.
+                    let operationCompletion = takeCompletion()
+                    let newState: FlagsClientState
                     if hadFlags && cachedContext == context {
-                        self?.stateManager.updateState(.stale)
+                        newState = .stale
                     } else {
                         // Clear cached data to prevent cross-context flag leakage.
                         // Without this, flagAssignment() could return the previous
                         // user's flags while in .error state.
                         self?.flagsData = nil
-                        self?.stateManager.updateState(.error)
+                        newState = .error
                     }
-                    takeCompletion()?(.failure(error))
+                    if initializationCompletion != nil {
+                        self?.stateManager.updateState(newState) {
+                            operationCompletion?(.failure(error))
+                        }
+                    } else {
+                        self?.stateManager.updateState(newState)
+                        operationCompletion?(.failure(error))
+                    }
                 }
             }
         }

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -151,6 +151,7 @@ internal final class FlagsRepository {
 
     private func makeInitializationCompletion(
         _ completion: @escaping (Result<Void, FlagsError>) -> Void,
+        context: FlagsEvaluationContext,
         beforeScheduling: () -> Void
     ) -> InitializationCompletion? {
         initializationLock.lock()
@@ -173,7 +174,8 @@ internal final class FlagsRepository {
             }
             if self?.stateManager.currentState != .ready,
                self?.stateManager.currentState != .stale {
-                self?.stateManager.updateState(.error) {
+                let timeoutState: FlagsClientState = self?.flagsData?.context == context ? .stale : .error
+                self?.stateManager.updateState(timeoutState) {
                     completion(.failure(.initializationTimedOut))
                 }
             } else {
@@ -271,7 +273,7 @@ extension FlagsRepository: FlagsRepositoryProtocol {
         _ context: FlagsEvaluationContext,
         completion: @escaping (Result<Void, FlagsError>) -> Void
     ) {
-        let initializationCompletion = makeInitializationCompletion(completion) {
+        let initializationCompletion = makeInitializationCompletion(completion, context: context) {
             stateManager.updateState(.reconciling)
         }
         let takeCompletion: () -> ((Result<Void, FlagsError>) -> Void)? = {

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -133,20 +133,22 @@ internal final class FlagsRepository {
         _ action: @escaping () -> Void
     ) -> FlagsInitializationTimeoutCancellation {
         let workItem = DispatchWorkItem(block: action)
-        let maximumSeconds = TimeInterval(Int.max / Int(NSEC_PER_SEC))
-        let nanoseconds: Int
-        if !timeout.isFinite || timeout <= 0 {
-            nanoseconds = 0
-        } else if timeout >= maximumSeconds {
-            nanoseconds = Int.max
-        } else {
-            nanoseconds = Int(timeout * TimeInterval(NSEC_PER_SEC))
-        }
         DispatchQueue.global(qos: .userInitiated).asyncAfter(
-            deadline: .now() + .nanoseconds(nanoseconds),
+            deadline: initializationTimeoutDeadline(after: timeout),
             execute: workItem
         )
         return { workItem.cancel() }
+    }
+
+    internal static func initializationTimeoutDeadline(
+        after timeout: TimeInterval,
+        from start: DispatchTime = .now()
+    ) -> DispatchTime {
+        guard timeout.isFinite, timeout > 0 else {
+            return start
+        }
+        let maximumSeconds = TimeInterval(UInt64.max - start.uptimeNanoseconds) / TimeInterval(NSEC_PER_SEC)
+        return timeout < maximumSeconds ? start + timeout : DispatchTime(uptimeNanoseconds: UInt64.max)
     }
 
     private func makeInitializationCompletion(

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -164,7 +164,9 @@ internal final class FlagsRepository {
         didStartInitialization = true
         initializationLock.unlock()
 
-        guard let initializationTimeout else {
+        guard let initializationTimeout,
+              initializationTimeout.isFinite,
+              initializationTimeout > 0 else {
             return nil
         }
 
@@ -258,16 +260,25 @@ extension FlagsRepository: FlagsRepositoryProtocol {
 
     var context: FlagsEvaluationContext? {
         waitForFlagsDataRead()
+        guard stateManager.currentState != .error else {
+            return nil
+        }
         return flagsData?.context
     }
 
     func flagAssignment(for key: String) -> FlagAssignment? {
         waitForFlagsDataRead()
+        guard stateManager.currentState != .error else {
+            return nil
+        }
         return flagsData?.flags[key]
     }
 
     func flagAssignments() -> [String: FlagAssignment]? {
         waitForFlagsDataRead()
+        guard stateManager.currentState != .error else {
+            return nil
+        }
         return flagsData?.flags
     }
 

--- a/DatadogFlags/Sources/Client/FlagsRepository.swift
+++ b/DatadogFlags/Sources/Client/FlagsRepository.swift
@@ -26,6 +26,50 @@ internal protocol FlagsRepositoryProtocol {
     func reset()
 }
 
+internal typealias FlagsInitializationTimeoutCancellation = () -> Void
+internal typealias FlagsInitializationTimeoutScheduler = (
+    TimeInterval,
+    @escaping () -> Void
+) -> FlagsInitializationTimeoutCancellation
+
+private final class InitializationCompletion {
+    typealias Completion = (Result<Void, FlagsError>) -> Void
+
+    private let lock = NSLock()
+    private var completion: Completion?
+    private var cancelTimeout: FlagsInitializationTimeoutCancellation?
+
+    init(completion: @escaping Completion) {
+        self.completion = completion
+    }
+
+    func armTimeoutCancellation(_ cancellation: @escaping FlagsInitializationTimeoutCancellation) {
+        lock.lock()
+        if completion == nil {
+            lock.unlock()
+            cancellation()
+        } else {
+            cancelTimeout = cancellation
+            lock.unlock()
+        }
+    }
+
+    func take() -> Completion? {
+        lock.lock()
+        guard let completion else {
+            lock.unlock()
+            return nil
+        }
+        self.completion = nil
+        let cancelTimeout = self.cancelTimeout
+        self.cancelTimeout = nil
+        lock.unlock()
+
+        cancelTimeout?()
+        return completion
+    }
+}
+
 internal final class FlagsRepository {
     private enum Constants {
         static let readTimeout: TimeInterval = 0.1
@@ -37,6 +81,11 @@ internal final class FlagsRepository {
     private let flagAssignmentsFetcher: any FlagAssignmentsFetching
     private let dateProvider: any DateProvider
     private let featureScope: any FeatureScope
+    private let initializationTimeout: TimeInterval?
+    private let scheduleInitializationTimeout: FlagsInitializationTimeoutScheduler
+
+    private let initializationLock = NSLock()
+    private var didStartInitialization = false
 
     @ReadWriteLock
     private var flagsData: FlagsData?
@@ -66,13 +115,68 @@ internal final class FlagsRepository {
         clientName: String,
         flagAssignmentsFetcher: any FlagAssignmentsFetching,
         dateProvider: any DateProvider,
-        featureScope: any FeatureScope
+        featureScope: any FeatureScope,
+        initializationTimeout: TimeInterval? = Flags.Configuration.defaultInitializationTimeout,
+        scheduleInitializationTimeout: FlagsInitializationTimeoutScheduler? = nil
     ) {
         self.clientName = clientName
         self.flagAssignmentsFetcher = flagAssignmentsFetcher
         self.dateProvider = dateProvider
         self.featureScope = featureScope
+        self.initializationTimeout = initializationTimeout
+        self.scheduleInitializationTimeout = scheduleInitializationTimeout ?? Self.scheduleInitializationTimeout
         readState()
+    }
+
+    private static func scheduleInitializationTimeout(
+        _ timeout: TimeInterval,
+        _ action: @escaping () -> Void
+    ) -> FlagsInitializationTimeoutCancellation {
+        let workItem = DispatchWorkItem(block: action)
+        let maximumSeconds = TimeInterval(Int.max / Int(NSEC_PER_SEC))
+        let nanoseconds: Int
+        if !timeout.isFinite || timeout <= 0 {
+            nanoseconds = 0
+        } else if timeout >= maximumSeconds {
+            nanoseconds = Int.max
+        } else {
+            nanoseconds = Int(timeout * TimeInterval(NSEC_PER_SEC))
+        }
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + .nanoseconds(nanoseconds),
+            execute: workItem
+        )
+        return { workItem.cancel() }
+    }
+
+    private func makeInitializationCompletion(
+        _ completion: @escaping (Result<Void, FlagsError>) -> Void
+    ) -> InitializationCompletion? {
+        initializationLock.lock()
+        guard !didStartInitialization else {
+            initializationLock.unlock()
+            return nil
+        }
+        didStartInitialization = true
+        initializationLock.unlock()
+
+        guard let initializationTimeout else {
+            return nil
+        }
+
+        let initializationCompletion = InitializationCompletion(completion: completion)
+        let cancelTimeout = scheduleInitializationTimeout(initializationTimeout) { [weak self, initializationCompletion] in
+            guard let completion = initializationCompletion.take() else {
+                return
+            }
+            if self?.stateManager.currentState != .ready,
+               self?.stateManager.currentState != .stale {
+                self?.stateManager.updateState(.error)
+            }
+            completion(.failure(.initializationTimedOut))
+        }
+        initializationCompletion.armTimeoutCancellation(cancelTimeout)
+        return initializationCompletion
     }
 
     private func readState() {
@@ -162,10 +266,16 @@ extension FlagsRepository: FlagsRepositoryProtocol {
         _ context: FlagsEvaluationContext,
         completion: @escaping (Result<Void, FlagsError>) -> Void
     ) {
+        let initializationCompletion = makeInitializationCompletion(completion)
+        let takeCompletion: () -> ((Result<Void, FlagsError>) -> Void)? = {
+            initializationCompletion?.take()
+                ?? (initializationCompletion == nil ? completion : nil)
+        }
+
         // Chain after disk read completes to ensure correct hadFlags determination
         whenFlagsDataRead { [weak self] in
             guard let self else {
-                completion(.failure(.clientNotInitialized))
+                takeCompletion()?(.failure(.clientNotInitialized))
                 return
             }
 
@@ -178,7 +288,7 @@ extension FlagsRepository: FlagsRepositoryProtocol {
                 switch result {
                 case .success(let flags):
                     guard let self else {
-                        completion(.failure(.clientNotInitialized))
+                        takeCompletion()?(.failure(.clientNotInitialized))
                         return
                     }
                     self.flagsData = .init(
@@ -189,13 +299,13 @@ extension FlagsRepository: FlagsRepositoryProtocol {
                     self._flagsDataVersion.mutate { $0 += 1 }
                     self.writeState()
                     self.stateManager.updateState(.ready)
-                    completion(.success(()))
+                    takeCompletion()?(.success(()))
                 case .failure(let error):
                     // Only update state if no newer request has succeeded.
                     // This prevents an older failing request from clearing data
                     // written by a newer successful request.
                     guard self?.flagsDataVersion == versionAtStart else {
-                        completion(.failure(error))
+                        takeCompletion()?(.failure(error))
                         return
                     }
                     // State must be updated before calling completion —
@@ -211,7 +321,7 @@ extension FlagsRepository: FlagsRepositoryProtocol {
                         self?.flagsData = nil
                         self?.stateManager.updateState(.error)
                     }
-                    completion(.failure(error))
+                    takeCompletion()?(.failure(error))
                 }
             }
         }

--- a/DatadogFlags/Sources/Client/FlagsStateManager.swift
+++ b/DatadogFlags/Sources/Client/FlagsStateManager.swift
@@ -60,10 +60,28 @@ internal final class FlagsStateManager: FlagsStateObservable {
         _ newState: FlagsClientState,
         beforeNotifying: (() -> Void)? = nil
     ) {
+        updateState(
+            newState,
+            unlessCurrentStateIs: [],
+            beforeNotifying: beforeNotifying
+        )
+    }
+
+    @discardableResult
+    func updateState(
+        _ newState: FlagsClientState,
+        unlessCurrentStateIs excludedStates: [FlagsClientState],
+        beforeNotifying: (() -> Void)? = nil
+    ) -> Bool {
         // Capture listeners under lock, then notify outside lock to prevent deadlock.
         var listenersToNotify: [WeakListener] = []
+        var accepted = false
 
         _managerState.mutate { state in
+            guard !excludedStates.contains(state.clientState) else {
+                return
+            }
+            accepted = true
             guard newState != state.clientState else {
                 return
             }
@@ -71,11 +89,15 @@ internal final class FlagsStateManager: FlagsStateObservable {
             listenersToNotify = state.listeners
         }
 
+        guard accepted else {
+            return false
+        }
         beforeNotifying?()
 
         for weakListener in listenersToNotify {
             weakListener.value?.flagsStateDidChange(newState)
         }
+        return true
     }
 
     func addListener(_ listener: FlagsStateListener) {

--- a/DatadogFlags/Sources/Client/FlagsStateManager.swift
+++ b/DatadogFlags/Sources/Client/FlagsStateManager.swift
@@ -56,7 +56,10 @@ internal final class FlagsStateManager: FlagsStateObservable {
         managerState.clientState
     }
 
-    func updateState(_ newState: FlagsClientState) {
+    func updateState(
+        _ newState: FlagsClientState,
+        beforeNotifying: (() -> Void)? = nil
+    ) {
         // Capture listeners under lock, then notify outside lock to prevent deadlock.
         var listenersToNotify: [WeakListener] = []
 
@@ -67,6 +70,8 @@ internal final class FlagsStateManager: FlagsStateObservable {
             state.clientState = newState
             listenersToNotify = state.listeners
         }
+
+        beforeNotifying?()
 
         for weakListener in listenersToNotify {
             weakListener.value?.flagsStateDidChange(newState)

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -16,6 +16,7 @@ internal struct FlagsFeature: DatadogRemoteFeature {
     }
 
     let flagAssignmentsFetcher: any FlagAssignmentsFetching
+    let initializationTimeout: TimeInterval?
     let requestBuilder: any FeatureRequestBuilder
     let messageReceiver: any FeatureMessageReceiver
     let clientRegistry: FlagsClientRegistry
@@ -36,6 +37,7 @@ internal struct FlagsFeature: DatadogRemoteFeature {
             customHeaders: configuration.customFlagsHeaders,
             featureScope: featureScope
         )
+        initializationTimeout = configuration.initializationTimeout
         requestBuilder = ExposureRequestBuilder(
             customIntakeURL: configuration.customExposureEndpoint,
             telemetry: featureScope.telemetry

--- a/DatadogFlags/Sources/Flags.swift
+++ b/DatadogFlags/Sources/Flags.swift
@@ -120,6 +120,7 @@ public enum Flags {
         ///   - gracefulModeEnabled: Controls error handling behavior for API misuse. Default: `true`.
         ///   - customFlagsEndpoint: Custom server URL for retrieving flag assignments. Default: `nil`.
         ///   - customFlagsHeaders: Additional HTTP headers for requests to `customFlagsEndpoint`. Default: `nil`.
+        ///   - initializationTimeout: Maximum time to wait for the first evaluation context. Default: `5` seconds.
         ///   - customExposureEndpoint: Custom server URL for sending exposure data. Default: `nil`.
         ///   - trackExposures: Enables exposure logging to the exposures intake endpoint. Default: `true`.
         ///   - customEvaluationEndpoint: Custom server URL for sending evaluation data. Default: `nil`.
@@ -130,6 +131,7 @@ public enum Flags {
             gracefulModeEnabled: Bool = true,
             customFlagsEndpoint: URL? = nil,
             customFlagsHeaders: [String: String]? = nil,
+            initializationTimeout: TimeInterval? = 5,
             customExposureEndpoint: URL? = nil,
             trackExposures: Bool = true,
             customEvaluationEndpoint: URL? = nil,
@@ -140,7 +142,7 @@ public enum Flags {
             self.gracefulModeEnabled = gracefulModeEnabled
             self.customFlagsEndpoint = customFlagsEndpoint
             self.customFlagsHeaders = customFlagsHeaders
-            self.initializationTimeout = Self.defaultInitializationTimeout
+            self.initializationTimeout = initializationTimeout
             self.customExposureEndpoint = customExposureEndpoint
             self.trackExposures = trackExposures
             self.customEvaluationEndpoint = customEvaluationEndpoint

--- a/DatadogFlags/Sources/Flags.swift
+++ b/DatadogFlags/Sources/Flags.swift
@@ -67,7 +67,11 @@ public enum Flags {
         /// It does not change the HTTP client's timeout. The assignment operation continues after this timeout
         /// and can update the client to ``FlagsClientState/ready`` when it completes.
         ///
-        /// The value is in seconds. Invalid values cause an immediate timeout.
+        /// The timeout applies to the first ``FlagsClientProtocol/setEvaluationContext(_:completion:)`` call only.
+        /// That call consumes the timeout even if the operation fails or never starts. Later calls have no timer.
+        ///
+        /// The value is in seconds. A positive finite value enables the timeout. `nil`, zero, negative, and
+        /// non-finite values disable it.
         ///
         /// Default: `5` seconds.
         public var initializationTimeout: TimeInterval?

--- a/DatadogFlags/Sources/Flags.swift
+++ b/DatadogFlags/Sources/Flags.swift
@@ -24,6 +24,8 @@ public enum Flags {
     /// Use this type to customize the behavior of feature flag evaluation, including custom endpoints,
     /// exposure tracking, and error handling modes.
     public struct Configuration {
+        internal static let defaultInitializationTimeout: TimeInterval? = 5
+
         /// Controls error handling behavior for `FlagsClient` API misuse.
         ///
         /// This setting determines how the SDK responds to incorrect usage, such as:
@@ -57,6 +59,18 @@ public enum Flags {
         ///
         /// Default: `nil`.
         public var customFlagsHeaders: [String: String]?
+
+        /// The maximum time to wait for the first evaluation context to become ready.
+        ///
+        /// This timeout covers the complete initialization operation. It includes loading cached data,
+        /// fetching assignments, reading the response body, decoding JSON, and publishing the ready state.
+        /// It does not change the HTTP client's timeout. The assignment operation continues after this timeout
+        /// and can update the client to ``FlagsClientState/ready`` when it completes.
+        ///
+        /// The value is in seconds. Invalid values cause an immediate timeout.
+        ///
+        /// Default: `5` seconds.
+        public var initializationTimeout: TimeInterval?
 
         /// Custom server url for sending Flags exposure data.
         ///
@@ -122,6 +136,7 @@ public enum Flags {
             self.gracefulModeEnabled = gracefulModeEnabled
             self.customFlagsEndpoint = customFlagsEndpoint
             self.customFlagsHeaders = customFlagsHeaders
+            self.initializationTimeout = Self.defaultInitializationTimeout
             self.customExposureEndpoint = customExposureEndpoint
             self.trackExposures = trackExposures
             self.customEvaluationEndpoint = customEvaluationEndpoint

--- a/DatadogFlags/Sources/Models/FlagsError.swift
+++ b/DatadogFlags/Sources/Models/FlagsError.swift
@@ -30,4 +30,7 @@ public enum FlagsError: Error {
     ///
     /// This may occur if required configuration parameters are missing or malformed.
     case invalidConfiguration
+
+    /// The first evaluation context did not become ready before the configured initialization timeout.
+    case initializationTimedOut
 }

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -215,6 +215,72 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertNotNil(flagsRepository.flagAssignment(for: "cached"))
     }
 
+    func testInitializationTimeoutDoesNotEvaluateCachedAssignmentsFromAnotherContext() throws {
+        // Given
+        let cachedContext = FlagsEvaluationContext(targetingKey: "user-A")
+        let requestedContext = FlagsEvaluationContext(targetingKey: "user-B")
+        let cachedAssignment = FlagAssignment(
+            allocationKey: "allocation",
+            variationKey: "enabled",
+            variation: .boolean(true),
+            reason: "TARGETING_MATCH",
+            doLog: true
+        )
+        let cachedData = FlagsData(
+            flags: ["promotion": cachedAssignment],
+            context: cachedContext,
+            date: .mockAny()
+        )
+        try featureScope.dataStoreMock.setValue(
+            JSONEncoder().encode(cachedData),
+            forKey: .mockAny()
+        )
+        var fetchCompletion: ((Result<[String: FlagAssignment], FlagsError>) -> Void)?
+        var timeoutAction: (() -> Void)?
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                fetchCompletion = completion
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { _, action in
+                timeoutAction = action
+                return {}
+            }
+        )
+        let exposureLogger = ExposureLoggerMock()
+        let client = FlagsClient(
+            repository: flagsRepository,
+            exposureLogger: exposureLogger,
+            evaluationLogger: EvaluationLoggerMock(),
+            rumFlagEvaluationReporter: RUMFlagEvaluationReporterMock()
+        )
+        featureScope.dataStore.flush()
+        XCTAssertEqual(flagsRepository.context, cachedContext)
+
+        // When
+        client.setEvaluationContext(requestedContext) { _ in }
+        try XCTUnwrap(timeoutAction)()
+        let details = client.getBooleanDetails(key: "promotion", defaultValue: false)
+
+        // Then
+        XCTAssertFalse(details.value)
+        XCTAssertEqual(details.error, .providerNotReady)
+        XCTAssertNil(flagsRepository.context)
+        XCTAssertNil(flagsRepository.flagAssignment(for: "promotion"))
+        XCTAssertNil(flagsRepository.flagAssignments())
+        XCTAssertTrue(exposureLogger.logExposureCalls.isEmpty)
+
+        // When a late response finishes the same request
+        try XCTUnwrap(fetchCompletion)(.success(["promotion": .mockRandom()]))
+
+        // Then the requested context becomes readable
+        XCTAssertEqual(flagsRepository.context, requestedContext)
+        XCTAssertNotNil(flagsRepository.flagAssignment(for: "promotion"))
+    }
+
     func testInitializationTimeoutDoesNotReplaceReadyStateFromANewerRequest() throws {
         // Given
         var fetchCompletions: [(Result<[String: FlagAssignment], FlagsError>) -> Void] = []
@@ -320,30 +386,37 @@ final class FlagsRepositoryTests: XCTestCase {
         }
     }
 
-    func testImmediateInitializationTimeoutRemainsError() {
-        // Given
-        var callbackResult: Result<Void, FlagsError>?
-        let flagsRepository = FlagsRepository(
-            clientName: .mockAny(),
-            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, _ in },
-            dateProvider: DateProviderMock(),
-            featureScope: featureScope,
-            initializationTimeout: 0,
-            scheduleInitializationTimeout: { _, action in
-                action()
-                return {}
-            }
-        )
-        featureScope.dataStore.flush()
+    func testNonPositiveOrNonFiniteInitializationTimeoutDisablesTimeout() throws {
+        let disabledTimeouts: [TimeInterval] = [0, -1, .nan, .infinity, -.infinity]
 
-        // When
-        flagsRepository.setEvaluationContext(.mockAny()) { callbackResult = $0 }
+        for timeout in disabledTimeouts {
+            // Given
+            let featureScope = FeatureScopeMock()
+            var scheduledTimeoutCount = 0
+            var callbackResult: Result<Void, FlagsError>?
+            let flagsRepository = FlagsRepository(
+                clientName: .mockAny(),
+                flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                    completion(.success([:]))
+                },
+                dateProvider: DateProviderMock(),
+                featureScope: featureScope,
+                initializationTimeout: timeout,
+                scheduleInitializationTimeout: { _, _ in
+                    scheduledTimeoutCount += 1
+                    return {}
+                }
+            )
+            featureScope.dataStore.flush()
 
-        // Then
-        guard case .failure(.initializationTimedOut) = callbackResult else {
-            return XCTFail("Expected initialization timeout")
+            // When
+            flagsRepository.setEvaluationContext(.mockAny()) { callbackResult = $0 }
+
+            // Then
+            XCTAssertEqual(scheduledTimeoutCount, 0, "Unexpected timer for \(timeout)")
+            XCTAssertNoThrow(try XCTUnwrap(callbackResult).get())
+            XCTAssertEqual(flagsRepository.state.currentState, .ready)
         }
-        XCTAssertEqual(flagsRepository.state.currentState, .error)
     }
 
     func testInitializationCompletionCancelsTimeout() throws {

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -170,6 +170,34 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertNotNil(flagsRepository.flagAssignment(for: "test"))
     }
 
+    func testInitializationTimeoutCompletesWhenRepositoryIsReleased() throws {
+        // Given
+        var timeoutAction: (() -> Void)?
+        var callbackResult: Result<Void, FlagsError>?
+        var flagsRepository: FlagsRepository? = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, _ in },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { _, action in
+                timeoutAction = action
+                return {}
+            }
+        )
+        featureScope.dataStore.flush()
+        flagsRepository?.setEvaluationContext(.mockAny()) { callbackResult = $0 }
+
+        // When
+        flagsRepository = nil
+        try XCTUnwrap(timeoutAction)()
+
+        // Then
+        guard case .failure(.clientNotInitialized) = callbackResult else {
+            return XCTFail("Expected client-not-initialized failure")
+        }
+    }
+
     func testInitializationTimeoutPublishesStaleForMatchingCachedContext() throws {
         // Given
         let context = FlagsEvaluationContext.mockAny()

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -170,6 +170,51 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertNotNil(flagsRepository.flagAssignment(for: "test"))
     }
 
+    func testInitializationTimeoutPublishesStaleForMatchingCachedContext() throws {
+        // Given
+        let context = FlagsEvaluationContext.mockAny()
+        let cachedData = FlagsData(
+            flags: ["cached": .mockAny()],
+            context: context,
+            date: .mockAny()
+        )
+        try featureScope.dataStoreMock.setValue(
+            JSONEncoder().encode(cachedData),
+            forKey: .mockAny()
+        )
+        var timeoutAction: (() -> Void)?
+        var callbackResult: Result<Void, FlagsError>?
+        var stateAtTimeoutCallback: FlagsClientState?
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, _ in },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { _, action in
+                timeoutAction = action
+                return {}
+            }
+        )
+        featureScope.dataStore.flush()
+
+        flagsRepository.setEvaluationContext(context) { result in
+            stateAtTimeoutCallback = flagsRepository.state.currentState
+            callbackResult = result
+        }
+
+        // When
+        try XCTUnwrap(timeoutAction)()
+
+        // Then
+        guard case .failure(.initializationTimedOut) = callbackResult else {
+            return XCTFail("Expected initialization timeout")
+        }
+        XCTAssertEqual(stateAtTimeoutCallback, .stale)
+        XCTAssertEqual(flagsRepository.state.currentState, .stale)
+        XCTAssertNotNil(flagsRepository.flagAssignment(for: "cached"))
+    }
+
     func testInitializationTimeoutDoesNotReplaceReadyStateFromANewerRequest() throws {
         // Given
         var fetchCompletions: [(Result<[String: FlagAssignment], FlagsError>) -> Void] = []

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -122,6 +122,174 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertNil(flagsRepository.flagAssignment(for: "test"))
     }
 
+    func testInitializationTimeoutReturnsFailureAndAllowsLateReadyState() throws {
+        // Given
+        var fetchCompletion: ((Result<[String: FlagAssignment], FlagsError>) -> Void)?
+        var timeoutAction: (() -> Void)?
+        var scheduledTimeout: TimeInterval?
+        var callbackResults: [Result<Void, FlagsError>] = []
+        var stateAtTimeoutCallback: FlagsClientState?
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                fetchCompletion = completion
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { timeout, action in
+                scheduledTimeout = timeout
+                timeoutAction = action
+                return {}
+            }
+        )
+
+        flagsRepository.setEvaluationContext(.mockAny()) {
+            stateAtTimeoutCallback = flagsRepository.state.currentState
+            callbackResults.append($0)
+        }
+
+        // When
+        try XCTUnwrap(timeoutAction)()
+
+        // Then
+        XCTAssertEqual(scheduledTimeout, 2.5)
+        XCTAssertEqual(callbackResults.count, 1)
+        guard case .failure(.initializationTimedOut) = callbackResults[0] else {
+            return XCTFail("Expected initialization timeout")
+        }
+        XCTAssertEqual(stateAtTimeoutCallback, .error)
+        XCTAssertEqual(flagsRepository.state.currentState, .error)
+
+        // When
+        try XCTUnwrap(fetchCompletion)(.success(["test": .mockAny()]))
+
+        // Then
+        XCTAssertEqual(callbackResults.count, 1)
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+        XCTAssertNotNil(flagsRepository.flagAssignment(for: "test"))
+    }
+
+    func testInitializationTimeoutDoesNotReplaceReadyStateFromANewerRequest() throws {
+        // Given
+        var fetchCompletions: [(Result<[String: FlagAssignment], FlagsError>) -> Void] = []
+        var timeoutAction: (() -> Void)?
+        var firstResult: Result<Void, FlagsError>?
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                fetchCompletions.append(completion)
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { _, action in
+                timeoutAction = action
+                return {}
+            }
+        )
+
+        flagsRepository.setEvaluationContext(.mockAny()) { firstResult = $0 }
+        flagsRepository.setEvaluationContext(.mockRandom()) { _ in }
+        XCTAssertEqual(fetchCompletions.count, 2)
+
+        // When
+        fetchCompletions[1](.success(["newer": .mockAny()]))
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+        try XCTUnwrap(timeoutAction)()
+
+        // Then
+        guard case .failure(.initializationTimedOut) = firstResult else {
+            return XCTFail("Expected the first request to time out")
+        }
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+    }
+
+    func testInitializationCompletionCancelsTimeout() throws {
+        // Given
+        var timeoutAction: (() -> Void)?
+        var timeoutCancellationCount = 0
+        var callbackCount = 0
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.success([:]))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { _, action in
+                timeoutAction = action
+                return { timeoutCancellationCount += 1 }
+            }
+        )
+
+        // When
+        flagsRepository.setEvaluationContext(.mockAny()) { _ in callbackCount += 1 }
+        try XCTUnwrap(timeoutAction)()
+
+        // Then
+        XCTAssertEqual(timeoutCancellationCount, 1)
+        XCTAssertEqual(callbackCount, 1)
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+    }
+
+    func testInitializationTimeoutOnlyAppliesToFirstContext() {
+        // Given
+        var scheduledTimeoutCount = 0
+        var callbackCount = 0
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.success([:]))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { _, _ in
+                scheduledTimeoutCount += 1
+                return {}
+            }
+        )
+
+        // When
+        flagsRepository.setEvaluationContext(.mockAny()) { _ in callbackCount += 1 }
+        flagsRepository.setEvaluationContext(.mockRandom()) { _ in callbackCount += 1 }
+
+        // Then
+        XCTAssertEqual(scheduledTimeoutCount, 1)
+        XCTAssertEqual(callbackCount, 2)
+    }
+
+    func testInitializationTimeoutDefaultsToFiveSeconds() {
+        // Given
+        var scheduledTimeoutCount = 0
+        var scheduledTimeout: TimeInterval?
+        var callbackCount = 0
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                completion(.success([:]))
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            scheduleInitializationTimeout: { timeout, _ in
+                scheduledTimeoutCount += 1
+                scheduledTimeout = timeout
+                return {}
+            }
+        )
+
+        // When
+        flagsRepository.setEvaluationContext(.mockAny()) { _ in callbackCount += 1 }
+
+        // Then
+        XCTAssertEqual(scheduledTimeoutCount, 1)
+        XCTAssertEqual(scheduledTimeout, 5)
+        XCTAssertEqual(callbackCount, 1)
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+    }
+
     // MARK: - State Transitions
 
     func testStateTransitionsToReadyOnSuccess() {

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -431,6 +431,19 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertEqual(flagsRepository.state.currentState, .ready)
     }
 
+    func testInitializationTimeoutDeadlineDoesNotUsePlatformIntWidth() {
+        // Given
+        let start = DispatchTime(uptimeNanoseconds: 1_000_000_000)
+
+        // When
+        let deadline = FlagsRepository.initializationTimeoutDeadline(after: 5, from: start)
+        let delay = deadline.uptimeNanoseconds - start.uptimeNanoseconds
+
+        // Then
+        XCTAssertEqual(delay, 5_000_000_000)
+        XCTAssertGreaterThan(delay, UInt64(Int32.max))
+    }
+
     // MARK: - State Transitions
 
     func testStateTransitionsToReadyOnSuccess() {

--- a/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsRepositoryTests.swift
@@ -205,6 +205,102 @@ final class FlagsRepositoryTests: XCTestCase {
         XCTAssertEqual(flagsRepository.state.currentState, .ready)
     }
 
+    func testInitializationSuccessClaimsCompletionBeforeReadyListeners() throws {
+        // Given
+        var fetchCompletion: ((Result<[String: FlagAssignment], FlagsError>) -> Void)?
+        var timeoutAction: (() -> Void)?
+        var callbackResult: Result<Void, FlagsError>?
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, completion in
+                fetchCompletion = completion
+            },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { _, action in
+                timeoutAction = action
+                return {}
+            }
+        )
+        featureScope.dataStore.flush()
+        let listener = ClosureFlagsStateListener { state in
+            if state == .ready {
+                timeoutAction?()
+            }
+        }
+        flagsRepository.state.addListener(listener)
+        flagsRepository.setEvaluationContext(.mockAny()) { callbackResult = $0 }
+
+        // When
+        try XCTUnwrap(fetchCompletion)(.success([:]))
+
+        // Then
+        XCTAssertNoThrow(try XCTUnwrap(callbackResult).get())
+        XCTAssertEqual(flagsRepository.state.currentState, .ready)
+    }
+
+    func testInitializationTimeoutCompletesBeforeErrorListeners() throws {
+        // Given
+        var timeoutAction: (() -> Void)?
+        var callbackResult: Result<Void, FlagsError>?
+        var callbackWasDeliveredBeforeErrorListener = false
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, _ in },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 2.5,
+            scheduleInitializationTimeout: { _, action in
+                timeoutAction = action
+                return {}
+            }
+        )
+        featureScope.dataStore.flush()
+        let listener = ClosureFlagsStateListener { state in
+            if state == .error {
+                callbackWasDeliveredBeforeErrorListener = callbackResult != nil
+            }
+        }
+        flagsRepository.state.addListener(listener)
+        flagsRepository.setEvaluationContext(.mockAny()) { callbackResult = $0 }
+
+        // When
+        try XCTUnwrap(timeoutAction)()
+
+        // Then
+        XCTAssertTrue(callbackWasDeliveredBeforeErrorListener)
+        guard case .failure(.initializationTimedOut) = callbackResult else {
+            return XCTFail("Expected initialization timeout")
+        }
+    }
+
+    func testImmediateInitializationTimeoutRemainsError() {
+        // Given
+        var callbackResult: Result<Void, FlagsError>?
+        let flagsRepository = FlagsRepository(
+            clientName: .mockAny(),
+            flagAssignmentsFetcher: FlagAssignmentsFetcherMock { _, _ in },
+            dateProvider: DateProviderMock(),
+            featureScope: featureScope,
+            initializationTimeout: 0,
+            scheduleInitializationTimeout: { _, action in
+                action()
+                return {}
+            }
+        )
+        featureScope.dataStore.flush()
+
+        // When
+        flagsRepository.setEvaluationContext(.mockAny()) { callbackResult = $0 }
+
+        // Then
+        guard case .failure(.initializationTimedOut) = callbackResult else {
+            return XCTFail("Expected initialization timeout")
+        }
+        XCTAssertEqual(flagsRepository.state.currentState, .error)
+    }
+
     func testInitializationCompletionCancelsTimeout() throws {
         // Given
         var timeoutAction: (() -> Void)?
@@ -643,5 +739,17 @@ final class FlagsRepositoryTests: XCTestCase {
         // (dd-openfeature-provider-swift depends on this ordering)
         waitForExpectations(timeout: 0)
         XCTAssertEqual(stateInCompletion, .error)
+    }
+}
+
+private final class ClosureFlagsStateListener: FlagsStateListener {
+    private let onStateChange: (FlagsClientState) -> Void
+
+    init(onStateChange: @escaping (FlagsClientState) -> Void) {
+        self.onStateChange = onStateChange
+    }
+
+    func flagsStateDidChange(_ newState: FlagsClientState) {
+        onStateChange(newState)
     }
 }

--- a/DatadogFlags/Tests/Client/FlagsStateManagerTests.swift
+++ b/DatadogFlags/Tests/Client/FlagsStateManagerTests.swift
@@ -32,6 +32,19 @@ final class FlagsStateManagerTests: XCTestCase {
         XCTAssertEqual(manager.currentState, .notReady)
     }
 
+    func testConditionalUpdateDoesNotReplaceExcludedCurrentState() {
+        // Given
+        let manager = FlagsStateManager()
+        manager.updateState(.ready)
+
+        // When
+        let accepted = manager.updateState(.stale, unlessCurrentStateIs: [.ready, .stale])
+
+        // Then
+        XCTAssertFalse(accepted)
+        XCTAssertEqual(manager.currentState, .ready)
+    }
+
     func testListenerReceivesCurrentStateOnAdd() {
         let manager = FlagsStateManager()
         manager.updateState(.ready)

--- a/DatadogFlags/Tests/FlagsTests.swift
+++ b/DatadogFlags/Tests/FlagsTests.swift
@@ -15,6 +15,7 @@ final class FlagsTests: XCTestCase {
 
         // Then
         XCTAssertNil(config.customExposureEndpoint)
+        XCTAssertEqual(config.initializationTimeout, 5)
     }
 
     func testWhenNotEnabled() {
@@ -41,6 +42,7 @@ final class FlagsTests: XCTestCase {
         var config = Flags.Configuration()
         config.customFlagsEndpoint = .mockRandom()
         config.customFlagsHeaders = .mockRandom()
+        config.initializationTimeout = 2.5
         config.customExposureEndpoint = .mockRandom()
         let core = FeatureRegistrationCoreMock()
 
@@ -53,6 +55,7 @@ final class FlagsTests: XCTestCase {
         XCTAssertEqual(flags.performanceOverride?.maxObjectsInFile, 50)
         XCTAssertEqual(flagAssignmentFetcher.customEndpoint, config.customFlagsEndpoint)
         XCTAssertEqual(flagAssignmentFetcher.customHeaders, config.customFlagsHeaders)
+        XCTAssertEqual(flags.initializationTimeout, config.initializationTimeout)
         let requestBuilder = try XCTUnwrap(flags.requestBuilder as? ExposureRequestBuilder)
         XCTAssertEqual(requestBuilder.customIntakeURL, config.customExposureEndpoint)
     }

--- a/DatadogFlags/Tests/FlagsTests.swift
+++ b/DatadogFlags/Tests/FlagsTests.swift
@@ -18,6 +18,16 @@ final class FlagsTests: XCTestCase {
         XCTAssertEqual(config.initializationTimeout, 5)
     }
 
+    func testConfigurationInitializerSetsInitializationTimeout() {
+        // When
+        let configured = Flags.Configuration(initializationTimeout: 2.5)
+        let disabled = Flags.Configuration(initializationTimeout: nil)
+
+        // Then
+        XCTAssertEqual(configured.initializationTimeout, 2.5)
+        XCTAssertNil(disabled.initializationTimeout)
+    }
+
     func testWhenNotEnabled() {
         // Given
         let core = FeatureRegistrationCoreMock()

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1625,6 +1625,7 @@ public enum Flags
         public var gracefulModeEnabled: Bool
         public var customFlagsEndpoint: URL?
         public var customFlagsHeaders: [String: String]?
+        public var initializationTimeout: TimeInterval?
         public var customExposureEndpoint: URL?
         public var trackExposures: Bool
         public var customEvaluationEndpoint: URL?
@@ -1689,6 +1690,7 @@ public enum FlagsError: Error
     case invalidResponse
     case clientNotInitialized
     case invalidConfiguration
+    case initializationTimedOut
 public struct FlagsEvaluationContext: Equatable, Codable
     public let targetingKey: String
     public let attributes: [String: AnyValue]

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1632,7 +1632,7 @@ public enum Flags
         public var trackEvaluations: Bool
         public var evaluationFlushInterval: TimeInterval
         public var rumIntegrationEnabled: Bool
-        public init(gracefulModeEnabled: Bool = true,customFlagsEndpoint: URL? = nil,customFlagsHeaders: [String: String]? = nil,customExposureEndpoint: URL? = nil,trackExposures: Bool = true,customEvaluationEndpoint: URL? = nil,trackEvaluations: Bool = true,evaluationFlushInterval: TimeInterval = 10.0,rumIntegrationEnabled: Bool = true)
+        public init(gracefulModeEnabled: Bool = true,customFlagsEndpoint: URL? = nil,customFlagsHeaders: [String: String]? = nil,initializationTimeout: TimeInterval? = 5,customExposureEndpoint: URL? = nil,trackExposures: Bool = true,customEvaluationEndpoint: URL? = nil,trackEvaluations: Bool = true,evaluationFlushInterval: TimeInterval = 10.0,rumIntegrationEnabled: Bool = true)
     public static func enable(with configuration: Flags.Configuration = .init(),in core: DatadogCoreProtocol = CoreRegistry.default)
 public enum AnyValue: Equatable, Hashable
     case string(String)


### PR DESCRIPTION
## Motivation

The first Flags context operation can wait without a limit. Mobile applications need a bounded initialization wait during normal onboarding.

## Changes and Decisions

- Add `Flags.Configuration.initializationTimeout` and a matching initializer parameter in seconds.
- Use five seconds by default.
- Use a positive finite value to enable the timeout. `nil`, zero, negative, and non-finite values disable it.
- Apply the timeout only to the first `setEvaluationContext` call. That call consumes the timeout even if it fails or never starts.
- Return `FlagsError.initializationTimedOut` when the timeout expires.
- Publish `.stale` when matching cached assignments are available.
- Otherwise, publish `.error` and do not evaluate cached assignments from a different context.
- Keep the initialization operation running. A late success can publish `.ready`.
- Do not change the HTTP client timeout.

### LOC Breakdown

| Category | Files | Added | Deleted |
|---|---:|---:|---:|
| Production source | 7 | 227 | 13 |
| Tests | 3 | 461 | 0 |
| Generated API snapshot | 1 | 3 | 1 |
| **Total** | **11** | **691** | **14** |

```mermaid
flowchart TD
    A[First setEvaluationContext] --> B{Completes within timeout?}
    B -->|Yes| C[Return success and publish Ready]
    B -->|No| D[Return initializationTimedOut]
    D --> E{Matching cached assignments?}
    E -->|Yes| F[Publish Stale]
    E -->|No| G[Publish Error and use defaults]
    D --> H[Initialization continues]
    H -->|Late success| C
    I[Later setEvaluationContext calls] --> J[No initialization timer]
```

Direct Flags use applies the five-second default:

```swift
Flags.enable()

let client = FlagsClient.create()
try await client.setEvaluationContext(
    FlagsEvaluationContext(targetingKey: "user-123")
)
```

OpenFeature uses the same configuration and timeout:

```swift
import DatadogFlags
import DatadogOpenFeatureProvider
import OpenFeature

let configuration = Flags.Configuration(initializationTimeout: 2)
Flags.enable(with: configuration)

let provider = DatadogProvider()
let context = MutableContext(targetingKey: "user-123")
await OpenFeatureAPI.shared.setProviderAndWait(
    provider: provider,
    initialContext: context
)
```
