### PR TITLE
[RUM-15810] Exclude Remote Configuration CDN fetches from URLSession auto-instrumentation

### DIFF
--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -238,9 +238,10 @@ internal final class RemoteConfigurationProvider {
                 .appendingPathComponent(id)
                 .appendingPathExtension("json")
         )
-        // This request carries no Datadog intake credentials (it targets a public CDN), so mark it
-        // internal explicitly to keep it out of RUM's automatic `URLSession` instrumentation.
-        request.setValue("1", forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddInternalHeaderField)
+        // This request carries no Datadog intake credentials (it targets a public CDN or a
+        // customer-supplied `customURL`), so mark it internal locally - without altering the request
+        // sent over the wire - to keep it out of RUM's automatic `URLSession` instrumentation.
+        URLRequestBuilder.markAsInternal(&request)
 
         var cache: RemoteConfigurationCache?
         if let file = try? directory.file(named: cacheFilename) {

--- a/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
+++ b/DatadogCore/Sources/Core/RemoteConfigurationProvider.swift
@@ -238,6 +238,9 @@ internal final class RemoteConfigurationProvider {
                 .appendingPathComponent(id)
                 .appendingPathExtension("json")
         )
+        // This request carries no Datadog intake credentials (it targets a public CDN), so mark it
+        // internal explicitly to keep it out of RUM's automatic `URLSession` instrumentation.
+        request.setValue("1", forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddInternalHeaderField)
 
         var cache: RemoteConfigurationCache?
         if let file = try? directory.file(named: cacheFilename) {

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -371,12 +371,15 @@ extension NetworkInstrumentationFeature {
         // uploader, which would otherwise pollute interception expectations via the global
         // `__NSCFLocalSessionTask.resume` swizzle in tests).
         //
-        // Some internal requests (e.g. Remote Configuration fetches from a public CDN) must not
-        // carry those intake credentials, so they are marked instead with a dedicated internal
-        // header.
-        return request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddAPIKeyHeaderField) != nil
-            || request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddClientTokenHeaderField) != nil
-            || request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddInternalHeaderField) != nil
+        // Some internal requests (e.g. Remote Configuration fetches, which may target a public CDN
+        // or a customer-supplied endpoint) must not carry those intake credentials over the wire, so
+        // they are marked instead with a local-only `URLProtocol` property that is never transmitted.
+        guard let request else {
+            return false
+        }
+        return request.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddAPIKeyHeaderField) != nil
+            || request.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddClientTokenHeaderField) != nil
+            || URLRequestBuilder.isMarkedInternal(request)
     }
 
     /// Helper structure that optionally contains a trace context and captured state, used to pass this

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -115,8 +115,8 @@ internal final class NetworkInstrumentationFeature: DatadogFeature {
                     return
                 }
 
-                // Skip Datadog's own intake requests to prevent infinite recursion
-                if self.hasDatadogAuthHeader(request: currentRequest) {
+                // Skip Datadog's own internal requests to prevent infinite recursion
+                if self.isDatadogInternalRequest(request: currentRequest) {
                     return
                 }
 
@@ -364,14 +364,19 @@ extension NetworkInstrumentationFeature {
     ///
     /// - Parameter request: The URLRequest to check.
     /// - Returns: `true` if the request is an SDK internal request, `false` otherwise.
-    private func hasDatadogAuthHeader(request: URLRequest?) -> Bool {
+    private func isDatadogInternalRequest(request: URLRequest?) -> Bool {
         // Datadog internal requests authenticate with either `DD-API-KEY` or `DD-CLIENT-TOKEN`.
         // This catches both this SDK's own uploads (preventing recursion) and other Datadog
         // tooling that may run in the same process (e.g. `DatadogSDKTesting`'s CI Visibility
         // uploader, which would otherwise pollute interception expectations via the global
         // `__NSCFLocalSessionTask.resume` swizzle in tests).
+        //
+        // Some internal requests (e.g. Remote Configuration fetches from a public CDN) must not
+        // carry those intake credentials, so they are marked instead with a dedicated internal
+        // header.
         return request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddAPIKeyHeaderField) != nil
             || request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddClientTokenHeaderField) != nil
+            || request?.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddInternalHeaderField) != nil
     }
 
     /// Helper structure that optionally contains a trace context and captured state, used to pass this

--- a/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
+++ b/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
@@ -25,6 +25,10 @@ public struct URLRequestBuilder {
         public static let ddEVPOriginVersionHeaderField = "DD-EVP-ORIGIN-VERSION"
         public static let ddRequestIDHeaderField = "DD-REQUEST-ID"
         public static let ddIdempotencyKeyHeaderField = "DD-IDEMPOTENCY-KEY"
+        /// Marks a request as originating from the SDK itself, so it can be excluded from automatic
+        /// `URLSession` instrumentation even when it carries no Datadog intake credentials
+        /// (e.g. requests to a public CDN, which must not receive `DD-API-KEY`/`DD-CLIENT-TOKEN`).
+        public static let ddInternalHeaderField = "X-Datadog-Internal"
 
         public enum ContentType {
             case applicationJSON

--- a/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
+++ b/DatadogInternal/Sources/Upload/URLRequestBuilder.swift
@@ -25,10 +25,6 @@ public struct URLRequestBuilder {
         public static let ddEVPOriginVersionHeaderField = "DD-EVP-ORIGIN-VERSION"
         public static let ddRequestIDHeaderField = "DD-REQUEST-ID"
         public static let ddIdempotencyKeyHeaderField = "DD-IDEMPOTENCY-KEY"
-        /// Marks a request as originating from the SDK itself, so it can be excluded from automatic
-        /// `URLSession` instrumentation even when it carries no Datadog intake credentials
-        /// (e.g. requests to a public CDN, which must not receive `DD-API-KEY`/`DD-CLIENT-TOKEN`).
-        public static let ddInternalHeaderField = "X-Datadog-Internal"
 
         public enum ContentType {
             case applicationJSON
@@ -115,6 +111,26 @@ public struct URLRequestBuilder {
             return HTTPHeader(field: ddIdempotencyKeyHeaderField, value: { key })
         }
     }
+
+    /// Marks a request as originating from the SDK itself using a local-only `URLProtocol` property
+    /// (never sent over the wire), so it can be recognized as internal by automatic `URLSession`
+    /// instrumentation without requiring Datadog intake credentials on the request - useful for SDK
+    /// requests (e.g. Remote Configuration fetches) that must reach third-party or customer-controlled
+    /// endpoints unmodified.
+    public static func markAsInternal(_ request: inout URLRequest) {
+        guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            return
+        }
+        URLProtocol.setProperty(true, forKey: isInternalRequestPropertyKey, in: mutableRequest)
+        request = mutableRequest as URLRequest
+    }
+
+    /// Checks whether a request was marked internal via `markAsInternal(_:)`.
+    public static func isMarkedInternal(_ request: URLRequest) -> Bool {
+        return URLProtocol.property(forKey: isInternalRequestPropertyKey, in: request) != nil
+    }
+
+    private static let isInternalRequestPropertyKey = "com.datadoghq.is-internal-request"
     /// Upload `URL`.
     private let url: URL
     /// HTTP headers.

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -1909,7 +1909,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // fetch), which cannot carry DD-API-KEY/DD-CLIENT-TOKEN since those must not reach a public CDN.
         let cdnURL = URL(string: "http://custom-endpoint.example.com/v1/remote-configuration.json")!
         var request = URLRequest(url: cdnURL)
-        request.setValue("1", forHTTPHeaderField: "X-Datadog-Internal")
+        URLRequestBuilder.markAsInternal(&request)
 
         let taskCompleted = expectation(description: "Task completed")
         let task = session.dataTask(with: request) { _, _, _ in
@@ -1922,7 +1922,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         wait(for: [taskCompleted], timeout: 1)
 
         // Then - Verify SDK request marked internal was not intercepted
-        XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests with X-Datadog-Internal header")
+        XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests marked internal via URLRequestBuilder.markAsInternal")
     }
 
     func testAutomaticMode_doesNotTrackDatadogSDKTestingRequests() throws {

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -1894,6 +1894,37 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests with DD-CLIENT-TOKEN header")
     }
 
+    func testAutomaticMode_doesNotTrackSDKRequestsMarkedInternal() throws {
+        // Given - Enable automatic mode
+        try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)
+
+        let session = URLSession(configuration: .ephemeral)
+
+        var interceptedSDKRequests: [URLSessionTaskInterception] = []
+        handler.onInterceptionDidStart = { interception in
+            interceptedSDKRequests.append(interception)
+        }
+
+        // When - Make a request to a public CDN endpoint marked internal (e.g. Remote Configuration
+        // fetch), which cannot carry DD-API-KEY/DD-CLIENT-TOKEN since those must not reach a public CDN.
+        let cdnURL = URL(string: "http://custom-endpoint.example.com/v1/remote-configuration.json")!
+        var request = URLRequest(url: cdnURL)
+        request.setValue("1", forHTTPHeaderField: "X-Datadog-Internal")
+
+        let taskCompleted = expectation(description: "Task completed")
+        let task = session.dataTask(with: request) { _, _, _ in
+            taskCompleted.fulfill()
+        }
+        task.resume()
+        task.cancel()
+
+        // Wait for the cancellation completion.
+        wait(for: [taskCompleted], timeout: 1)
+
+        // Then - Verify SDK request marked internal was not intercepted
+        XCTAssertEqual(interceptedSDKRequests.count, 0, "Should not intercept SDK requests with X-Datadog-Internal header")
+    }
+
     func testAutomaticMode_doesNotTrackDatadogSDKTestingRequests() throws {
         // Given - Enable automatic mode
         try URLSessionInstrumentation.enableOrThrow(with: nil, in: core)


### PR DESCRIPTION
### What and why?

Remote Configuration fetches go to a public CDN (or a customer-supplied `customURL`) and correctly omit `DD-API-KEY`/`DD-CLIENT-TOKEN` (those are intake credentials and must not be sent to a third-party endpoint). As a result, `NetworkInstrumentationFeature`'s only SDK-internal exclusion check (`hasDatadogAuthHeader`) didn't recognize them, so RUM's automatic `URLSession` instrumentation could track RC fetches as ordinary RUM resources and inject trace headers into them.

### How?

- Add `URLRequestBuilder.markAsInternal(_:)`/`isMarkedInternal(_:)`, backed by a local-only `URLProtocol` request property that is never sent over the wire, for SDK-internal requests that can't carry intake credentials.
- Mark the `RemoteConfigurationProvider` CDN request with it.
- Extend `NetworkInstrumentationFeature`'s internal-request check (renamed `hasDatadogAuthHeader` → `isDatadogInternalRequest`) to also skip requests marked this way.

(An earlier version of this PR used a custom HTTP header instead, but that header would have been sent to customer-supplied `customURL` endpoints, so it was replaced with the local-only `URLProtocol` property approach.)

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our guidelines (internal)
- [ ] Run `make api-surface` when adding new APIs