### PR TITLE
RUM-18345 Add defaultTimeseries constant, stop defaulting collectTypes to all

### DIFF
--- a/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
+++ b/DatadogCore/Tests/Objc/DDRUMConfigurationTests.swift
@@ -215,12 +215,12 @@ class DDRUMConfigurationTests: XCTestCase {
         XCTAssertNil(swift.vitalsUpdateFrequency)
     }
 
-func testTimeseriesConfigurationWithAllTypes() {
-    objc.setTimeseriesConfiguration(.init(collectTypes: nil))
+    func testTimeseriesConfigurationWithDefaultTypes() {
+        objc.setTimeseriesConfiguration(.default)
 
-    XCTAssertNotNil(swift.timeseries)
-    XCTAssertNil(swift.timeseries?.collectTypes)
-}
+        XCTAssertNotNil(swift.timeseries)
+        XCTAssertEqual(swift.timeseries?.collectTypes, [.memory, .cpu])
+    }
 
     func testTimeseriesConfigurationWithMemoryType() {
         objc.setTimeseriesConfiguration(.init(collectTypes: [.memory]))

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -275,17 +275,17 @@ Event mappers allow modifying or dropping events before upload:
 
 ### Timeseries Collection (Experimental)
 - `RUM.Configuration.timeseries` — gated behind `@_spi(Experimental)`; not an init parameter, must be set on the configuration instance before calling `RUM.enable(with:)`. Default: `nil` (disabled).
-- Set it to `RUM.Configuration.Timeseries(collectTypes:)`, or to the built-in `.defaultTimeseries`, to sample memory footprint and/or CPU usage roughly once per second during a RUM session, uploaded as timeseries events scoped to the session.
+- Set it to `RUM.Configuration.Timeseries(collectTypes:)`, or to the built-in `.default`, to sample memory footprint and/or CPU usage roughly once per second during a RUM session, uploaded as timeseries events scoped to the session.
   ```swift
   @_spi(Experimental) import DatadogRUM
 
   var rumConfig = RUM.Configuration(applicationID: "<rum_application_id>")
-  rumConfig.timeseries = .defaultTimeseries // memory + cpu
+  rumConfig.timeseries = .default // memory + cpu
   // or, to pick specific types explicitly:
   // rumConfig.timeseries = RUM.Configuration.Timeseries(collectTypes: [.memory])
   RUM.enable(with: rumConfig)
   ```
-- `collectTypes: nil` (e.g. `RUM.Configuration.Timeseries()`) collects nothing — there is no implicit "collect everything" default. Use `RUM.Configuration.Timeseries.defaultTimeseries` (`[.memory, .cpu]`) to opt into the standard set explicitly; this constant is stable across SDK versions.
+- `collectTypes` is a mandatory `Set<TimeseriesType>` — there is no implicit "collect everything" default and no nil state. Use `RUM.Configuration.Timeseries.default` (`[.memory, .cpu]`) to opt into the standard set explicitly; this constant is stable across SDK versions.
 - `TimeseriesType`: `.memory` (physical memory footprint and % of total device RAM), `.cpu` (usage percentage). `.cpu` is unavailable on watchOS and is filtered out of `collectTypes` automatically there.
 - When enabled, `core.telemetry.usage(event: .timeseries)` is fired once from `RUM.enable(with:)` to report adoption.
 

--- a/DatadogRUM/RUM_FEATURE.md
+++ b/DatadogRUM/RUM_FEATURE.md
@@ -275,17 +275,17 @@ Event mappers allow modifying or dropping events before upload:
 
 ### Timeseries Collection (Experimental)
 - `RUM.Configuration.timeseries` — gated behind `@_spi(Experimental)`; not an init parameter, must be set on the configuration instance before calling `RUM.enable(with:)`. Default: `nil` (disabled).
-- Set it to `RUM.Configuration.Timeseries(collectTypes:)` to sample memory footprint and/or CPU usage roughly once per second during a RUM session, uploaded as timeseries events scoped to the session.
+- Set it to `RUM.Configuration.Timeseries(collectTypes:)`, or to the built-in `.defaultTimeseries`, to sample memory footprint and/or CPU usage roughly once per second during a RUM session, uploaded as timeseries events scoped to the session.
   ```swift
   @_spi(Experimental) import DatadogRUM
 
   var rumConfig = RUM.Configuration(applicationID: "<rum_application_id>")
-  rumConfig.timeseries = RUM.Configuration.Timeseries(
-      // Default: nil (collects all types available on the current platform)
-      collectTypes: [.memory, .cpu]
-  )
+  rumConfig.timeseries = .defaultTimeseries // memory + cpu
+  // or, to pick specific types explicitly:
+  // rumConfig.timeseries = RUM.Configuration.Timeseries(collectTypes: [.memory])
   RUM.enable(with: rumConfig)
   ```
+- `collectTypes: nil` (e.g. `RUM.Configuration.Timeseries()`) collects nothing — there is no implicit "collect everything" default. Use `RUM.Configuration.Timeseries.defaultTimeseries` (`[.memory, .cpu]`) to opt into the standard set explicitly; this constant is stable across SDK versions.
 - `TimeseriesType`: `.memory` (physical memory footprint and % of total device RAM), `.cpu` (usage percentage). `.cpu` is unavailable on watchOS and is filtered out of `collectTypes` automatically there.
 - When enabled, `core.telemetry.usage(event: .timeseries)` is fired once from `RUM.enable(with:)` to report adoption.
 

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -478,11 +478,11 @@ public final class objc_RUMTimeseriesType: NSObject {
 public final class objc_RUMTimeseriesConfiguration: NSObject {
     internal let swiftConfig: RUM.Configuration.Timeseries
 
-    public init(collectTypes: [objc_RUMTimeseriesType]?) {
-        swiftConfig = .init(collectTypes: collectTypes?.map(\.swiftType))
+    public init(collectTypes: [objc_RUMTimeseriesType]) {
+        swiftConfig = .init(collectTypes: Set(collectTypes.map(\.swiftType)))
     }
 
-    public static let defaultTimeseries = objc_RUMTimeseriesConfiguration(collectTypes: [.memory, .cpu])
+    public static let `default` = objc_RUMTimeseriesConfiguration(collectTypes: [.memory, .cpu])
 }
 
 @objc(DDOperationOptions)

--- a/DatadogRUM/Sources/RUM+objc.swift
+++ b/DatadogRUM/Sources/RUM+objc.swift
@@ -481,6 +481,8 @@ public final class objc_RUMTimeseriesConfiguration: NSObject {
     public init(collectTypes: [objc_RUMTimeseriesType]?) {
         swiftConfig = .init(collectTypes: collectTypes?.map(\.swiftType))
     }
+
+    public static let defaultTimeseries = objc_RUMTimeseriesConfiguration(collectTypes: [.memory, .cpu])
 }
 
 @objc(DDOperationOptions)

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -419,22 +419,19 @@ extension RUM {
         @_spi(Experimental)
         public struct Timeseries {
             /// The specific timeseries types to collect.
-            ///
-            /// Default: `nil` - which means no timeseries types are collected. Use `.defaultTimeseries` for the
-            /// standard set (memory and CPU).
-            public var collectTypes: [TimeseriesType]?
+            public var collectTypes: Set<TimeseriesType>
 
             /// Creates a timeseries configuration.
             /// - Parameters:
-            ///   - collectTypes: The specific timeseries types to collect. Default: `nil` - no types are collected.
+            ///   - collectTypes: The specific timeseries types to collect.
             public init(
-                collectTypes: [TimeseriesType]? = nil
+                collectTypes: Set<TimeseriesType>
             ) {
                 self.collectTypes = collectTypes
             }
 
             /// The default timeseries configuration: memory and CPU.
-            public static let defaultTimeseries = Timeseries(collectTypes: [.memory, .cpu])
+            public static let `default` = Timeseries(collectTypes: [.memory, .cpu])
         }
 
         /// A timeseries type that can be collected.
@@ -594,11 +591,8 @@ extension RUM.Configuration.Timeseries {
     ///
     /// Empty means timeseries collection should be disabled entirely (e.g. `collectTypes: [.cpu]` on watchOS).
     internal var effectiveCollectTypes: Set<RUM.Configuration.TimeseriesType> {
-        guard let collectTypes else {
-            return []
-        }
         let available = RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform
-        return Set(collectTypes).intersection(available)
+        return collectTypes.intersection(available)
     }
 }
 

--- a/DatadogRUM/Sources/RUMConfiguration.swift
+++ b/DatadogRUM/Sources/RUMConfiguration.swift
@@ -420,17 +420,21 @@ extension RUM {
         public struct Timeseries {
             /// The specific timeseries types to collect.
             ///
-            /// Default: `nil` - which means all available timeseries types are collected.
+            /// Default: `nil` - which means no timeseries types are collected. Use `.defaultTimeseries` for the
+            /// standard set (memory and CPU).
             public var collectTypes: [TimeseriesType]?
 
             /// Creates a timeseries configuration.
             /// - Parameters:
-            ///   - collectTypes: The specific timeseries types to collect. Default: `nil` - all types are collected.
+            ///   - collectTypes: The specific timeseries types to collect. Default: `nil` - no types are collected.
             public init(
                 collectTypes: [TimeseriesType]? = nil
             ) {
                 self.collectTypes = collectTypes
             }
+
+            /// The default timeseries configuration: memory and CPU.
+            public static let defaultTimeseries = Timeseries(collectTypes: [.memory, .cpu])
         }
 
         /// A timeseries type that can be collected.
@@ -590,10 +594,10 @@ extension RUM.Configuration.Timeseries {
     ///
     /// Empty means timeseries collection should be disabled entirely (e.g. `collectTypes: [.cpu]` on watchOS).
     internal var effectiveCollectTypes: Set<RUM.Configuration.TimeseriesType> {
-        let available = RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform
         guard let collectTypes else {
-            return available
+            return []
         }
+        let available = RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform
         return Set(collectTypes).intersection(available)
     }
 }

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -117,8 +117,7 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
     }
 
     /// Per-process CPU as a percentage of total device capacity (0–100), summed across all app threads
-    /// and normalized by `activeProcessorCount`, so multi-threaded work is represented correctly without
-    /// artificial clamping to a single core.
+    /// and normalized by `activeProcessorCount`.
     /// Separated into a static so it can be called from the init closure without capturing self.
     private static func processCPU() -> Double? {
         #if os(watchOS)

--- a/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
+++ b/DatadogRUM/Sources/Timeseries/TimeseriesSessionCollector.swift
@@ -116,7 +116,9 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
         timer?.cancel()
     }
 
-    /// Per-process CPU as a percentage (0–100+), summed across all app threads.
+    /// Per-process CPU as a percentage of total device capacity (0–100), summed across all app threads
+    /// and normalized by `activeProcessorCount`, so multi-threaded work is represented correctly without
+    /// artificial clamping to a single core.
     /// Separated into a static so it can be called from the init closure without capturing self.
     private static func processCPU() -> Double? {
         #if os(watchOS)
@@ -156,7 +158,8 @@ internal class TimeseriesSessionCollector: TimeseriesCollecting {
             }
             total += Double(info.cpu_usage) / Double(TH_USAGE_SCALE) * 100.0
         }
-        return min(total, 100.0)
+        let coreCount = max(ProcessInfo.processInfo.activeProcessorCount, 1)
+        return min(max(total / Double(coreCount), 0.0), 100.0)
         #endif
     }
 

--- a/DatadogRUM/Tests/Timeseries/TimeseriesConfigurationTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesConfigurationTests.swift
@@ -17,20 +17,12 @@ class TimeseriesConfigurationTests: XCTestCase {
         #endif
     }
 
-    func testWhenCollectTypesIsNil_effectiveCollectTypesIsEmpty() {
+    func testDefault_collectsMemoryAndCpu() {
         // Given
-        let timeseries = RUM.Configuration.Timeseries()
+        let timeseries = RUM.Configuration.Timeseries.default
 
         // Then
-        XCTAssertTrue(timeseries.effectiveCollectTypes.isEmpty, "No timeseries type is collected unless explicitly requested")
-    }
-
-    func testDefaultTimeseries_collectsMemoryAndCpu() {
-        // Given
-        let timeseries = RUM.Configuration.Timeseries.defaultTimeseries
-
-        // Then
-        XCTAssertEqual(timeseries.collectTypes, [.memory, .cpu])
+        XCTAssertEqual(timeseries.collectTypes, [.memory, .cpu] as Set<RUM.Configuration.TimeseriesType>)
         XCTAssertEqual(timeseries.effectiveCollectTypes, RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform)
     }
 

--- a/DatadogRUM/Tests/Timeseries/TimeseriesConfigurationTests.swift
+++ b/DatadogRUM/Tests/Timeseries/TimeseriesConfigurationTests.swift
@@ -17,11 +17,20 @@ class TimeseriesConfigurationTests: XCTestCase {
         #endif
     }
 
-    func testWhenCollectTypesIsNil_effectiveCollectTypesReturnsAllAvailableOnCurrentPlatform() {
+    func testWhenCollectTypesIsNil_effectiveCollectTypesIsEmpty() {
         // Given
         let timeseries = RUM.Configuration.Timeseries()
 
         // Then
+        XCTAssertTrue(timeseries.effectiveCollectTypes.isEmpty, "No timeseries type is collected unless explicitly requested")
+    }
+
+    func testDefaultTimeseries_collectsMemoryAndCpu() {
+        // Given
+        let timeseries = RUM.Configuration.Timeseries.defaultTimeseries
+
+        // Then
+        XCTAssertEqual(timeseries.collectTypes, [.memory, .cpu])
         XCTAssertEqual(timeseries.effectiveCollectTypes, RUM.Configuration.TimeseriesType.allAvailableOnCurrentPlatform)
     }
 

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3935,6 +3935,7 @@ public final class objc_RUMTimeseriesType: NSObject
     public static let cpu = objc_RUMTimeseriesType(.cpu)
 public final class objc_RUMTimeseriesConfiguration: NSObject
     public init(collectTypes: [objc_RUMTimeseriesType]?)
+    public static let defaultTimeseries = objc_RUMTimeseriesConfiguration(collectTypes: [.memory, .cpu])
 public class objc_OperationOptions: NSObject
 public final class objc_ProfilingOptions: objc_OperationOptions
     public init(sampleRate: Float)

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -3934,8 +3934,8 @@ public final class objc_RUMTimeseriesType: NSObject
     public static let memory = objc_RUMTimeseriesType(.memory)
     public static let cpu = objc_RUMTimeseriesType(.cpu)
 public final class objc_RUMTimeseriesConfiguration: NSObject
-    public init(collectTypes: [objc_RUMTimeseriesType]?)
-    public static let defaultTimeseries = objc_RUMTimeseriesConfiguration(collectTypes: [.memory, .cpu])
+    public init(collectTypes: [objc_RUMTimeseriesType])
+    public static let `default` = objc_RUMTimeseriesConfiguration(collectTypes: [.memory, .cpu])
 public class objc_OperationOptions: NSObject
 public final class objc_ProfilingOptions: objc_OperationOptions
     public init(sampleRate: Float)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -433,9 +433,9 @@ public enum RUM
             case average
             case rare
         public struct Timeseries
-            public var collectTypes: [TimeseriesType]?
-            public init(collectTypes: [TimeseriesType]? = nil)
-            public static let defaultTimeseries = Timeseries(collectTypes: [.memory, .cpu])
+            public var collectTypes: Set<TimeseriesType>
+            public init(collectTypes: Set<TimeseriesType>)
+            public static let `default` = Timeseries(collectTypes: [.memory, .cpu])
         public enum TimeseriesType: CaseIterable
             case memory
             case cpu

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -435,6 +435,7 @@ public enum RUM
         public struct Timeseries
             public var collectTypes: [TimeseriesType]?
             public init(collectTypes: [TimeseriesType]? = nil)
+            public static let defaultTimeseries = Timeseries(collectTypes: [.memory, .cpu])
         public enum TimeseriesType: CaseIterable
             case memory
             case cpu


### PR DESCRIPTION
### What and why?

Adds `RUM.Configuration.Timeseries.default`, a stable, explicit constant for the standard timeseries set (memory + CPU). `collectTypes:` is now mandatory so customers need to specify which Timeseries they want to collect.

Also normalizes the CPU value by the CPU cores count and then clamps to 100%.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference (no ticket for this change)
- [ ] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our guidelines (internal)
- [x] Run `make api-surface` when adding new APIs