### PR TITLE
[RUM-15810] Fix RC schema path after dd-go schema move

### DIFF
--- a/DatadogInternal/Sources/Models/RC/RCDataModels.swift
+++ b/DatadogInternal/Sources/Models/RC/RCDataModels.swift
@@ -333,4 +333,4 @@ public struct RemoteConfiguration: Codable {
     }
 }
 
-// Generated from https://github.com/DataDog/dd-go/blob/96df9f634c7c1215670fce6a12adee84ae5bc392/remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/STAGING/ios.json
+// Generated from https://github.com/DataDog/dd-go/blob/f244f7ec1a50ada7d0f8c5139917922a90f0f347/remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/ios.json

--- a/tools/rum-models-generator/run.py
+++ b/tools/rum-models-generator/run.py
@@ -24,7 +24,7 @@ SR_SCHEMA_PATH = '/rum-events-format/schemas/session-replay-mobile-schema.json'
 
 # RC schema lives in the private dd-go repo; cloned sparsely using GITHUB_TOKEN
 DD_GO_REPO = 'https://github.com/DataDog/dd-go.git'
-RC_SCHEMA_REPO_PATH = 'remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/STAGING/ios.json'
+RC_SCHEMA_REPO_PATH = 'remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/ios.json'
 RC_SCHEMA_SPARSE_DIR = 'remote-config/apps/rc-schema-validation/schemas'
 RC_SCHEMA_LOCAL_PATH = f'dd-go/{RC_SCHEMA_REPO_PATH}'  # relative to cwd (script_dir)
 


### PR DESCRIPTION
### What and why?

`make rc-models-generate` was failing because the RC (Remote Configuration) JSON schema was moved in the `dd-go` repo from `remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/STAGING/ios.json` to `remote-config/apps/rc-schema-validation/schemas/rum-sdk-config/ios.json`.

### How?

Updated the hardcoded `RC_SCHEMA_REPO_PATH` in `tools/rum-models-generator/run.py` to the new location, and regenerated `RCDataModels.swift` (only the trailing source-URL comment changed — no functional model differences).

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration) — N/A, tooling script fix verified by running `make rc-models-generate` and `make rc-models-verify` successfully
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes — N/A, internal tooling change only
- [ ] Add Objective-C interface for public APIs — N/A
- [ ] Run `make api-surface` when adding new APIs — N/A