### PR TITLE
RUM-18420: Improve Profiling telemetry and app-launch handling

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,7 +52,7 @@ Checks: [
 
 CheckOptions:
   readability-function-cognitive-complexity.IgnoreMacros: true
-  readability-function-cognitive-complexity.Threshold: 35
+  readability-function-cognitive-complexity.Threshold: 40
 
 WarningsAsErrors: '*'
 

--- a/DatadogProfiling/Mach/aggregation_worker.cpp
+++ b/DatadogProfiling/Mach/aggregation_worker.cpp
@@ -26,7 +26,7 @@ aggregation_worker::aggregation_worker(
         worker_qos,
         callback,
         ctx,
-        hard_limit_bytes
+        hard_limit_bytes,
     } {
 }
 
@@ -113,7 +113,7 @@ bool aggregation_worker::request_flush(flush_action_t action) {
 
     flush_barrier barrier{
         flush_id,
-        std::move(action)
+        std::move(action),
     };
 
     if (producer_finished) {
@@ -160,7 +160,7 @@ void aggregation_worker::enqueue_active_buffer(std::vector<stack_trace_t>& activ
             diagnostics.max_pending_bytes = std::max(diagnostics.max_pending_bytes, pending_bytes);
             pending_work.emplace_back(batch_item{
                 std::move(batch),
-                batch_bytes
+                batch_bytes,
             });
         }
     }

--- a/DatadogProfiling/Mach/dd_pprof.cpp
+++ b/DatadogProfiling/Mach/dd_pprof.cpp
@@ -8,6 +8,8 @@
 
 #if defined(__APPLE__) && !TARGET_OS_WATCH
 
+#include <cstdlib>
+
 #include "dd_pprof_testing.h"
 #include "profile.h"
 #include "profile_pprof_packer.h"
@@ -46,8 +48,8 @@ size_t dd_pprof_serialize(dd_pprof_t* profile, uint8_t** data) {
     return dd::profiler::profile_pprof_pack(*reinterpret_cast<dd::profiler::profile*>(profile), data);
 }
 
-void dd_pprof_free_serialized_data(uint8_t* data) {
-    if (data) free(data);
+void dd_pprof_free_serialized_data(const uint8_t* data) {
+    if (data) std::free(const_cast<uint8_t*>(data));
 }
 
 void dd_pprof_callback(stack_trace_t* traces, size_t count, void* ctx) {

--- a/DatadogProfiling/Mach/dd_profiler.cpp
+++ b/DatadogProfiling/Mach/dd_profiler.cpp
@@ -247,8 +247,8 @@ public:
 
         if (!create_profile_and_profiler()) return 0;
 
-        start();
-        return 1;
+        started_at_launch = start() == 1;
+        return started_at_launch ? 1 : 0;
     }
 
     int start() {
@@ -278,6 +278,10 @@ public:
     profile* get_profile() {
         std::lock_guard<std::mutex> lock(profile_mutex);
         return profile;
+    }
+
+    bool was_started_at_launch() const {
+        return started_at_launch;
     }
 
     /**
@@ -407,6 +411,7 @@ private:
     uint64_t sampling_interval_ns = SAMPLING_CONFIG_DEFAULT_INTERVAL_NANOS;
     int64_t server_time_offset_ns = 0;
     bool record_cpu_time = false;
+    bool started_at_launch = false;
 
     /**
      * Mutex protecting the profile pointer.
@@ -511,6 +516,11 @@ dd_profiler_diagnostics_t dd_profiler_diagnostics(void) {
 bool dd_profiler_is_running() {
     std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
     return g_dd_profiler ? g_dd_profiler->status == DD_PROFILER_STATUS_RUNNING : false;
+}
+
+bool dd_profiler_was_started_at_launch() {
+    std::lock_guard<std::mutex> lock(g_dd_profiler_mutex);
+    return g_dd_profiler ? g_dd_profiler->was_started_at_launch() : false;
 }
 
 dd_profile_t* dd_profiler_get_profile(void) {

--- a/DatadogProfiling/Mach/include/dd_pprof.h
+++ b/DatadogProfiling/Mach/include/dd_pprof.h
@@ -81,7 +81,7 @@ size_t dd_pprof_serialize(dd_pprof_t* profile, uint8_t** data);
  *
  * @param data Pointer to the data to free
  */
-void dd_pprof_free_serialized_data(uint8_t* data);
+void dd_pprof_free_serialized_data(const uint8_t* data);
 
 /**
  * Callback function that resolves binary images and forwards stack traces

--- a/DatadogProfiling/Mach/include/dd_profiler.h
+++ b/DatadogProfiling/Mach/include/dd_profiler.h
@@ -178,6 +178,15 @@ void dd_profiler_stop();
  */
 bool dd_profiler_is_running();
 
+/**
+ * Checks whether the profiler successfully started from the process-launch constructor.
+ *
+ * Starting the profiler later with `dd_profiler_start()` does not change this value.
+ *
+ * @return true if profiling started during process launch, false otherwise.
+ */
+bool dd_profiler_was_started_at_launch();
+
 // MARK: - DD Profiler (auto-start) API
 
 /**

--- a/DatadogProfiling/Mach/mach_sampling_profiler.cpp
+++ b/DatadogProfiling/Mach/mach_sampling_profiler.cpp
@@ -772,24 +772,32 @@ uint64_t mach_sampling_profiler::thread_cpu_time_delta_nanos(thread_t thread, ui
         return 0;
     }
 
-    auto result = cpu_time_baselines.emplace(
-        thread_id,
-        cpu_time_baseline{current_cpu_time_nanos, cpu_time_sampling_cycle}
-    );
-    if (result.second) {
+    try {
+        auto result = cpu_time_baselines.try_emplace(
+            thread_id,
+            cpu_time_baseline{current_cpu_time_nanos, cpu_time_sampling_cycle}
+        );
+        if (result.second) {
+            return 0;
+        }
+
+        cpu_time_baseline& baseline = result.first->second;
+        const uint64_t previous_cpu_time_nanos = baseline.cumulative_nanos;
+        baseline.cumulative_nanos = current_cpu_time_nanos;
+        baseline.last_seen_cycle = cpu_time_sampling_cycle;
+
+        if (current_cpu_time_nanos < previous_cpu_time_nanos) {
+            return 0;
+        }
+
+        return current_cpu_time_nanos - previous_cpu_time_nanos;
+    } catch (const std::bad_alloc&) {
+        // CPU-time bookkeeping is best-effort. Keep wall-time profiling active
+        // instead of letting an allocation failure escape the sampling pthread.
+        config.record_cpu_time = 0;
+        cpu_time_baselines.clear();
         return 0;
     }
-
-    cpu_time_baseline& baseline = result.first->second;
-    const uint64_t previous_cpu_time_nanos = baseline.cumulative_nanos;
-    baseline.cumulative_nanos = current_cpu_time_nanos;
-    baseline.last_seen_cycle = cpu_time_sampling_cycle;
-
-    if (current_cpu_time_nanos < previous_cpu_time_nanos) {
-        return 0;
-    }
-
-    return current_cpu_time_nanos - previous_cpu_time_nanos;
 }
 
 void mach_sampling_profiler::prune_thread_cpu_time_state() {

--- a/DatadogProfiling/Mach/mach_sampling_profiler.cpp
+++ b/DatadogProfiling/Mach/mach_sampling_profiler.cpp
@@ -439,10 +439,9 @@ static void walk_frames(
         if (stack_base != 0 && fp_addr < stack_base) break;
 
         frame_pointer_pair_t next_frame = {};
-        if (!read_frame_pair_from_snapshot(fp_addr, stack_base, stack_buf, bytes_read, &next_frame)) {
-            if (!allow_memory_fallback || !read_frame_pair_from_memory(fp_addr, &next_frame)) {
-                break;
-            }
+        if (!read_frame_pair_from_snapshot(fp_addr, stack_base, stack_buf, bytes_read, &next_frame)
+            && (!allow_memory_fallback || !read_frame_pair_from_memory(fp_addr, &next_frame))) {
+            break;
         }
 
         fp = next_frame.next_frame_pointer;  // saved x29 / rbp
@@ -835,7 +834,7 @@ void mach_sampling_profiler::main() {
         } else {
             thread_act_array_t threads = nullptr;
             mach_msg_type_number_t count = 0;
-            
+
             if (task_threads(mach_task_self(), &threads, &count) != KERN_SUCCESS) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 continue;
@@ -849,7 +848,7 @@ void mach_sampling_profiler::main() {
 
                 // Skip profiler-owned threads to avoid self-noise in customer profiles.
                 if (is_profiler_internal_thread(threads[i])) continue;
-                
+
                 sample_thread(threads[i], interval_nanos);
 
                 if (sample_buffer.size() >= config.max_buffer_size) {

--- a/DatadogProfiling/Mach/profile_pprof_packer.cpp
+++ b/DatadogProfiling/Mach/profile_pprof_packer.cpp
@@ -25,6 +25,8 @@
 
 #if defined(__APPLE__) && !TARGET_OS_WATCH
 
+#include <cstdlib>
+
 #include "profile.h"
 #include "profile.pb-c.h"
 
@@ -39,20 +41,20 @@
 /** @brief Allocation function wrapper around malloc */
 static void* sys_malloc(void* allocator_data, size_t size) {
     (void)allocator_data;
-    return malloc(size);
+    return std::malloc(size);
 }
 
 /** @brief Deallocation function wrapper around free */
 static void sys_free(void* allocator_data, void* ptr) {
     (void)allocator_data;
-    free(ptr);
+    std::free(ptr);
 }
 
 /** @brief Global allocator instance used for all protobuf allocations */
 static ProtobufCAllocator profile_allocator = {
     sys_malloc,
     sys_free,
-    nullptr  // allocator_data
+    nullptr,  // allocator_data
 };
 
 /** @brief Allocate memory using the protobuf allocator */
@@ -131,7 +133,7 @@ size_t profile_pprof_pack(const profile& prof, uint8_t** data) {
         return 0;
     }
     
-    uint8_t* buffer = static_cast<uint8_t*>(malloc(packed_size));
+    uint8_t* buffer = static_cast<uint8_t*>(std::malloc(packed_size));
     if (!buffer) {
         perftools__profiles__profile__free_unpacked(pprof, &profile_allocator);
         return 0;
@@ -146,7 +148,7 @@ size_t profile_pprof_pack(const profile& prof, uint8_t** data) {
     perftools__profiles__profile__free_unpacked(pprof, &profile_allocator);
     
     if (actual_size == 0) {
-        free(buffer);
+        std::free(buffer);
         return 0;
     }
     

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -39,7 +39,8 @@ internal final class DatadogProfiler: ProfilingHandler {
     private let profilingConditions: ProfilingConditions
     private let profilingInterval: TimeInterval
     private let minProfileDuration: TimeInterval
-    private let isAppLaunchProfilingEnabled: Bool
+    /// Whether the native profiler started at process launch and the latest configuration permits harvesting it.
+    private let hasAppLaunchProfileToHarvest: Bool
     private var timer: DispatchSourceTimer?
 
     let featureScope: FeatureScope
@@ -67,6 +68,8 @@ internal final class DatadogProfiler: ProfilingHandler {
     /// Consent remains fail-open while `.pending`; only `.notGranted` disables collection.
     private var isTrackingConsentAllowed = true
     private var previousAppState: AppState?
+    /// Current RUM session.
+    private var currentRUMSessionID: String?
     // Current profiling mode
     private(set) var operation: ProfilingOperation
     /// Allows continuous profiling to temporarily run while waiting for the first
@@ -99,7 +102,7 @@ internal final class DatadogProfiler: ProfilingHandler {
         self.profilingConditions = profilingConditions
         self.profilingInterval = profilingInterval
         self.minProfileDuration = minProfileDuration
-        self.isAppLaunchProfilingEnabled = isAppLaunchProfilingEnabled
+        self.hasAppLaunchProfileToHarvest = isAppLaunchProfilingEnabled && dd_profiler_was_started_at_launch()
         self.encoder = encoder
         self.dateProvider = dateProvider
         self.profileStartDate = dateProvider.now
@@ -194,6 +197,12 @@ private extension DatadogProfiler {
         queue.async { [weak self] in
             guard let self else {
                 return
+            }
+
+            if let sessionID = context.additionalContext(ofType: RUMCoreContext.self)?.sessionID,
+               sessionID != currentRUMSessionID {
+                currentRUMSessionID = sessionID
+                telemetryController.resetContinuousCycleIndex()
             }
 
             let wasTrackingConsentAllowed = isTrackingConsentAllowed
@@ -337,7 +346,7 @@ private extension DatadogProfiler {
         let shouldSendCurrentProfile = shouldSendProfile || (hasTimedOut && canProfile && !isCustomProfiling)
         if shouldSendCurrentProfile {
             sendProfile()
-        } else if !canProfile {
+        } else if !canProfile && !shouldWaitForAppLaunchVital {
             discardCurrentProfile()
             cleanUpState()
         }
@@ -462,7 +471,7 @@ private extension DatadogProfiler {
             return
         }
 
-        if isAppLaunchProfilingEnabled {
+        if hasAppLaunchProfileToHarvest {
             writeAppLaunchProfile(profile)
         }
         cleanUpState()
@@ -564,7 +573,10 @@ private extension DatadogProfiler {
     var shouldWaitForAppLaunchVital: Bool {
         // If continuous profiling samples out before TTID, keep the native profiler
         // briefly so it can harvest the launch profile.
-        isAppLaunchProfilingEnabled
+        hasAppLaunchProfileToHarvest
+            && isTrackingConsentAllowed
+            && !quotaChecker.isRejectedByQuota
+            && hasConditionsToProfile
             && hasReceivedAppLaunchVital == false
             && dateProvider.now.timeIntervalSince(profileStartDate) < Constants.cutOffTime
     }
@@ -587,7 +599,7 @@ private extension DatadogProfiler {
     var shouldHarvestAppLaunchProfileOnTTID: Bool {
         // TTID may still be attached to continuous/custom profiles when standalone
         // app-launch upload is disabled; this gate only decides standalone launch harvesting.
-        guard isAppLaunchProfilingEnabled
+        guard hasAppLaunchProfileToHarvest
                 && hasReceivedAppLaunchVital
                 && !quotaChecker.isRejectedByQuota else {
             return false

--- a/DatadogProfiling/Sources/ProfilingHandler.swift
+++ b/DatadogProfiling/Sources/ProfilingHandler.swift
@@ -84,11 +84,11 @@ extension ProfilingHandler {
         var data: UnsafeMutablePointer<UInt8>?
         let start = dd_pprof_get_start_timestamp_s(profile)
         let end = dd_pprof_get_end_timestamp_s(profile)
-        let durationNs = (end - start).dd.toInt64Nanoseconds
+        let durationMs = (end - start).dd.toInt64Milliseconds
         let size = dd_pprof_serialize(profile, &data)
 
         guard let data else {
-            telemetryController.sendNoData(durationNs: durationNs, for: operation)
+            telemetryController.sendNoData(durationMs: durationMs, for: operation)
             return
         }
 
@@ -133,7 +133,7 @@ extension ProfilingHandler {
             let attachments = ProfileAttachments(pprof: pprof, rumEvents: rumEventsData)
             writer.write(value: event, metadata: attachments)
             self.telemetryController.sendProfile(
-                durationNs: durationNs,
+                durationMs: durationMs,
                 fileSize: Int64(clamping: size),
                 for: operation
             )

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingSessionMetric.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingSessionMetric.swift
@@ -31,6 +31,31 @@ internal final class ProfilingSessionMetric {
         case rumOperation = "rum_operation"
     }
 
+    /// Error codes aligned with `android.os.ProfilingResult`.
+    enum ErrorCode: Int {
+        /// The profiling request completed without an execution or post-processing error.
+        case none = 0
+        /// Profiling could not start because another profiling session was already running.
+        case profilingAlreadyInProgress = 3
+        /// The profiling request executed but failed to produce a profile.
+        case executionFailed = 4
+        /// Profiling failed for an unknown reason.
+        case unknown = 8
+
+        init(status: ProfilingContext.Status) {
+            switch status {
+            case .running, .stopped:
+                self = .none
+            case .error(reason: .alreadyStarted):
+                self = .profilingAlreadyInProgress
+            case .error(reason: .memoryAllocationFailed):
+                self = .executionFailed
+            case .unknown:
+                self = .unknown
+            }
+        }
+    }
+
     enum ProfileDropReason: Equatable {
         case noProfiledEvents
         case profileTooLarge
@@ -57,12 +82,12 @@ internal final class ProfilingSessionMetric {
     let startReason: StartReason
     /// Status of the profiler at the end of the profiling session.
     let status: ProfilingContext.Status
-    /// Duration of the profile in nanoseconds.
-    let durationNs: Int64?
+    /// Duration of the profile in milliseconds.
+    let durationMs: Int64?
     /// Size of the profile file in bytes.
     let fileSize: Int64?
-    /// Error code when the profile is not sent or the profiler is in an error state.
-    let errorCode: Int?
+    /// Error code describing the outcome of the profiling session.
+    let errorCode: ErrorCode
     /// Error message when the profile is not sent.
     var errorMessage: String?
     /// Index of the continuous profiling cycle.
@@ -73,16 +98,16 @@ internal final class ProfilingSessionMetric {
     init(
         startReason: StartReason,
         status: ProfilingContext.Status,
-        durationNs: Int64? = nil,
+        durationMs: Int64? = nil,
         fileSize: Int64? = nil,
-        errorCode: Int? = nil,
+        errorCode: ErrorCode = .none,
         errorMessage: String? = nil,
         cycleIndex: Int? = nil,
         appStartInfo: String? = nil
     ) {
         self.startReason = startReason
         self.status = status
-        self.durationNs = durationNs
+        self.durationMs = durationMs
         self.fileSize = fileSize
         self.errorCode = errorCode
         self.errorMessage = errorMessage
@@ -109,8 +134,8 @@ internal final class ProfilingSessionMetric {
             SDKMetricFields.typeKey: Constants.typeValue,
             Constants.sessionKey: Attributes(
                 startReason: startReason.rawValue,
-                duration: durationNs,
-                errorCode: errorCode,
+                duration: durationMs,
+                errorCode: errorCode.rawValue,
                 errorMessage: errorMessage,
                 fileSize: fileSize,
                 stoppedReason: stoppedReason,
@@ -127,14 +152,13 @@ extension ProfilingSessionMetric {
     static func noProfile(
         startReason: StartReason,
         status: ProfilingContext.Status,
-        errorCode: Int?,
         cycleIndex: Int? = nil,
         appStartInfo: String? = nil
     ) -> ProfilingSessionMetric {
         .init(
             startReason: startReason,
             status: status,
-            errorCode: errorCode,
+            errorCode: .init(status: status),
             errorMessage: Constants.noProfileErrorMessage,
             cycleIndex: cycleIndex,
             appStartInfo: appStartInfo
@@ -144,16 +168,15 @@ extension ProfilingSessionMetric {
     static func noData(
         startReason: StartReason,
         status: ProfilingContext.Status,
-        durationNs: Int64?,
-        errorCode: Int?,
+        durationMs: Int64?,
         cycleIndex: Int?,
         appStartInfo: String? = nil
     ) -> ProfilingSessionMetric {
         .init(
             startReason: startReason,
             status: status,
-            durationNs: durationNs,
-            errorCode: errorCode,
+            durationMs: durationMs,
+            errorCode: .init(status: status),
             errorMessage: Constants.noDataErrorMessage,
             cycleIndex: cycleIndex,
             appStartInfo: appStartInfo
@@ -183,8 +206,9 @@ extension ProfilingSessionMetric {
     /// Container to encode Profiling Session data according to the spec.
     internal struct Attributes: Encodable {
         let startReason: String
+        /// Profile duration in milliseconds.
         let duration: Int64?
-        let errorCode: Int?
+        let errorCode: Int
         let errorMessage: String?
         let fileSize: Int64?
         let stoppedReason: String?

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
@@ -9,14 +9,6 @@ import DatadogInternal
 
 #if !os(watchOS)
 
-// swiftlint:disable duplicate_imports
-#if swift(>=6.0)
-internal import DatadogMachProfiler
-#else
-@_implementationOnly import DatadogMachProfiler
-#endif
-// swiftlint:enable duplicate_imports
-
 internal final class ProfilingTelemetryController {
     /// The default sample rate for "Profiling Session" metric (20%),
     /// applied in addition to the Profiling continuous sample rate (5% by default).
@@ -49,13 +41,18 @@ internal final class ProfilingTelemetryController {
         appStartInfo = context.launchInfo.profilingAppStartInfo
     }
 
+    /// Resets the cycle index used by continuous profiling telemetry.
+    func resetContinuousCycleIndex() {
+        continuousCycleIndex = 0
+    }
+
     /// Sends a metric for a written profile, decorated with shared profiling telemetry state.
-    func sendProfile(durationNs: Int64, fileSize: Int64, for operation: ProfilingOperation) {
+    func sendProfile(durationMs: Int64, fileSize: Int64, for operation: ProfilingOperation) {
         send(
             .init(
                 startReason: operation.startReason,
                 status: .current,
-                durationNs: durationNs,
+                durationMs: durationMs,
                 fileSize: fileSize,
                 cycleIndex: cycleIndex(for: operation),
                 appStartInfo: operation == .appLaunch ? appStartInfo : nil
@@ -64,13 +61,12 @@ internal final class ProfilingTelemetryController {
     }
 
     /// Sends a metric for a profile that could not be serialized.
-    func sendNoData(durationNs: Int64?, for operation: ProfilingOperation) {
+    func sendNoData(durationMs: Int64?, for operation: ProfilingOperation) {
         send(
             .noData(
                 startReason: operation.startReason,
                 status: .current,
-                durationNs: durationNs,
-                errorCode: Int(dd_profiler_get_status().rawValue),
+                durationMs: durationMs,
                 cycleIndex: cycleIndex(for: operation),
                 appStartInfo: operation == .appLaunch ? appStartInfo : nil
             )
@@ -83,7 +79,6 @@ internal final class ProfilingTelemetryController {
             .noProfile(
                 startReason: operation.startReason,
                 status: .current,
-                errorCode: Int(dd_profiler_get_status().rawValue),
                 cycleIndex: cycleIndex(for: operation),
                 appStartInfo: operation == .appLaunch ? appStartInfo : nil
             )

--- a/DatadogProfiling/Tests/DDProfilerTests.swift
+++ b/DatadogProfiling/Tests/DDProfilerTests.swift
@@ -56,6 +56,20 @@ final class DDProfilerTests: XCTestCase {
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING, "Profiler should start with custom timeout")
     }
 
+    func testDDProfiler_wasStartedAtLaunch_whenAutoStartSucceeds() {
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+
+        XCTAssertTrue(dd_profiler_was_started_at_launch())
+    }
+
+    func testDDProfiler_wasNotStartedAtLaunch_whenStartedLater() {
+        XCTAssertFalse(dd_profiler_was_started_at_launch())
+
+        XCTAssertEqual(dd_profiler_start(), 1)
+
+        XCTAssertFalse(dd_profiler_was_started_at_launch())
+    }
+
     func testDDProfiler_flushHarvestsPartialBatch() {
         dd_profiler_start_testing(100, false, 1.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -109,6 +109,7 @@ final class DatadogProfilerTests: XCTestCase {
     func testReceiveApplicationLaunchVital_capturesOngoingRUMVitals() throws {
         // Given
         let dateProvider = DateProviderMock()
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = continuousProfiler(isAppLaunchProfilingEnabled: true, dateProvider: dateProvider)
         let completedOperationStart = Vital.mockWith(name: "completed-operation")
         let completedOperationEnd = Vital.mockWith(
@@ -120,8 +121,6 @@ final class DatadogProfilerTests: XCTestCase {
         let hang = DurationEvent(id: "hang-id", type: .error, start: 0, duration: 500)
         let longTask = DurationEvent(id: "long-task-id", type: .longTask, start: 0, duration: 100)
         let launchVital: Vital = .mockWith(stepType: nil)
-
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         _ = profiler.receive(
             message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: completedOperationStart)),
@@ -761,6 +760,7 @@ extension DatadogProfilerTests {
         // Given
         core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = continuousProfiler(
             profilingSamplerProvider: profilingSamplerProvider,
             isAppLaunchProfilingEnabled: true
@@ -800,6 +800,7 @@ extension DatadogProfilerTests {
         // Given
         core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = continuousProfiler(
             profilingSamplerProvider: profilingSamplerProvider,
             isAppLaunchProfilingEnabled: true
@@ -841,6 +842,138 @@ extension DatadogProfilerTests {
         )
         let event = try XCTUnwrap(core.events.first as? ProfileEvent)
         XCTAssertTrue(event.tags.contains("operation:launch"))
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveContext_discardsLateStartedProfile_whenNativeProfilerDidNotStartAtLaunch() {
+        // Given - launch profiling sampled out before the SDK initialized.
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        let profiler = continuousProfiler(
+            profilingSamplerProvider: profilingSamplerProvider,
+            isAppLaunchProfilingEnabled: true
+        )
+        connectMessageReceiver(to: profiler, profilingSamplerProvider: profilingSamplerProvider)
+
+        // Continuous profiling starts later while waiting for the RUM sampling decision.
+        core.context = .mockWith(applicationStateHistory: .mockAppInForeground())
+        flushQueue()
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_RUNNING)
+        XCTAssertFalse(dd_profiler_was_started_at_launch())
+
+        let partialTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        partialTrace.pointee = .mockWith(
+            tid: 1,
+            addresses: [0x100001000],
+            timestamp: DispatchTime.now().uptimeNanoseconds
+        )
+        dd_pprof_add_samples(dd_profiler_get_profile(), partialTrace, 1)
+        dd_free(partialTrace)
+        XCTAssertGreaterThan(dd_pprof_sample_count(dd_profiler_get_profile()), 0)
+
+        _ = profiler.receive(
+            message: .payload(TTIDMessage(attributes: mockRandomAttributes(), ttid: .mockWith(stepType: nil))),
+            from: core
+        )
+        flushQueue()
+        XCTAssertTrue(core.metadata.isEmpty)
+
+        // When - the RUM session samples continuous profiling out.
+        core.context = .mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: 0)]
+        )
+        flushQueue()
+
+        // Then - the partial profile is discarded instead of being labeled as app launch.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        XCTAssertEqual(dd_pprof_sample_count(dd_profiler_get_profile()), 0)
+        XCTAssertTrue(core.events.isEmpty)
+        XCTAssertTrue(core.metadata.isEmpty)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveContext_preservesLaunchSamplesUntilTTID_whenOnlyAppLaunchProfilingIsEnabled() throws {
+        // Given - native launch profiling starts before the SDK receives its first foreground context.
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        let profiler = customProfiler(isAppLaunchProfilingEnabled: true)
+
+        let launchTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        launchTrace.pointee = .mockWith(
+            tid: 1,
+            addresses: [0x100001000],
+            timestamp: DispatchTime.now().uptimeNanoseconds
+        )
+        dd_pprof_add_samples(dd_profiler_get_profile(), launchTrace, 1)
+        dd_free(launchTrace)
+        XCTAssertGreaterThan(dd_pprof_sample_count(dd_profiler_get_profile()), 0)
+
+        // When - the foreground context arrives with continuous profiling disabled.
+        core.context = .mockWith(applicationStateHistory: .mockAppInForeground())
+        _ = profiler.receive(message: .context(core.context), from: core)
+        flushQueue()
+
+        // Then - sampling stops, but the captured launch profile remains available for TTID.
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        XCTAssertGreaterThan(dd_pprof_sample_count(dd_profiler_get_profile()), 0)
+
+        // When - TTID arrives within the app-launch grace period.
+        waitForProfileWrite(timeout: 1.0) {
+            _ = profiler.receive(
+                message: .payload(TTIDMessage(
+                    attributes: mockRandomAttributes(),
+                    ttid: .mockWith(id: "ttid-id", stepType: nil)
+                )),
+                from: core
+            )
+            flushQueue()
+        }
+
+        // Then - the preserved profile is written as the app-launch profile.
+        XCTAssertEqual(core.events.count, 1)
+        let metadata = try XCTUnwrap(core.metadata.first as? ProfileAttachments)
+        XCTAssertEqual(
+            eventIDs(ofType: "vital", in: try typedRUMEvents(from: metadata)),
+            ["ttid-id"]
+        )
+        let event = try XCTUnwrap(core.events.first as? ProfileEvent)
+        XCTAssertTrue(event.tags.contains("operation:launch"))
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testReceiveContext_discardsLaunchSamples_whenTTIDGracePeriodHasExpired() {
+        // Given
+        let dateProvider = DateProviderMock()
+        core = PassthroughCoreMock(context: .mockWith(applicationStateHistory: .mockAppInBackground()))
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
+        let profiler = customProfiler(
+            isAppLaunchProfilingEnabled: true,
+            dateProvider: dateProvider
+        )
+
+        let launchTrace = UnsafeMutablePointer<stack_trace_t>.allocate(capacity: 1)
+        launchTrace.pointee = .mockWith(
+            tid: 1,
+            addresses: [0x100001000],
+            timestamp: DispatchTime.now().uptimeNanoseconds
+        )
+        dd_pprof_add_samples(dd_profiler_get_profile(), launchTrace, 1)
+        dd_free(launchTrace)
+        XCTAssertGreaterThan(dd_pprof_sample_count(dd_profiler_get_profile()), 0)
+
+        dateProvider.now = dateProvider.now.addingTimeInterval(DatadogProfiler.Constants.cutOffTime + 1)
+
+        // When
+        core.context = .mockWith(applicationStateHistory: .mockAppInForeground())
+        _ = profiler.receive(message: .context(core.context), from: core)
+        flushQueue()
+
+        // Then
+        XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_STOPPED)
+        XCTAssertEqual(dd_pprof_sample_count(dd_profiler_get_profile()), 0)
+        XCTAssertTrue(core.metadata.isEmpty)
         withExtendedLifetime(profiler) {}
     }
 
@@ -1551,9 +1684,9 @@ extension DatadogProfilerTests {
     func testCustomProfiler_stopsProfiler_whenOperationsExpired() {
         // Given
         let dateProvider = DateProviderMock(now: Date())
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = customProfiler(isAppLaunchProfilingEnabled: true, dateProvider: dateProvider)
         shareCurrentContext(with: profiler)
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         let startOp: Vital = .mockWith(stepType: .start, date: dateProvider.now)
         _ = profiler.receive(message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: startOp)), from: core)
@@ -1733,7 +1866,7 @@ extension DatadogProfilerTests {
         XCTAssertEqual(metric.cycleIndex, 0)
         XCTAssertNotNil(metric.duration)
         XCTAssertNotNil(metric.fileSize)
-        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertNil(metric.errorMessage)
 
         let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: ProfilingSessionMetric.Constants.name))
@@ -1774,8 +1907,53 @@ extension DatadogProfilerTests {
         XCTAssertNil(metric.duration)
         XCTAssertNil(metric.fileSize)
         XCTAssertEqual(metric.errorMessage, ProfilingSessionMetric.Constants.noProfiledEventsErrorMessage)
-        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertTrue(core.metadata.isEmpty)
+        withExtendedLifetime(profiler) {}
+    }
+
+    func testContinuousProfiler_resetsCycleIndex_whenRUMSessionChanges() {
+        // Given
+        let telemetry = TelemetryMock()
+        let telemetryController = ProfilingTelemetryController(telemetry: telemetry)
+        let profiler = continuousProfiler(telemetryController: telemetryController)
+        let firstSessionID: UUID = .mockAny()
+        let firstSessionContext = DatadogContext.mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionID: firstSessionID)]
+        )
+        _ = profiler.receive(message: .context(firstSessionContext), from: core)
+        flushQueue()
+        telemetryController.sendProfile(durationMs: 1, fileSize: 1, for: .continuousProfiling)
+        telemetryController.sendProfile(durationMs: 1, fileSize: 1, for: .continuousProfiling)
+
+        // When - another context update arrives for the same RUM session.
+        _ = profiler.receive(message: .context(firstSessionContext), from: core)
+        flushQueue()
+        telemetryController.sendProfile(durationMs: 1, fileSize: 1, for: .continuousProfiling)
+
+        // Then - the existing cycle continues.
+        var cycleIndexes = telemetry.messages.compactMap {
+            ($0.asMetric?.attributes[ProfilingSessionMetric.Constants.sessionKey]
+                as? ProfilingSessionMetric.Attributes)?.cycleIndex
+        }
+        XCTAssertEqual(cycleIndexes, [0, 1, 2])
+
+        // When - RUM starts a new session.
+        let secondSessionContext = DatadogContext.mockWith(
+            applicationStateHistory: .mockAppInForeground(),
+            additionalContext: [RUMCoreContext.mockWith(sessionID: .mockAny())]
+        )
+        _ = profiler.receive(message: .context(secondSessionContext), from: core)
+        flushQueue()
+        telemetryController.sendProfile(durationMs: 1, fileSize: 1, for: .continuousProfiling)
+
+        // Then - the first continuous metric in the new session starts at zero.
+        cycleIndexes = telemetry.messages.compactMap {
+            ($0.asMetric?.attributes[ProfilingSessionMetric.Constants.sessionKey]
+                as? ProfilingSessionMetric.Attributes)?.cycleIndex
+        }
+        XCTAssertEqual(cycleIndexes, [0, 1, 2, 0])
         withExtendedLifetime(profiler) {}
     }
 
@@ -1817,7 +1995,7 @@ extension DatadogProfilerTests {
         XCTAssertNotNil(metric.duration)
         XCTAssertNotNil(metric.fileSize)
         XCTAssertEqual(metric.stoppedReason, ProfilingContext.Status.StopReason.manual.rawValue)
-        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertNil(metric.errorMessage)
         withExtendedLifetime(profiler) {}
     }
@@ -1915,6 +2093,7 @@ extension DatadogProfilerTests {
         let telemetryController = ProfilingTelemetryController(telemetry: telemetry)
         let quotaChecker = ProfilingQuotaCheckerMock()
         let profilingSamplerProvider = profilingSamplerProvider(isContinuousProfiling: true)
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = continuousProfiler(
             profilingSamplerProvider: profilingSamplerProvider,
             isAppLaunchProfilingEnabled: true,
@@ -1925,7 +2104,6 @@ extension DatadogProfilerTests {
             applicationStateHistory: .mockAppInForeground(),
             additionalContext: [RUMCoreContext.mockWith(sessionSampleRate: .maxSampleRate)]
         )
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
 
         // When - TTID is harvested while quota is still pending.
         _ = profiler.receive(
@@ -2260,19 +2438,19 @@ extension DatadogProfilerTests {
 // MARK: - Application Launch Profiling
 
 extension DatadogProfilerTests {
-    func testReceiveTTIDMessage_whenProfilerSampledOut_reportsMissingProfileWithoutWriting() throws {
+    func testReceiveTTIDMessage_whenLaunchProfilerDidNotStart_doesNotWriteProfileOrMetric() {
         // Given
         let telemetry = TelemetryMock()
         core = PassthroughCoreMock(context: .mockWith(
             launchInfo: .mockWith(launchReason: .userLaunch)
         ))
+        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = customProfiler(
             isAppLaunchProfilingEnabled: true,
             telemetryController: ProfilingTelemetryController(telemetry: telemetry)
         )
         _ = profiler.receive(message: .context(core.context), from: core)
         flushQueue()
-        dd_profiler_start_testing(0, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_NOT_STARTED)
 
         // When
@@ -2286,20 +2464,13 @@ extension DatadogProfilerTests {
         XCTAssertTrue(result)
         XCTAssertTrue(core.events.isEmpty)
         XCTAssertTrue(core.metadata.isEmpty)
-
-        let metric = try lastProfilingSessionMetric(from: telemetry)
-        XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.applicationLaunch.rawValue)
-        XCTAssertEqual(metric.appStartInfo, "user_launch")
-        XCTAssertNil(metric.duration)
-        XCTAssertNil(metric.fileSize)
-        XCTAssertEqual(metric.errorMessage, ProfilingSessionMetric.Constants.noProfileErrorMessage)
-        XCTAssertNotNil(metric.errorCode)
+        XCTAssertNil(telemetry.messages.lastMetric(named: ProfilingSessionMetric.Constants.name))
     }
 
     func testReceiveTTIDMessage_whenProfilerPrewarmed_doesNotWriteProfile() {
         // Given
-        let profiler = customProfiler(isAppLaunchProfilingEnabled: true)
         dd_profiler_start_testing(100, true, 5.seconds.dd.toInt64Nanoseconds, 0)
+        let profiler = customProfiler(isAppLaunchProfilingEnabled: true)
         XCTAssertEqual(dd_profiler_get_status(), DD_PROFILER_STATUS_PREWARMED)
 
         // When
@@ -2344,13 +2515,13 @@ extension DatadogProfilerTests {
                 launchInfo: .mockWith(launchReason: .backgroundLaunch)
             )
         )
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = customProfiler(
             isAppLaunchProfilingEnabled: true,
             telemetryController: ProfilingTelemetryController(telemetry: telemetry)
         )
         _ = profiler.receive(message: .context(core.context), from: core)
         flushQueue()
-        XCTAssertEqual(dd_profiler_start(), 1)
         Thread.sleep(forTimeInterval: 0.05)
         _ = profiler.receive(
             message: .payload(OperationMessage(attributes: mockRandomAttributes(), operation: ttfdVital)),
@@ -2412,7 +2583,7 @@ extension DatadogProfilerTests {
         XCTAssertNotNil(metric.duration)
         XCTAssertNotNil(metric.fileSize)
         XCTAssertEqual(metric.stoppedReason, ProfilingContext.Status.StopReason.manual.rawValue)
-        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertNil(metric.errorMessage)
 
         let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: ProfilingSessionMetric.Constants.name))
@@ -2436,6 +2607,7 @@ extension DatadogProfilerTests {
     func testReceiveTTIDMessage_preservesNewerContextServerTimeOffset_whenQueueIsBacklogged() throws {
         // Given
         let queue = DispatchQueue(label: "test.profiler.server-time-offset")
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = customProfiler(isAppLaunchProfilingEnabled: true, queue: queue)
         let ttidServerTimeOffset: TimeInterval = 2
         let contextServerTimeOffset: TimeInterval = 3
@@ -2448,7 +2620,6 @@ extension DatadogProfilerTests {
             date: launchDate,
             serverTimeOffset: ttidServerTimeOffset
         )
-        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         Thread.sleep(forTimeInterval: 0.05)
         dd_profiler_stop()
         let nativeProfile = try XCTUnwrap(dd_profiler_get_profile())
@@ -2553,6 +2724,7 @@ extension DatadogProfilerTests {
         core = PassthroughCoreMock(context: .mockWith(
             launchInfo: .mockWith(launchReason: .userLaunch)
         ))
+        dd_profiler_start_testing(100, false, 5.seconds.dd.toInt64Nanoseconds, 0)
         let profiler = customProfiler(
             isAppLaunchProfilingEnabled: true,
             telemetryController: ProfilingTelemetryController(telemetry: telemetry),
@@ -2561,7 +2733,6 @@ extension DatadogProfilerTests {
         _ = profiler.receive(message: .context(core.context), from: core)
         flushQueue()
 
-        XCTAssertEqual(dd_profiler_start(), 1)
         Thread.sleep(forTimeInterval: 0.05)
         let rejectedLaunchProfile = try XCTUnwrap(dd_profiler_get_profile())
 

--- a/DatadogProfiling/Tests/SDKMetrics/ProfilingTelemetryControllerTests.swift
+++ b/DatadogProfiling/Tests/SDKMetrics/ProfilingTelemetryControllerTests.swift
@@ -15,7 +15,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
 
     func testTrackingProfilingSessionMetric_whileAppLaunchProfilingIsRunning() throws {
         // Given
-        let duration = Int64(123_000_000)
+        let durationMs = Int64(123)
         let fileSize = Int64(1_000_000)
         let controller = ProfilingTelemetryController(telemetry: telemetry)
 
@@ -24,7 +24,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
             ProfilingSessionMetric(
                 startReason: .applicationLaunch,
                 status: .running,
-                durationNs: duration,
+                durationMs: durationMs,
                 fileSize: fileSize,
                 appStartInfo: "user_launch"
             )
@@ -33,10 +33,10 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         // Then
         let metric = try XCTUnwrap(telemetry.messages.profilingSessionMetric)
         XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.applicationLaunch.rawValue)
-        XCTAssertEqual(metric.duration, duration)
+        XCTAssertEqual(metric.duration, durationMs)
         XCTAssertEqual(metric.fileSize, fileSize)
         XCTAssertNil(metric.stoppedReason)
-        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertNil(metric.errorMessage)
         XCTAssertNil(metric.cycleIndex)
         XCTAssertEqual(metric.appStartInfo, "user_launch")
@@ -47,7 +47,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
 
     func testTrackingProfilingSessionMetric_afterAppLaunchProfilingManuallyStopped() throws {
         // Given
-        let duration = Int64(123_000_000)
+        let durationMs = Int64(123)
         let fileSize = Int64(1_000_000)
         let controller = ProfilingTelemetryController(telemetry: telemetry)
 
@@ -56,7 +56,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
             ProfilingSessionMetric(
                 startReason: .applicationLaunch,
                 status: .stopped(reason: .manual),
-                durationNs: duration,
+                durationMs: durationMs,
                 fileSize: fileSize,
                 appStartInfo: "background_launch"
             )
@@ -65,7 +65,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         // Then
         let metric = try XCTUnwrap(telemetry.messages.profilingSessionMetric)
         XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.applicationLaunch.rawValue)
-        XCTAssertEqual(metric.duration, duration)
+        XCTAssertEqual(metric.duration, durationMs)
         XCTAssertEqual(metric.fileSize, fileSize)
         XCTAssertEqual(metric.stoppedReason, ProfilingContext.Status.StopReason.manual.rawValue)
         XCTAssertNil(metric.errorMessage)
@@ -84,8 +84,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
             ProfilingSessionMetric.noData(
                 startReason: .applicationLaunch,
                 status: .stopped(reason: .manual),
-                durationNs: nil,
-                errorCode: 3,
+                durationMs: nil,
                 cycleIndex: nil,
                 appStartInfo: "prewarming"
             )
@@ -96,7 +95,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.applicationLaunch.rawValue)
         XCTAssertNil(metric.duration)
         XCTAssertNil(metric.fileSize)
-        XCTAssertEqual(metric.errorCode, 3)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertFalse(metric.errorMessage?.isEmpty ?? true)
         XCTAssertEqual(metric.appStartInfo, "prewarming")
 
@@ -113,7 +112,6 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
             ProfilingSessionMetric.noProfile(
                 startReason: .applicationLaunch,
                 status: .stopped(reason: .notStarted),
-                errorCode: 1,
                 cycleIndex: nil,
                 appStartInfo: "uncertain"
             )
@@ -124,7 +122,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.applicationLaunch.rawValue)
         XCTAssertNil(metric.duration)
         XCTAssertNil(metric.fileSize)
-        XCTAssertEqual(metric.errorCode, 1)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertFalse(metric.errorMessage?.isEmpty ?? true)
         XCTAssertEqual(metric.appStartInfo, "uncertain")
 
@@ -134,7 +132,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
 
     func testTrackingProfilingSessionMetric_whileContinuousProfilingIsRunning() throws {
         // Given
-        let duration = Int64(123_000_000)
+        let durationMs = Int64(123)
         let fileSize = Int64(1_000_000)
         let controller = ProfilingTelemetryController(telemetry: telemetry)
 
@@ -143,7 +141,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
             ProfilingSessionMetric(
                 startReason: .continuous,
                 status: .running,
-                durationNs: duration,
+                durationMs: durationMs,
                 fileSize: fileSize,
                 cycleIndex: 0
             )
@@ -152,11 +150,11 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         // Then
         let metric = try XCTUnwrap(telemetry.messages.profilingSessionMetric)
         XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.continuous.rawValue)
-        XCTAssertEqual(metric.duration, duration)
+        XCTAssertEqual(metric.duration, durationMs)
         XCTAssertEqual(metric.fileSize, fileSize)
         XCTAssertEqual(metric.cycleIndex, 0)
         XCTAssertNil(metric.stoppedReason)
-        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertNil(metric.errorMessage)
 
         let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: ProfilingSessionMetric.Constants.name))
@@ -175,7 +173,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.rumOperation.rawValue)
         XCTAssertNil(metric.duration)
         XCTAssertNil(metric.fileSize)
-        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertEqual(metric.errorMessage, ProfilingSessionMetric.Constants.noProfiledEventsErrorMessage)
 
         let metricTelemetry = try XCTUnwrap(telemetry.messages.lastMetric(named: ProfilingSessionMetric.Constants.name))
@@ -194,7 +192,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         XCTAssertEqual(metric.startReason, ProfilingSessionMetric.StartReason.rumOperation.rawValue)
         XCTAssertNil(metric.duration)
         XCTAssertNil(metric.fileSize)
-        XCTAssertNil(metric.errorCode)
+        XCTAssertEqual(metric.errorCode, ProfilingSessionMetric.ErrorCode.none.rawValue)
         XCTAssertEqual(
             metric.errorMessage,
             "\(ProfilingSessionMetric.Constants.quotaErrorMessage) Quota reason: quota_exceeded."
@@ -210,7 +208,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         let diagnosticsKey = AggregationDiagnosticsMetric.Constants.diagnosticsKey
 
         // When
-        controller.sendProfile(durationNs: 1, fileSize: 2, for: .continuousProfiling)
+        controller.sendProfile(durationMs: 1, fileSize: 2, for: .continuousProfiling)
         controller.sendProfileDropped(for: .customProfiling)
 
         // Then
@@ -228,7 +226,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         let controller = ProfilingTelemetryController(telemetry: telemetry)
 
         // When
-        controller.sendProfile(durationNs: 1, fileSize: 2, for: .continuousProfiling)
+        controller.sendProfile(durationMs: 1, fileSize: 2, for: .continuousProfiling)
 
         // Then
         let metric = try XCTUnwrap(telemetry.messages.profilingSessionMetric)
@@ -241,8 +239,8 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         let controller = ProfilingTelemetryController(telemetry: telemetry)
 
         // When
-        controller.sendProfile(durationNs: 1, fileSize: 2, for: .customProfiling)
-        controller.sendNoData(durationNs: 1, for: .customProfiling)
+        controller.sendProfile(durationMs: 1, fileSize: 2, for: .customProfiling)
+        controller.sendNoData(durationMs: 1, for: .customProfiling)
 
         // Then
         let firstMetric = try XCTUnwrap(telemetry.messages[0]
@@ -277,8 +275,8 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         let controller = ProfilingTelemetryController(telemetry: telemetry)
 
         // When
-        controller.sendProfile(durationNs: 1, fileSize: 2, for: .continuousProfiling)
-        controller.sendProfile(durationNs: 3, fileSize: 4, for: .continuousProfiling)
+        controller.sendProfile(durationMs: 1, fileSize: 2, for: .continuousProfiling)
+        controller.sendProfile(durationMs: 3, fileSize: 4, for: .continuousProfiling)
 
         // Then
         let firstMetric = try XCTUnwrap(telemetry.messages[0]
@@ -293,7 +291,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         // Given
         let iterations = 10
         let status: ProfilingContext.Status = .running
-        let duration = Int64(123_000_000)
+        let durationMs = Int64(123)
         let controller = ProfilingTelemetryController(telemetry: telemetry)
 
         // When
@@ -302,7 +300,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
                 ProfilingSessionMetric(
                     startReason: .continuous,
                     status: status,
-                    durationNs: duration,
+                    durationMs: durationMs,
                     fileSize: Int64($0),
                     cycleIndex: $0
                 )
@@ -314,7 +312,7 @@ final class ProfilingTelemetryControllerTests: XCTestCase {
         try (0..<iterations).forEach {
             let metric = try XCTUnwrap(telemetry.messages[$0]
                 .asMetric?.attributes[ProfilingSessionMetric.Constants.sessionKey] as? ProfilingSessionMetric.Attributes)
-            XCTAssertEqual(metric.duration, duration)
+            XCTAssertEqual(metric.duration, durationMs)
             XCTAssertEqual(metric.fileSize, Int64($0))
             XCTAssertEqual(metric.cycleIndex, $0)
         }


### PR DESCRIPTION
### What and why?

This PR improves Profiling telemetry and app-launch profile handling.
It prevents `profiling_session.cycle_index` from growing across RUM sessions, reports consistent duration and error values  and ensures only profiles actually started during process launch are classified as app-launch profiles.

### How?
- Reset the continuous profiling cycle index when the RUM session ID changes.
- Report profile duration in milliseconds and map `error_code` to stable values aligned with Android.
- Track whether the native profiler successfully auto-started at launch.
- Fix C++ lint findings.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
