### PR TITLE
[FFL-2891] Separate Flags implementation ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,6 @@
 
 ## Feature Flags
 
-/DatadogFlags/ @DataDog/rum-mobile @DataDog/rum-mobile-ios @DataDog/feature-flagging-and-experimentation-sdk
+# FFE owns implementation changes. Public API changes also update api-surface-swift,
+# which retains the global mobile ownership above.
+/DatadogFlags/ @DataDog/feature-flagging-and-experimentation-sdk


### PR DESCRIPTION
## Motivation

FFE owns the Flags implementation. The current rule also requires mobile review for internal changes that do not change the SDK public API.

## Changes and Decisions

- Assign the DatadogFlags implementation path to FFE.
- Keep mobile ownership of api-surface-swift through the global rule.
- Require FFE and mobile review when a Flags public API change updates the API surface.
- Keep Session Replay unchanged because the mobile team owns its implementation and public API.