### PR TITLE
[FFL-2891] Add assignment request timeout

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -872,6 +872,8 @@
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A01D384CBDE4FFDC49CCD424 /* HeatmapIdentifierRegistryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9F4D5BEEE5E977A58E2034 /* HeatmapIdentifierRegistryFeature.swift */; };
 		A1B2C3D42F90000100ABCDEF /* aggregation_worker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D22F90000100ABCDEF /* aggregation_worker.cpp */; };
+		A1B2C3D4E5F60718293A4B61 /* AssignmentRequestFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B60 /* AssignmentRequestFetch.swift */; };
+		A1B2C3D4E5F60718293A4B63 /* AssignmentRequestFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B62 /* AssignmentRequestFetchTests.swift */; };
 		A1B2C3D52F90000100ABCDEF /* aggregation_worker.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D32F90000100ABCDEF /* aggregation_worker.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1B2C3E52F92000100ABCDEF /* ProfilingContext+RUM.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E42F92000100ABCDEF /* ProfilingContext+RUM.swift */; };
 		A1B2C3E72F92000100ABCDEF /* ProfilingContextRUMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E62F92000100ABCDEF /* ProfilingContextRUMTests.swift */; };
@@ -2870,6 +2872,8 @@
 		9EC8B5ED2668E4DB000F7529 /* VitalCPUReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalCPUReaderTests.swift; sourceTree = "<group>"; };
 		A1B2C3D22F90000100ABCDEF /* aggregation_worker.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = aggregation_worker.cpp; sourceTree = "<group>"; };
 		A1B2C3D32F90000100ABCDEF /* aggregation_worker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = aggregation_worker.h; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B60 /* AssignmentRequestFetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentRequestFetch.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B62 /* AssignmentRequestFetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentRequestFetchTests.swift; sourceTree = "<group>"; };
 		A1B2C3E42F92000100ABCDEF /* ProfilingContext+RUM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProfilingContext+RUM.swift"; sourceTree = "<group>"; };
 		A1B2C3E62F92000100ABCDEF /* ProfilingContextRUMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingContextRUMTests.swift; sourceTree = "<group>"; };
 		A70A82642A935F210072F5DC /* BackgroundTaskCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundTaskCoordinator.swift; sourceTree = "<group>"; };
@@ -4102,6 +4106,7 @@
 				5B5B8CB52E8BCA5F00A6740E /* FlagsRepositoryTests.swift */,
 				5B1D02722E8D2EF300AB2391 /* FlagAssignmentsRequestTests.swift */,
 				5B1D02782E8D6DE400AB2391 /* FlagAssignmentsFetcherTests.swift */,
+				A1B2C3D4E5F60718293A4B62 /* AssignmentRequestFetchTests.swift */,
 				11014EACF1FB9927DAD57822 /* EvaluationMocks.swift */,
 				BDC44AD2847746ED69201F65 /* EvaluationLoggingTests.swift */,
 				5AA681535D980BA99B12659B /* EvaluationAggregatorTests.swift */,
@@ -4188,6 +4193,7 @@
 				5BF802712E9CD12E00097B0E /* RUMFlagEvaluationReporter.swift */,
 				5B1D027B2E8D896300AB2391 /* FlagAssignmentsRequest.swift */,
 				5B1D027C2E8D896300AB2391 /* FlagAssignmentsFetcher.swift */,
+				A1B2C3D4E5F60718293A4B60 /* AssignmentRequestFetch.swift */,
 				5B5B8CC12E8C0E8900A6740E /* FlagsClientProtocol.swift */,
 				8DADC3AE2E7CCF0D0060F558 /* FlagsClient.swift */,
 				5BBDF1C22E97B33300670CEB /* FallbackFlagsClient.swift */,
@@ -8397,6 +8403,7 @@
 				5B0E75DB2E9690D200F66739 /* ExposureTracker.swift in Sources */,
 				5B16A3702E83EE340046A863 /* FlagAssignmentsResponse.swift in Sources */,
 				5B1D027D2E8D896300AB2391 /* FlagAssignmentsFetcher.swift in Sources */,
+				A1B2C3D4E5F60718293A4B61 /* AssignmentRequestFetch.swift in Sources */,
 				5B1D027E2E8D896300AB2391 /* FlagAssignmentsRequest.swift in Sources */,
 				5BB294C02E83E02900CAA44B /* ExposureLogger.swift in Sources */,
 				27A047D86EB162480FF0C5AC /* EvaluationLogger.swift in Sources */,
@@ -8422,6 +8429,7 @@
 				5B1D02912E8ED10500AB2391 /* ExposureEventTests.swift in Sources */,
 				5B1D026E2E8D079F00AB2391 /* FallbackFlagsClientTests.swift in Sources */,
 				5B1D027A2E8D6DE700AB2391 /* FlagAssignmentsFetcherTests.swift in Sources */,
+				A1B2C3D4E5F60718293A4B63 /* AssignmentRequestFetchTests.swift in Sources */,
 				5B16A3732E8434200046A863 /* ExposureMocks.swift in Sources */,
 				5B5B8CB62E8BCA6A00A6740E /* FlagsRepositoryTests.swift in Sources */,
 				5B16A36B2E83E46F0046A863 /* AnyValueTests.swift in Sources */,

--- a/DatadogFlags/Sources/Client/AssignmentRequestFetch.swift
+++ b/DatadogFlags/Sources/Client/AssignmentRequestFetch.swift
@@ -1,0 +1,312 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import DatadogInternal
+
+internal typealias AssignmentRequestSchedule = @Sendable (
+    TimeInterval,
+    @escaping @Sendable () -> Void
+) -> @Sendable () -> Void
+
+private final class AssignmentRequestScheduledWork: @unchecked Sendable {
+    let workItem: DispatchWorkItem
+
+    init(operation: @escaping @Sendable () -> Void) {
+        workItem = DispatchWorkItem(block: operation)
+    }
+}
+
+private final class AssignmentRequestTimeoutOperation: @unchecked Sendable {
+    static let maximumSupportedTimeout: TimeInterval = 2_147_483.647
+
+    private struct State {
+        var isStarted = false
+        var isComplete = false
+        var cancelFetch: Flags.AssignmentRequestFetch.Cancellation?
+        var cancelTimeout: Flags.AssignmentRequestFetch.Cancellation?
+        var completion: Flags.AssignmentRequestFetch.Completion?
+        var keepAlive: AssignmentRequestTimeoutOperation?
+    }
+
+    private let request: URLRequest
+    private let timeout: TimeInterval
+    private let fetch: Flags.AssignmentRequestFetch
+    private let schedule: AssignmentRequestSchedule
+
+    @ReadWriteLock
+    private var state = State()
+
+    init(
+        request: URLRequest,
+        timeout: TimeInterval,
+        fetch: Flags.AssignmentRequestFetch,
+        schedule: @escaping AssignmentRequestSchedule
+    ) {
+        self.request = request
+        self.timeout = timeout
+        self.fetch = fetch
+        self.schedule = schedule
+    }
+
+    @discardableResult
+    func start(
+        completion: @escaping Flags.AssignmentRequestFetch.Completion
+    ) -> Flags.AssignmentRequestFetch.Cancellation {
+        var shouldStart = false
+        _state.mutate { state in
+            guard !state.isStarted else {
+                return
+            }
+            state.isStarted = true
+            state.completion = completion
+            state.keepAlive = self
+            shouldStart = true
+        }
+        guard shouldStart else {
+            return {}
+        }
+
+        let cancelFetch = fetch(request) { [self] result in
+            finish(with: result)
+        }
+        setFetchCancellation(cancelFetch)
+
+        if isActive {
+            let cancelTimeout = schedule(timeout) { [weak self] in
+                self?.timeOut()
+            }
+            setTimeoutCancellation(cancelTimeout)
+        }
+
+        return { [weak self] in self?.cancel() }
+    }
+
+    private var isActive: Bool {
+        !state.isComplete
+    }
+
+    private func setFetchCancellation(
+        _ cancellation: @escaping Flags.AssignmentRequestFetch.Cancellation
+    ) {
+        var didSet = false
+        _state.mutate { state in
+            guard !state.isComplete else {
+                return
+            }
+            state.cancelFetch = cancellation
+            didSet = true
+        }
+        if !didSet {
+            cancellation()
+        }
+    }
+
+    private func setTimeoutCancellation(
+        _ cancellation: @escaping Flags.AssignmentRequestFetch.Cancellation
+    ) {
+        var didSet = false
+        _state.mutate { state in
+            guard !state.isComplete else {
+                return
+            }
+            state.cancelTimeout = cancellation
+            didSet = true
+        }
+        if !didSet {
+            cancellation()
+        }
+    }
+
+    private func timeOut() {
+        var cancelFetch: Flags.AssignmentRequestFetch.Cancellation?
+        var completion: Flags.AssignmentRequestFetch.Completion?
+        _state.mutate { state in
+            guard !state.isComplete else {
+                return
+            }
+            state.isComplete = true
+            cancelFetch = state.cancelFetch
+            state.cancelFetch = nil
+            state.cancelTimeout = nil
+            completion = state.completion
+            state.completion = nil
+            state.keepAlive = nil
+        }
+        cancelFetch?()
+        completion?(.failure(URLError(.timedOut)))
+    }
+
+    private func finish(
+        with result: Result<Flags.AssignmentRequestFetch.Response, Error>
+    ) {
+        var cancelTimeout: Flags.AssignmentRequestFetch.Cancellation?
+        var completion: Flags.AssignmentRequestFetch.Completion?
+        _state.mutate { state in
+            guard !state.isComplete else {
+                return
+            }
+            state.isComplete = true
+            cancelTimeout = state.cancelTimeout
+            state.cancelTimeout = nil
+            state.cancelFetch = nil
+            completion = state.completion
+            state.completion = nil
+            state.keepAlive = nil
+        }
+        cancelTimeout?()
+        completion?(result)
+    }
+
+    private func cancel() {
+        var cancelFetch: Flags.AssignmentRequestFetch.Cancellation?
+        var cancelTimeout: Flags.AssignmentRequestFetch.Cancellation?
+        _state.mutate { state in
+            guard !state.isComplete else {
+                return
+            }
+            state.isComplete = true
+            cancelFetch = state.cancelFetch
+            cancelTimeout = state.cancelTimeout
+            state.cancelFetch = nil
+            state.cancelTimeout = nil
+            state.completion = nil
+            state.keepAlive = nil
+        }
+        cancelTimeout?()
+        cancelFetch?()
+    }
+
+    static func boundedTimeout(_ timeout: TimeInterval) -> TimeInterval? {
+        guard timeout.isFinite, timeout > 0 else {
+            return nil
+        }
+        return min(timeout, maximumSupportedTimeout)
+    }
+
+    static let schedule: AssignmentRequestSchedule = { delay, work in
+        let scheduledWork = AssignmentRequestScheduledWork(operation: work)
+        DispatchQueue.global().asyncAfter(
+            deadline: .now() + delay,
+            execute: scheduledWork.workItem
+        )
+        return { scheduledWork.workItem.cancel() }
+    }
+}
+
+extension Flags {
+    /// A transport for precomputed flag-assignment requests.
+    ///
+    /// The SDK builds the complete request before it passes the request to this transport.
+    public struct AssignmentRequestFetch: Sendable {
+        /// The response returned by an assignment-request transport.
+        public struct Response: Sendable {
+            /// The complete response body.
+            public let data: Data
+
+            /// The HTTP response metadata.
+            public let httpResponse: HTTPURLResponse
+
+            /// Creates an assignment-request response.
+            public init(data: Data, httpResponse: HTTPURLResponse) {
+                self.data = data
+                self.httpResponse = httpResponse
+            }
+        }
+
+        /// Completion callback for an assignment request.
+        public typealias Completion = @Sendable (Result<Response, Error>) -> Void
+
+        /// Requests cancellation of an in-flight assignment request.
+        public typealias Cancellation = @Sendable () -> Void
+
+        private let execute: @Sendable (
+            URLRequest,
+            @escaping Completion
+        ) -> Cancellation
+
+        /// Creates a transport from a request execution closure.
+        public init(
+            _ fetch: @escaping @Sendable (
+                URLRequest,
+                @escaping Completion
+            ) -> Cancellation
+        ) {
+            execute = fetch
+        }
+
+        /// Executes this transport for an SDK-built assignment request.
+        @discardableResult
+        public func callAsFunction(
+            _ request: URLRequest,
+            completion: @escaping Completion
+        ) -> Cancellation {
+            execute(request, completion)
+        }
+
+        /// Creates the SDK's default assignment transport with an ephemeral `URLSession`.
+        public static func urlSession() -> Self {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.urlCache = nil
+            return urlSession(URLSession(configuration: configuration))
+        }
+
+        /// Creates an assignment transport with a caller-provided `URLSession`.
+        public static func urlSession(_ session: URLSession) -> Self {
+            Self { request, completion in
+                let task = session.dataTask(with: request) { data, response, error in
+                    if let error {
+                        completion(.failure(error))
+                        return
+                    }
+                    guard let httpResponse = response as? HTTPURLResponse else {
+                        completion(.failure(URLError(.badServerResponse)))
+                        return
+                    }
+                    completion(
+                        .success(
+                            Response(
+                                data: data ?? Data(),
+                                httpResponse: httpResponse
+                            )
+                        )
+                    )
+                }
+                task.resume()
+                return { task.cancel() }
+            }
+        }
+
+        /// Wraps this transport with a timeout for the complete response-body download.
+        ///
+        /// A value of zero disables the timer. Negative and non-finite values leave the transport unchanged.
+        /// Values above the supported timer range are capped at `2_147_483.647` seconds.
+        public func withTimeout(_ timeout: TimeInterval) -> Self {
+            withTimeout(timeout, schedule: AssignmentRequestTimeoutOperation.schedule)
+        }
+
+        internal func withTimeout(
+            _ timeout: TimeInterval,
+            schedule: @escaping AssignmentRequestSchedule
+        ) -> Self {
+            guard let timeout = AssignmentRequestTimeoutOperation.boundedTimeout(timeout) else {
+                return self
+            }
+            return Self { request, completion in
+                let operation = AssignmentRequestTimeoutOperation(
+                    request: request,
+                    timeout: timeout,
+                    fetch: self,
+                    schedule: schedule
+                )
+                return operation.start(completion: completion)
+            }
+        }
+    }
+}

--- a/DatadogFlags/Sources/Client/FlagAssignmentsFetcher.swift
+++ b/DatadogFlags/Sources/Client/FlagAssignmentsFetcher.swift
@@ -14,43 +14,55 @@ internal protocol FlagAssignmentsFetching {
     )
 }
 
+private final class FlagAssignmentsCompletionGate: @unchecked Sendable {
+    @ReadWriteLock
+    private var isComplete = false
+
+    func accept() -> Bool {
+        var accepted = false
+        _isComplete.mutate { isComplete in
+            guard !isComplete else {
+                return
+            }
+            isComplete = true
+            accepted = true
+        }
+        return accepted
+    }
+}
+
 internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
     let customEndpoint: URL?
     let customHeaders: [String: String]?
 
     private let featureScope: any FeatureScope
-    private let fetch: (URLRequest, @escaping (Result<Data, Error>) -> Void) -> Void
+    private let assignmentRequestFetch: Flags.AssignmentRequestFetch
 
     private static let decoder = JSONDecoder()
-
-    convenience init(
-        customEndpoint: URL?,
-        customHeaders: [String: String]?,
-        featureScope: any FeatureScope
-    ) {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.urlCache = nil
-
-        let urlSession = URLSession(configuration: configuration)
-
-        self.init(
-            customEndpoint: customEndpoint,
-            customHeaders: customHeaders,
-            featureScope: featureScope,
-            fetch: urlSession.fetch
-        )
-    }
 
     init(
         customEndpoint: URL?,
         customHeaders: [String: String]?,
         featureScope: any FeatureScope,
-        fetch: @escaping (URLRequest, @escaping (Result<Data, Error>) -> Void) -> Void
+        assignmentRequestFetch: Flags.AssignmentRequestFetch
     ) {
+        let completionQueue = DispatchQueue(
+            label: "com.datadoghq.flags.assignment-request-completion"
+        )
         self.customEndpoint = customEndpoint
         self.customHeaders = customHeaders
         self.featureScope = featureScope
-        self.fetch = fetch
+        self.assignmentRequestFetch = .init { request, completion in
+            let completionGate = FlagAssignmentsCompletionGate()
+            return assignmentRequestFetch(request) { result in
+                completionQueue.async {
+                    guard completionGate.accept() else {
+                        return
+                    }
+                    completion(result)
+                }
+            }
+        }
     }
 
     func flagAssignments(
@@ -69,11 +81,25 @@ internal final class FlagAssignmentsFetcher: FlagAssignmentsFetching {
                     context: context,
                     customHeaders: self.customHeaders
                 )
-                self.fetch(request) { [featureScope] result in
+                self.assignmentRequestFetch(request) { [featureScope] result in
                     switch result {
-                    case .success(let data):
+                    case .success(let response):
+                        guard 200..<300 ~= response.httpResponse.statusCode else {
+                            let error = URLError(.badServerResponse)
+                            DD.logger.error("Failed to fetch flag assignments from the server.", error: error)
+                            featureScope.telemetry.error(
+                                "Failed to fetch flag assignments from the server "
+                                    + "(status: \(response.httpResponse.statusCode))",
+                                error: error
+                            )
+                            completion(.failure(.networkError(error)))
+                            return
+                        }
                         do {
-                            let response = try Self.decoder.decode(FlagAssignmentsResponse.self, from: data)
+                            let response = try Self.decoder.decode(
+                                FlagAssignmentsResponse.self,
+                                from: response.data
+                            )
 
                             // Log any flags that failed to decode to telemetry
                             if !response.failedFlags.isEmpty {
@@ -141,31 +167,5 @@ extension DatadogSite {
             return URL(string: "https://\(subdomain).ff-cdn.datadoghq.com")!
         // swiftlint:enable force_unwrapping
         }
-    }
-}
-
-extension URLSession {
-    fileprivate func fetch(
-        _ request: URLRequest,
-        completion: @escaping (Result<Data, Error>) -> Void
-    ) {
-        let task = self.dataTask(with: request) { data, response, error in
-            if let error {
-                completion(.failure(error))
-                return
-            }
-
-            guard
-                let data,
-                let httpResponse = response as? HTTPURLResponse,
-                200..<300 ~= httpResponse.statusCode
-            else {
-                completion(.failure(URLError(.badServerResponse)))
-                return
-            }
-
-            completion(.success(data))
-        }
-        task.resume()
     }
 }

--- a/DatadogFlags/Sources/Feature/FlagsFeature.swift
+++ b/DatadogFlags/Sources/Feature/FlagsFeature.swift
@@ -31,10 +31,14 @@ internal struct FlagsFeature: DatadogRemoteFeature {
         featureScope: FeatureScope,
         core: DatadogCoreProtocol
     ) {
+        let assignmentRequestFetch = configuration.assignmentRequestFetch
+            ?? Flags.AssignmentRequestFetch.urlSession()
+                .withTimeout(configuration.assignmentRequestTimeout)
         flagAssignmentsFetcher = FlagAssignmentsFetcher(
             customEndpoint: configuration.customFlagsEndpoint,
             customHeaders: configuration.customFlagsHeaders,
-            featureScope: featureScope
+            featureScope: featureScope,
+            assignmentRequestFetch: assignmentRequestFetch
         )
         requestBuilder = ExposureRequestBuilder(
             customIntakeURL: configuration.customExposureEndpoint,

--- a/DatadogFlags/Sources/Flags.swift
+++ b/DatadogFlags/Sources/Flags.swift
@@ -58,6 +58,24 @@ public enum Flags {
         /// Default: `nil`.
         public var customFlagsHeaders: [String: String]?
 
+        /// A custom transport used only to retrieve precomputed flag assignments.
+        ///
+        /// The SDK constructs the URL, body, authentication, and custom headers. Exposure and evaluation uploads do
+        /// not use this transport. Use `AssignmentRequestFetch.urlSession().withTimeout(_:)` to compose a timeout.
+        /// The application retains ownership of a supplied `URLSession` and other transport resources.
+        ///
+        /// Default: `nil` (use the SDK transport).
+        public var assignmentRequestFetch: Flags.AssignmentRequestFetch?
+
+        /// The timeout for a request that retrieves precomputed flag assignments.
+        ///
+        /// The timeout includes the complete response-body download. Set this value to `0` to disable the SDK
+        /// timeout. A negative or non-finite value also disables it. Values greater than `2_147_483.647` seconds are
+        /// reduced to this maximum. A custom `assignmentRequestFetch` replaces this setting.
+        ///
+        /// Default: `0` (disabled).
+        public var assignmentRequestTimeout: TimeInterval
+
         /// Custom server url for sending Flags exposure data.
         ///
         /// Default: `nil`.
@@ -122,6 +140,8 @@ public enum Flags {
             self.gracefulModeEnabled = gracefulModeEnabled
             self.customFlagsEndpoint = customFlagsEndpoint
             self.customFlagsHeaders = customFlagsHeaders
+            self.assignmentRequestFetch = nil
+            self.assignmentRequestTimeout = 0
             self.customExposureEndpoint = customExposureEndpoint
             self.trackExposures = trackExposures
             self.customEvaluationEndpoint = customEvaluationEndpoint

--- a/DatadogFlags/Tests/Client/AssignmentRequestFetchTests.swift
+++ b/DatadogFlags/Tests/Client/AssignmentRequestFetchTests.swift
@@ -1,0 +1,351 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogFlags
+
+final class AssignmentRequestFetchTests: XCTestCase {
+    func testCallerCanComposeOwnWrapperUsingPublicInvocation() throws {
+        let receivedRequest = LockedBox<URLRequest?>(nil)
+        let cancellationCount = LockedBox(0)
+        let capturedResult = LockedBox<Result<Flags.AssignmentRequestFetch.Response, Error>?>(nil)
+        let base = Flags.AssignmentRequestFetch { request, completion in
+            receivedRequest.value = request
+            completion(.success(mockAssignmentResponse()))
+            return { cancellationCount.mutate { $0 += 1 } }
+        }
+        let wrapped = Flags.AssignmentRequestFetch { request, completion in
+            var request = request
+            request.setValue("wrapper-value", forHTTPHeaderField: "X-Caller-Wrapper")
+            return base(request, completion: completion)
+        }
+
+        let cancel = wrapped(URLRequest(url: .mockAny())) { capturedResult.value = $0 }
+
+        XCTAssertEqual(receivedRequest.value?.value(forHTTPHeaderField: "X-Caller-Wrapper"), "wrapper-value")
+        _ = try XCTUnwrap(capturedResult.value).get()
+        cancel()
+        XCTAssertEqual(cancellationCount.value, 1, "a caller-authored wrapper must preserve cancellation")
+    }
+
+    func testTimeoutCancelsFetchAndCompletesOnce() throws {
+        let scheduler = ManualAssignmentRequestScheduler()
+        let fetchCompletion = LockedBox<Flags.AssignmentRequestFetch.Completion?>(nil)
+        let cancellationCount = LockedBox(0)
+        let completionCount = LockedBox(0)
+        let capturedResult = LockedBox<Result<Flags.AssignmentRequestFetch.Response, Error>?>(nil)
+        let base = Flags.AssignmentRequestFetch { _, completion in
+            fetchCompletion.value = completion
+            return { cancellationCount.mutate { $0 += 1 } }
+        }
+        let fetch = base.withTimeout(1, schedule: scheduler.makeSchedule())
+
+        _ = fetch(URLRequest(url: .mockAny())) { result in
+            completionCount.mutate { $0 += 1 }
+            capturedResult.value = result
+        }
+        scheduler.runNext()
+
+        XCTAssertEqual(cancellationCount.value, 1)
+        XCTAssertEqual(completionCount.value, 1)
+        XCTAssertEqual(try XCTUnwrap(capturedResult.value).failureURLCode, .timedOut)
+
+        fetchCompletion.value?(.success(mockAssignmentResponse()))
+        XCTAssertEqual(completionCount.value, 1, "a late transport callback must be ignored")
+    }
+
+    func testSynchronousCompletionCancelsReturnedTransportHandleWithoutSchedulingTimeout() throws {
+        let scheduler = ManualAssignmentRequestScheduler()
+        let cancellationCount = LockedBox(0)
+        let capturedResult = LockedBox<Result<Flags.AssignmentRequestFetch.Response, Error>?>(nil)
+        let base = Flags.AssignmentRequestFetch { _, completion in
+            completion(.success(mockAssignmentResponse()))
+            return { cancellationCount.mutate { $0 += 1 } }
+        }
+
+        _ = base.withTimeout(1, schedule: scheduler.makeSchedule())(URLRequest(url: .mockAny())) {
+            capturedResult.value = $0
+        }
+
+        XCTAssertEqual(cancellationCount.value, 1)
+        XCTAssertTrue(scheduler.delays.isEmpty)
+        _ = try XCTUnwrap(capturedResult.value).get()
+    }
+
+    func testCancellationStopsFetchAndTimerWithoutCompleting() {
+        let scheduler = ManualAssignmentRequestScheduler()
+        let fetchCancellationCount = LockedBox(0)
+        let completionCount = LockedBox(0)
+        let base = Flags.AssignmentRequestFetch { _, _ in
+            return { fetchCancellationCount.mutate { $0 += 1 } }
+        }
+        let cancel = base.withTimeout(1, schedule: scheduler.makeSchedule())(URLRequest(url: .mockAny())) { _ in
+            completionCount.mutate { $0 += 1 }
+        }
+
+        cancel()
+        scheduler.runNext()
+
+        XCTAssertEqual(fetchCancellationCount.value, 1)
+        XCTAssertEqual(completionCount.value, 0)
+        XCTAssertTrue(scheduler.delays.isEmpty)
+    }
+
+    func testDisabledAndInvalidTimeoutsLeaveTransportUnchanged() throws {
+        for timeout in [0, -1, .nan, .infinity] {
+            let scheduler = ManualAssignmentRequestScheduler()
+            let capturedResult = LockedBox<Result<Flags.AssignmentRequestFetch.Response, Error>?>(nil)
+            let base = Flags.AssignmentRequestFetch { _, completion in
+                completion(.success(mockAssignmentResponse()))
+                return {}
+            }
+
+            _ = base.withTimeout(timeout, schedule: scheduler.makeSchedule())(URLRequest(url: .mockAny())) {
+                capturedResult.value = $0
+            }
+
+            XCTAssertTrue(scheduler.delays.isEmpty, "timeout: \(timeout)")
+            _ = try XCTUnwrap(capturedResult.value).get()
+        }
+    }
+
+    func testTimeoutIsCappedAtSupportedTimerRange() {
+        let scheduler = ManualAssignmentRequestScheduler()
+        let base = Flags.AssignmentRequestFetch { _, _ in {} }
+
+        let cancel = base.withTimeout(.greatestFiniteMagnitude, schedule: scheduler.makeSchedule())(
+            URLRequest(url: .mockAny())
+        ) { _ in }
+
+        XCTAssertEqual(scheduler.delays, [2_147_483.647])
+        cancel()
+        XCTAssertTrue(scheduler.delays.isEmpty)
+    }
+
+    func testTimeoutThatFiresDuringTimerRegistrationCompletesOnce() throws {
+        let cancellationCount = LockedBox(0)
+        let completionCount = LockedBox(0)
+        let capturedResult = LockedBox<Result<Flags.AssignmentRequestFetch.Response, Error>?>(nil)
+        let base = Flags.AssignmentRequestFetch { _, _ in
+            return { cancellationCount.mutate { $0 += 1 } }
+        }
+        let schedule: AssignmentRequestSchedule = { _, work in
+            work()
+            return { cancellationCount.mutate { $0 += 1 } }
+        }
+
+        _ = base.withTimeout(1, schedule: schedule)(URLRequest(url: .mockAny())) { result in
+            completionCount.mutate { $0 += 1 }
+            capturedResult.value = result
+        }
+
+        XCTAssertEqual(cancellationCount.value, 2, "both transport and consumed timer handles must be cancelled")
+        XCTAssertEqual(completionCount.value, 1)
+        XCTAssertEqual(try XCTUnwrap(capturedResult.value).failureURLCode, .timedOut)
+    }
+
+    func testDefaultScheduleCancellationPreventsTimeoutCompletion() {
+        let transportCancellationCount = LockedBox(0)
+        let completion = expectation(description: "timeout completion")
+        completion.isInverted = true
+        let base = Flags.AssignmentRequestFetch { _, _ in
+            return { transportCancellationCount.mutate { $0 += 1 } }
+        }
+
+        let cancel = base.withTimeout(0.1)(URLRequest(url: .mockAny())) { _ in
+            completion.fulfill()
+        }
+        cancel()
+
+        wait(for: [completion], timeout: 0.2)
+        XCTAssertEqual(transportCancellationCount.value, 1)
+    }
+
+    func testDefaultScheduleDefersTimeoutByRequestedDelay() throws {
+        let requestedDelay: TimeInterval = 0.1
+        let startedAt = Date()
+        let elapsed = LockedBox<TimeInterval?>(nil)
+        let capturedResult = LockedBox<Result<Flags.AssignmentRequestFetch.Response, Error>?>(nil)
+        let completed = expectation(description: "timeout completed")
+        let base = Flags.AssignmentRequestFetch { _, _ in {} }
+
+        _ = base.withTimeout(requestedDelay)(URLRequest(url: .mockAny())) { result in
+            elapsed.value = Date().timeIntervalSince(startedAt)
+            capturedResult.value = result
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1)
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(elapsed.value), requestedDelay)
+        XCTAssertEqual(try XCTUnwrap(capturedResult.value).failureURLCode, .timedOut)
+    }
+
+    func testCompletedOperationIsNotRetainedByTimerOrCancellation() {
+        let scheduler = ManualAssignmentRequestScheduler()
+        let fetchCompletion = LockedBox<Flags.AssignmentRequestFetch.Completion?>(nil)
+        let cancellation = LockedBox<Flags.AssignmentRequestFetch.Cancellation?>(nil)
+        weak var weakProbe: AssignmentRequestFetchLifetimeProbe?
+
+        autoreleasepool {
+            let probe = AssignmentRequestFetchLifetimeProbe()
+            weakProbe = probe
+            let base = Flags.AssignmentRequestFetch { [probe] _, completion in
+                _ = probe
+                fetchCompletion.value = completion
+                return {}
+            }
+            let fetch = base.withTimeout(1, schedule: scheduler.makeSchedule())
+
+            cancellation.value = fetch(URLRequest(url: .mockAny())) { _ in }
+            fetchCompletion.value?(.success(mockAssignmentResponse()))
+            fetchCompletion.value = nil
+        }
+
+        XCTAssertNotNil(cancellation.value)
+        XCTAssertNil(weakProbe)
+        XCTAssertTrue(scheduler.delays.isEmpty)
+        withExtendedLifetime(cancellation.value) {}
+    }
+
+    func testTransportCompletionIsDeliveredExactlyOnce() throws {
+        let completionCount = LockedBox(0)
+        let capturedResult = LockedBox<Result<Flags.AssignmentRequestFetch.Response, Error>?>(nil)
+        let base = Flags.AssignmentRequestFetch { _, completion in
+            completion(.success(mockAssignmentResponse()))
+            completion(.failure(URLError(.notConnectedToInternet)))
+            return {}
+        }
+
+        _ = base.withTimeout(1)(URLRequest(url: .mockAny())) { result in
+            completionCount.mutate { $0 += 1 }
+            capturedResult.value = result
+        }
+
+        XCTAssertEqual(completionCount.value, 1)
+        _ = try XCTUnwrap(capturedResult.value).get()
+    }
+
+    func testConcurrentTimeoutAndTransportCompletionCompleteExactlyOnce() {
+        for _ in 0..<100 {
+            let timeoutWork = LockedBox<(@Sendable () -> Void)?>(nil)
+            let fetchCompletion = LockedBox<Flags.AssignmentRequestFetch.Completion?>(nil)
+            let completionCount = LockedBox(0)
+            let schedule: AssignmentRequestSchedule = { _, work in
+                timeoutWork.value = work
+                return {}
+            }
+            let base = Flags.AssignmentRequestFetch { _, completion in
+                fetchCompletion.value = completion
+                return {}
+            }
+
+            _ = base.withTimeout(1, schedule: schedule)(URLRequest(url: .mockAny())) { _ in
+                completionCount.mutate { $0 += 1 }
+            }
+
+            let race = DispatchGroup()
+            DispatchQueue.global().async(group: race) {
+                timeoutWork.value?()
+            }
+            DispatchQueue.global().async(group: race) {
+                fetchCompletion.value?(.success(mockAssignmentResponse()))
+            }
+
+            XCTAssertEqual(race.wait(timeout: .now() + 1), .success)
+            XCTAssertEqual(completionCount.value, 1)
+        }
+    }
+}
+
+private final class ManualAssignmentRequestScheduler: @unchecked Sendable {
+    private struct Entry {
+        let id: UUID
+        let delay: TimeInterval
+        let work: @Sendable () -> Void
+    }
+
+    private let lock = NSLock()
+    private var entries: [Entry] = []
+
+    var delays: [TimeInterval] {
+        lock.withLock { entries.map(\.delay) }
+    }
+
+    func makeSchedule() -> AssignmentRequestSchedule {
+        return { [self] delay, work in
+            let id = UUID()
+            lock.withLock {
+                entries.append(Entry(id: id, delay: delay, work: work))
+            }
+            return { [weak self] in
+                self?.lock.withLock {
+                    self?.entries.removeAll { $0.id == id }
+                }
+            }
+        }
+    }
+
+    func runNext() {
+        let work = lock.withLock {
+            entries.isEmpty ? nil : entries.removeFirst().work
+        }
+        work?()
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ operation: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return operation()
+    }
+}
+
+private final class LockedBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Value
+
+    init(_ value: Value) {
+        storedValue = value
+    }
+
+    var value: Value {
+        get { lock.withLock { storedValue } }
+        set { lock.withLock { storedValue = newValue } }
+    }
+
+    func mutate(_ operation: (inout Value) -> Void) {
+        lock.withLock { operation(&storedValue) }
+    }
+}
+
+private final class AssignmentRequestFetchLifetimeProbe {}
+
+private extension Result where Success == Flags.AssignmentRequestFetch.Response, Failure == Error {
+    var failureURLCode: URLError.Code? {
+        guard case .failure(let error) = self else {
+            return nil
+        }
+        return (error as? URLError)?.code
+    }
+}
+
+private func mockAssignmentResponse(
+    statusCode: Int = 200,
+    data: Data = .mockAnyFlagAssignmentsResponse()
+) -> Flags.AssignmentRequestFetch.Response {
+    let url = URL.mockAny()
+    return .init(
+        data: data,
+        httpResponse: HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    )
+}

--- a/DatadogFlags/Tests/Client/FlagAssignmentsFetcherTests.swift
+++ b/DatadogFlags/Tests/Client/FlagAssignmentsFetcherTests.swift
@@ -17,14 +17,15 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
     func testFlagAssignments() throws {
         // Given
         featureScope.contextMock = .mockWith(site: .us3)
-        var capturedRequest: URLRequest?
+        let capturedRequest = LockedBox<URLRequest?>(nil)
         let fetcher = FlagAssignmentsFetcher(
             customEndpoint: nil,
             customHeaders: [:],
             featureScope: featureScope,
-            fetch: { request, completion in
-                capturedRequest = request
-                completion(.success(.mockAnyFlagAssignmentsResponse()))
+            assignmentRequestFetch: .init { request, completion in
+                capturedRequest.value = request
+                completion(.success(mockAssignmentFetchResponse()))
+                return {}
             }
         )
         let completed = expectation(description: "completed")
@@ -37,9 +38,9 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(
-            capturedRequest?.url?.absoluteString,
+            capturedRequest.value?.url?.absoluteString,
             "https://preview.ff-cdn.us3.datadoghq.com/precompute-assignments"
         )
         let flagAssignments = try XCTUnwrap(capturedResult?.get())
@@ -52,8 +53,9 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
             customEndpoint: nil,
             customHeaders: [:],
             featureScope: featureScope,
-            fetch: { _, completion in
+            assignmentRequestFetch: .init { _, completion in
                 completion(.failure(URLError(.notConnectedToInternet)))
+                return {}
             }
         )
         let completedWithNetworkError = expectation(description: "completedWithNetworkError")
@@ -68,7 +70,12 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(
+            featureScope.telemetryMock.messages.firstError()?.message.hasPrefix(
+                "Failed to fetch flag assignments from the server"
+            ) == true
+        )
     }
 
     func testFlagAssignmentsInvalidResponse() {
@@ -77,8 +84,9 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
             customEndpoint: nil,
             customHeaders: [:],
             featureScope: featureScope,
-            fetch: { _, completion in
-                completion(.success(Data()))
+            assignmentRequestFetch: .init { _, completion in
+                completion(.success(mockAssignmentFetchResponse(data: Data())))
+                return {}
             }
         )
         let completedWithInvalidResponseError = expectation(description: "completedWithInvalidResponseError")
@@ -91,20 +99,21 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 1)
     }
 
     func testFlagAssignmentsCustomEndpoint() {
         // Given
         let customEndpoint = URL(string: "https://custom-proxy.com/flags")!
-        var capturedRequest: URLRequest?
+        let capturedRequest = LockedBox<URLRequest?>(nil)
         let fetcher = FlagAssignmentsFetcher(
             customEndpoint: customEndpoint,
             customHeaders: ["X-Custom-Header": "custom-value"],
             featureScope: featureScope,
-            fetch: { request, completion in
-                capturedRequest = request
-                completion(.success(.mockAnyFlagAssignmentsResponse()))
+            assignmentRequestFetch: .init { request, completion in
+                capturedRequest.value = request
+                completion(.success(mockAssignmentFetchResponse()))
+                return {}
             }
         )
 
@@ -116,9 +125,153 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0)
-        XCTAssertEqual(capturedRequest?.url, customEndpoint)
-        XCTAssertEqual(capturedRequest?.allHTTPHeaderFields?["X-Custom-Header"], "custom-value")
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(capturedRequest.value?.url, customEndpoint)
+        XCTAssertEqual(capturedRequest.value?.allHTTPHeaderFields?["X-Custom-Header"], "custom-value")
+    }
+
+    func testFlagAssignmentsRejectsUnsuccessfulHTTPResponse() {
+        // Given
+        let fetcher = FlagAssignmentsFetcher(
+            customEndpoint: nil,
+            customHeaders: [:],
+            featureScope: featureScope,
+            assignmentRequestFetch: .init { _, completion in
+                completion(.success(mockAssignmentFetchResponse(statusCode: 503)))
+                return {}
+            }
+        )
+        let completedWithNetworkError = expectation(description: "completedWithNetworkError")
+
+        // When
+        fetcher.flagAssignments(for: .mockAny()) { result in
+            if case .failure(.networkError(let error)) = result,
+               let urlError = error as? URLError,
+               urlError.code == .badServerResponse {
+                completedWithNetworkError.fulfill()
+            }
+        }
+
+        // Then
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(
+            featureScope.telemetryMock.messages.firstError()?.message.contains(
+                "Failed to fetch flag assignments from the server (status: 503)"
+            ) == true
+        )
+    }
+
+    func testCustomAssignmentRequestFetchReceivesSDKOwnedRequest() throws {
+        // Given
+        featureScope.contextMock = .mockWith(
+            site: .eu1,
+            clientToken: "client-token",
+            additionalContext: [RUMCoreContext.mockWith(applicationID: "application-id")]
+        )
+        let capturedRequest = LockedBox<URLRequest?>(nil)
+        let fetcher = FlagAssignmentsFetcher(
+            customEndpoint: nil,
+            customHeaders: ["X-Custom-Header": "custom-value"],
+            featureScope: featureScope,
+            assignmentRequestFetch: .init { request, completion in
+                capturedRequest.value = request
+                completion(.success(mockAssignmentFetchResponse()))
+                return {}
+            }
+        )
+        let completed = expectation(description: "completed")
+        let capturedResult = LockedBox<Result<[String: FlagAssignment], FlagsError>?>(nil)
+
+        // When
+        fetcher.flagAssignments(for: .mockAny()) {
+            capturedResult.value = $0
+            completed.fulfill()
+        }
+
+        // Then
+        wait(for: [completed], timeout: 1)
+        XCTAssertEqual(
+            capturedRequest.value?.url?.absoluteString,
+            "https://preview.ff-cdn.datadoghq.eu/precompute-assignments"
+        )
+        XCTAssertEqual(capturedRequest.value?.httpMethod, "POST")
+        XCTAssertEqual(capturedRequest.value?.value(forHTTPHeaderField: "dd-client-token"), "client-token")
+        XCTAssertEqual(capturedRequest.value?.value(forHTTPHeaderField: "dd-application-id"), "application-id")
+        XCTAssertEqual(capturedRequest.value?.value(forHTTPHeaderField: "X-Custom-Header"), "custom-value")
+        XCTAssertNotNil(capturedRequest.value?.httpBody)
+        XCTAssertEqual(try XCTUnwrap(capturedResult.value).get(), .mockAny())
+    }
+
+    func testSerializesCompletionDeliveryForConcurrentRequests() {
+        let transportCompletions = LockedBox<[Flags.AssignmentRequestFetch.Completion]>([])
+        let fetcher = FlagAssignmentsFetcher(
+            customEndpoint: nil,
+            customHeaders: nil,
+            featureScope: featureScope,
+            assignmentRequestFetch: .init { _, completion in
+                transportCompletions.mutate { $0.append(completion) }
+                return {}
+            }
+        )
+        let firstEntered = DispatchSemaphore(value: 0)
+        let releaseFirst = DispatchSemaphore(value: 0)
+        let secondEntered = DispatchSemaphore(value: 0)
+
+        fetcher.flagAssignments(for: .mockAny()) { _ in
+            firstEntered.signal()
+            _ = releaseFirst.wait(timeout: .now() + 2)
+        }
+        fetcher.flagAssignments(for: .mockAny()) { _ in
+            secondEntered.signal()
+        }
+        XCTAssertEqual(transportCompletions.value.count, 2)
+
+        transportCompletions.value[0](.success(mockAssignmentFetchResponse()))
+        XCTAssertEqual(firstEntered.wait(timeout: .now() + 1), .success)
+        transportCompletions.value[1](.success(mockAssignmentFetchResponse()))
+        XCTAssertEqual(
+            secondEntered.wait(timeout: .now() + 0.1),
+            .timedOut,
+            "the second callback must not overlap the first callback"
+        )
+        releaseFirst.signal()
+        XCTAssertEqual(secondEntered.wait(timeout: .now() + 1), .success)
+    }
+
+    func testFlagAssignmentsAcceptsOnlyFirstTransportCompletion() {
+        // Given
+        let fetcher = FlagAssignmentsFetcher(
+            customEndpoint: nil,
+            customHeaders: [:],
+            featureScope: featureScope,
+            assignmentRequestFetch: .init { _, completion in
+                completion(.success(mockAssignmentFetchResponse()))
+                completion(.failure(URLError(.timedOut)))
+                return {}
+            }
+        )
+        let completionCount = LockedBox(0)
+        let firstCompletion = expectation(description: "first completion")
+        let duplicateCompletion = expectation(description: "duplicate completion")
+        duplicateCompletion.isInverted = true
+
+        // When
+        fetcher.flagAssignments(for: .mockAny()) { _ in
+            let count = completionCount.mutate { value -> Int in
+                value += 1
+                return value
+            }
+            if count == 1 {
+                firstCompletion.fulfill()
+            } else {
+                duplicateCompletion.fulfill()
+            }
+        }
+
+        // Then
+        wait(for: [firstCompletion], timeout: 1)
+        wait(for: [duplicateCompletion], timeout: 0.1)
+        XCTAssertEqual(completionCount.value, 1)
     }
 
     func testFlagsEndpointForAllSites() {
@@ -136,4 +289,48 @@ final class FlagAssignmentsFetcherTests: XCTestCase {
             XCTAssertEqual(site.flagsEndpoint().absoluteString, expectedEndpoint)
         }
     }
+}
+
+private final class LockedBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Value
+
+    init(_ value: Value) {
+        storedValue = value
+    }
+
+    var value: Value {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedValue
+        }
+        set {
+            lock.lock()
+            storedValue = newValue
+            lock.unlock()
+        }
+    }
+
+    @discardableResult
+    func mutate<Result>(_ operation: (inout Value) -> Result) -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return operation(&storedValue)
+    }
+}
+
+private func mockAssignmentFetchResponse(
+    statusCode: Int = 200,
+    data: Data = .mockAnyFlagAssignmentsResponse()
+) -> Flags.AssignmentRequestFetch.Response {
+    .init(
+        data: data,
+        httpResponse: HTTPURLResponse(
+            url: .mockAny(),
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    )
 }

--- a/DatadogFlags/Tests/FlagsTests.swift
+++ b/DatadogFlags/Tests/FlagsTests.swift
@@ -15,6 +15,25 @@ final class FlagsTests: XCTestCase {
 
         // Then
         XCTAssertNil(config.customExposureEndpoint)
+        XCTAssertNil(config.assignmentRequestFetch)
+        XCTAssertEqual(config.assignmentRequestTimeout, 0)
+    }
+
+    func testLegacyInitializerKeepsAssignmentRequestDefaults() {
+        let config = Flags.Configuration(
+            gracefulModeEnabled: false,
+            customFlagsEndpoint: nil,
+            customFlagsHeaders: nil,
+            customExposureEndpoint: nil,
+            trackExposures: false,
+            customEvaluationEndpoint: nil,
+            trackEvaluations: false,
+            evaluationFlushInterval: 20,
+            rumIntegrationEnabled: false
+        )
+
+        XCTAssertNil(config.assignmentRequestFetch)
+        XCTAssertEqual(config.assignmentRequestTimeout, 0)
     }
 
     func testWhenNotEnabled() {
@@ -42,6 +61,8 @@ final class FlagsTests: XCTestCase {
         config.customFlagsEndpoint = .mockRandom()
         config.customFlagsHeaders = .mockRandom()
         config.customExposureEndpoint = .mockRandom()
+        config.assignmentRequestFetch = .init { _, _ in {} }
+        config.assignmentRequestTimeout = 1.5
         let core = FeatureRegistrationCoreMock()
 
         // When
@@ -53,7 +74,70 @@ final class FlagsTests: XCTestCase {
         XCTAssertEqual(flags.performanceOverride?.maxObjectsInFile, 50)
         XCTAssertEqual(flagAssignmentFetcher.customEndpoint, config.customFlagsEndpoint)
         XCTAssertEqual(flagAssignmentFetcher.customHeaders, config.customFlagsHeaders)
+        XCTAssertNotNil(config.assignmentRequestFetch)
+        XCTAssertEqual(config.assignmentRequestTimeout, 1.5)
         let requestBuilder = try XCTUnwrap(flags.requestBuilder as? ExposureRequestBuilder)
         XCTAssertEqual(requestBuilder.customIntakeURL, config.customExposureEndpoint)
+    }
+
+    func testZeroAssignmentRequestTimeoutIsAccepted() {
+        var configuration = Flags.Configuration()
+        configuration.assignmentRequestTimeout = 0
+        let core = FeatureRegistrationCoreMock()
+
+        Flags.enable(with: configuration, in: core)
+
+        XCTAssertNotNil(core.get(feature: FlagsFeature.self))
+    }
+
+    func testCustomAssignmentRequestFetchBypassesScalarTimeout() throws {
+        // Given
+        let fetchCount = FlagsTestsLockedBox(0)
+        let expectedError = URLError(.notConnectedToInternet)
+        let customFetch = Flags.AssignmentRequestFetch { _, completion in
+            fetchCount.mutate { $0 += 1 }
+            completion(.failure(expectedError))
+            return {}
+        }
+        var configuration = Flags.Configuration()
+        configuration.assignmentRequestTimeout = 0.000001
+        configuration.assignmentRequestFetch = customFetch
+        let core = SingleFeatureCoreMock<FlagsFeature>()
+        let capturedErrorCode = FlagsTestsLockedBox<URLError.Code?>(nil)
+        let completion = expectation(description: "custom transport completed")
+
+        // When
+        Flags.enable(with: configuration, in: core)
+        let feature = try XCTUnwrap(core.get(feature: FlagsFeature.self))
+        feature.flagAssignmentsFetcher.flagAssignments(for: .mockAny()) { result in
+            if case .failure(.networkError(let error)) = result {
+                capturedErrorCode.value = (error as? URLError)?.code
+            }
+            completion.fulfill()
+        }
+        wait(for: [completion], timeout: 1)
+
+        // Then
+        XCTAssertEqual(fetchCount.value, 1)
+        XCTAssertEqual(capturedErrorCode.value, expectedError.code)
+    }
+}
+
+private final class FlagsTestsLockedBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Value
+
+    init(_ value: Value) {
+        storedValue = value
+    }
+
+    var value: Value {
+        get { lock.withLock { storedValue } }
+        set { lock.withLock { storedValue = newValue } }
+    }
+
+    @discardableResult
+    func mutate<Result>(_ mutation: (inout Value) -> Result) -> Result {
+        lock.withLock { mutation(&storedValue) }
     }
 }

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1568,6 +1568,19 @@ public struct SessionReplayPrivacyView<Content: View>: View
 # API surface for DatadogFlags:
 # ----------------------------------
 
+[?] extension Flags
+    public struct AssignmentRequestFetch: Sendable
+        public struct Response: Sendable
+            public let data: Data
+            public let httpResponse: HTTPURLResponse
+            public init(data: Data, httpResponse: HTTPURLResponse)
+        public typealias Completion = @Sendable (Result<Response, Error>) -> Void
+        public typealias Cancellation = @Sendable () -> Void
+        public init(_ fetch: @escaping @Sendable (URLRequest,@escaping Completion) -> Cancellation)
+        public func callAsFunction(_ request: URLRequest,completion: @escaping Completion) -> Cancellation
+        public static func urlSession() -> Self
+        public static func urlSession(_ session: URLSession) -> Self
+        public func withTimeout(_ timeout: TimeInterval) -> Self
 public final class FlagsClient
     public static let defaultName = "default"
     public static func create(name: String = FlagsClient.defaultName,in core: DatadogCoreProtocol = CoreRegistry.default) -> FlagsClientProtocol
@@ -1625,6 +1638,8 @@ public enum Flags
         public var gracefulModeEnabled: Bool
         public var customFlagsEndpoint: URL?
         public var customFlagsHeaders: [String: String]?
+        public var assignmentRequestFetch: Flags.AssignmentRequestFetch?
+        public var assignmentRequestTimeout: TimeInterval
         public var customExposureEndpoint: URL?
         public var trackExposures: Bool
         public var customEvaluationEndpoint: URL?


### PR DESCRIPTION
## Motivation

Flag assignment requests can wait on a slow or incomplete response without an SDK-level bound.

## Changes and Decisions

- Add an opt-in timeout for each assignment request. Zero preserves current behavior.
- Include the complete response-body download in the timeout.
- Add `AssignmentRequestFetch` as an assignment-only transport building block.
- Let a custom fetch replace the scalar timeout policy. Callers can compose `withTimeout(_:)` explicitly.

## Usage

Set a five-second timeout before you enable Flags:

```swift
import DatadogFlags

var flagsConfiguration = Flags.Configuration()
flagsConfiguration.assignmentRequestTimeout = 5
Flags.enable(with: flagsConfiguration)
```

## Validation

Validated commit `09d60f130` on an iPhone 17 Pro simulator with iOS 26.5. A deterministic local server supplied delayed bodies and HTTP errors. Each case ran three times through public Flags APIs. Telemetry uploads were disabled.

| Validation | Expected behavior | Observed result |
| --- | --- | --- |
| Timeout disabled | A 1.2-second response succeeds without an SDK timeout. | 3/3 passed; one request and one completion; `ready` in 1,211–1,224 ms. |
| Scalar full-body timeout | A stalled response body stops near 0.5 seconds. | 3/3 passed; one request and one completion; `error` in 550–566 ms. |
| Initial request only | HTTP 503 ends after the initial assignment request. | 3/3 passed; one request and one completion; `error` in 2–4 ms. |
| Building block | `urlSession().withTimeout(0.5)` stops a stalled response body. | 3/3 passed; one request and one completion; `error` in 548–553 ms. |
| Custom transport | An explicitly wrapped custom transport uses the timeout. | 3/3 passed; one custom fetch and one completion; `error` in 548–550 ms. |
| Custom policy precedence | A custom fetch replaces the scalar 0.5-second timeout. | 3/3 passed; one custom fetch and one completion; `ready` in 1,206–1,210 ms. |

Result: **18/18 fresh timeout-only simulator cases passed**.