### PR TITLE
[RUM-16719] Remove dead pre-iOS 15 completion-detection fallback

### DIFF
--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -151,22 +151,16 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
         if let delegateClass = configuration?.delegateClass {
             // Swizzle delegate methods for metrics collection and completion detection:
             // - didFinishCollecting: Captures `URLSessionTaskMetrics` for detailed timing information
-            // - didCompleteWithError: Detects completion on pre-iOS 15 where setState doesn't fire
+            // - didCompleteWithError: Detects completion for tasks with completion handlers
             //
             // Completion detection strategy:
-            // For tasks WITHOUT completion handlers:
-            //   - iOS 15+: setState swizzling detects completion (didCompleteWithError is not called by URLSession)
-            //   - Pre-iOS 15: didCompleteWithError delegate detects completion (setState doesn't change to completed)
-            // For tasks WITH completion handlers:
-            //   - All iOS versions: Completion handler swizzling detects completion
+            // - Tasks WITHOUT completion handlers: setState swizzling detects completion
+            //   (didCompleteWithError is not called by URLSession in this case)
+            // - Tasks WITH completion handlers: Completion handler swizzling detects completion
             try swizzler.swizzle(
                 delegateClass: delegateClass,
                 interceptDidFinishCollecting: { [weak self] session, task, metrics in
                     self?.task(task, didFinishCollecting: metrics)
-
-                    if !task.dd.hasCompletion {
-                        self?.task(task, didCompleteWithError: task.error)
-                    }
                 },
                 interceptDidCompleteWithError: { [weak self] session, task, error in
                     self?.task(task, didCompleteWithError: error)

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionSwizzler.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionSwizzler.swift
@@ -80,11 +80,9 @@ internal final class URLSessionSwizzler {
             swizzle(method) { previousImplementation -> Signature in
                 return { session, request, completionHandler -> URLSessionDataTask in
                     guard let completionHandler = completionHandler else {
-                        // The `completionHandler` can be `nil` in two cases:
-                        // - on iOS 11 or 12, where `dataTask(with:)` (for `URL` and `URLRequest`) calls
-                        //   the `dataTask(with:completionHandler:)` (for `URLRequest`) internally by nullifying the completion block.
-                        // - when `[session dataTaskWithURL:completionHandler:]` is called in Objective-C with explicitly passing
-                        //   `nil` as the `completionHandler` (it produces a warning, but compiles).
+                        // The `completionHandler` can be `nil` when `[session dataTaskWithURL:completionHandler:]` is called
+                        // in Objective-C with explicitly passing `nil` as the `completionHandler` (it produces a warning,
+                        // but compiles).
                         return previousImplementation(session, Self.selector, request, completionHandler)
                     }
 
@@ -136,11 +134,9 @@ internal final class URLSessionSwizzler {
             swizzle(method) { previousImplementation -> Signature in
                 return { session, url, completionHandler -> URLSessionDataTask in
                     guard let completionHandler = completionHandler else {
-                        // The `completionHandler` can be `nil` in two cases:
-                        // - on iOS 11 or 12, where `dataTask(with:)` (for `URL` and `URLRequest`) calls
-                        //   the `dataTask(with:completionHandler:)` (for `URLRequest`) internally by nullifying the completion block.
-                        // - when `[session dataTaskWithURL:completionHandler:]` is called in Objective-C with explicitly passing
-                        //   `nil` as the `completionHandler` (it produces a warning, but compiles).
+                        // The `completionHandler` can be `nil` when `[session dataTaskWithURL:completionHandler:]` is called
+                        // in Objective-C with explicitly passing `nil` as the `completionHandler` (it produces a warning,
+                        // but compiles).
                         return previousImplementation(session, Self.selector, url, completionHandler)
                     }
 


### PR DESCRIPTION
### What and why?

The last back-deployment workaround left over from raising the minimum deployment target to iOS 15: a manual fallback that detected completion for delegate-based tasks without a completion handler, needed because `setState` swizzling used to be unreliable on older OS versions. Now that iOS 15 is the floor, that fallback path never runs, so it's removed along with a stale comment describing iOS 11/12 completion-handler behavior that's no longer reachable.

### How?

Completion for delegate-based tasks without a completion handler is now detected solely through `setState` swizzling, which is the same path already used on iOS 15+. There's no longer a second detection path standing by for older OS versions.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration) — removing dead code already covered by existing `setState`-based tests; ran the full `DatadogInternal` suite (386 tests passed)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — not user-facing
- [ ] Add Objective-C interface for public APIs — no public API changes
- [ ] Run `make api-surface` when adding new APIs — no new APIs