### PR TITLE
[RUM-17921] Create the RUM session identity synchronously in `RUM.enable()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FIX] Resolve the RUM session sampling decision synchronously in `RUM.enable()`, so WebViews instrumented immediately after initialization get a decision consistent with the session. See [#3183][]
+
 # 3.17.0 / 09-09-2026
 
 - [FEATURE] Add a configurable initialization timeout for the first Datadog Flags evaluation context. See [#3167][]
@@ -1244,6 +1246,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#3165]: https://github.com/DataDog/dd-sdk-ios/pull/3165
 [#3164]: https://github.com/DataDog/dd-sdk-ios/pull/3164
 [#3167]: https://github.com/DataDog/dd-sdk-ios/pull/3167
+[#3183]: https://github.com/DataDog/dd-sdk-ios/pull/3183
 
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin

--- a/Datadog/IntegrationUnitTests/RUM/DeterministicSamplingIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/RUM/DeterministicSamplingIntegrationTests.swift
@@ -74,6 +74,43 @@ class DeterministicSamplingIntegrationTests: XCTestCase {
         XCTAssertTrue(events.isEmpty, "Unsampled session must produce no RUM events")
     }
 
+    // MARK: - Initial session adopts the synchronously created identity
+
+    /// Verifies the initial session adopts the session ID created in `RUM.enable()` instead of generating
+    /// its own once the asynchronous session-creation flow runs.
+    ///
+    /// The generator hands out a different UUID on every call, so if the initial session generated its own
+    /// ID the sampler published by `onSessionUpdate` would differ from the one exposed synchronously. This
+    /// is what guarantees an early request and the rest of the session share one decision. See RUM-17921.
+    func testInitialSession_adoptsTheIdentityCreatedAtEnableTime() throws {
+        // Given
+        let presetUUID = UUID(uuidString: "c5b3c4ab-fa4a-4de9-8199-a522131ec48a")!
+        let nextUUID = UUID(uuidString: "c5b3c4ab-fa4a-4de9-8199-a5221003fa41")!
+        let generator = SequencedRUMUUIDGeneratorMock(uuids: [RUMUUID(rawValue: presetUUID), RUMUUID(rawValue: nextUUID)])
+
+        var rumConfig = RUM.Configuration(applicationID: "test-app-id")
+        rumConfig.sessionSampleRate = 60
+        rumConfig.uuidGenerator = generator
+
+        // When
+        RUM.enable(with: rumConfig, in: core)
+
+        let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
+        let synchronousSampler = try XCTUnwrap(rum.rumSessionSampler, "Sampler must exist before any flush")
+
+        // Let the asynchronous session-creation flow run
+        RUMMonitor.shared(in: core).startView(key: "test-view", name: "TestView")
+        core.flush()
+
+        // Then - the session published by `onSessionUpdate` must be the one created at enable time
+        XCTAssertEqual(
+            rum.rumSessionSampler,
+            synchronousSampler,
+            "The initial session must adopt the preset identity, not generate a new one"
+        )
+        XCTAssertEqual(synchronousSampler, DeterministicSampler(uuid: presetUUID, samplingRate: 60))
+    }
+
     // MARK: - Session Replay child-rate correction
 
     #if os(iOS)
@@ -267,5 +304,24 @@ class DeterministicSamplingIntegrationTests: XCTestCase {
 
         let dd = try XCTUnwrap(span.context.dd)
         XCTAssert(dd.samplingDecision.samplingPriority.isKept == spansExist)
+    }
+}
+
+/// A `RUMUUIDGenerator` that returns a different UUID on each call, then repeats the last one.
+///
+/// `RUMUUIDGeneratorMock` always returns the same value, which cannot distinguish "the session adopted the
+/// preset ID" from "the session generated a new one".
+private final class SequencedRUMUUIDGeneratorMock: RUMUUIDGenerator {
+    private var uuids: [RUMUUID]
+    private var index = 0
+
+    init(uuids: [RUMUUID]) {
+        precondition(!uuids.isEmpty)
+        self.uuids = uuids
+    }
+
+    func generateUnique() -> RUMUUID {
+        defer { index = min(index + 1, uuids.count - 1) }
+        return uuids[index]
     }
 }

--- a/DatadogInternal/Sources/Models/RUM/RUMSessionSamplerProvider.swift
+++ b/DatadogInternal/Sources/Models/RUM/RUMSessionSamplerProvider.swift
@@ -6,9 +6,14 @@
 
 import Foundation
 
-/// Provides the RUM session deterministic sampler for the active session.
+/// Provides the deterministic sampler for the current RUM session.
 public protocol RUMSessionSamplerProvider {
-    /// The RUM session deterministic sampler for the active session. `nil` if there is no active session.
+    /// The deterministic sampler for the current RUM session, including the initial session while it is
+    /// still being created.
+    ///
+    /// The initial session's identity is created synchronously inside `RUM.enable()`, so this is populated
+    /// by the time `RUM.enable()` returns, before the session scope itself exists. It is `nil` when RUM is
+    /// not enabled, and while no session is active, for example after `stopSession()`.
     var rumSessionSampler: DeterministicSampler? { get }
 }
 

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -139,6 +139,21 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
 
         let sessionSampleRate = configuration.debugSDK ? 100 : configuration.sessionSampleRate
 
+        // Create the initial session identity here, synchronously, while still on the main thread inside
+        // `RUM.enable()`. The session scope is still created asynchronously further down the line and adopts
+        // this ID, but deriving the sampler now means `RUMSessionSamplerProvider` resolves by the time
+        // `RUM.enable()` returns instead of staying `nil` until the initial session is created. WebViewTracking
+        // reads it through that protocol, so a WebView instrumented immediately after enable gets a real
+        // tracing decision rather than `null`.
+        //
+        // Trace, Profiling and the URLSession handlers do NOT read this. They still resolve their RUM context
+        // through the message bus and keep their existing behaviour until the centralized sampling service
+        // lands. See RUM-17921.
+        let initialSessionUUID = configuration.uuidGenerator.generateUnique()
+        _rumSessionSampler.mutate {
+            $0 = DeterministicSampler(uuid: initialSessionUUID.rawValue, samplingRate: sessionSampleRate)
+        }
+
         let timeseriesCollector: TimeseriesCollecting? = configuration.timeseries.flatMap { timeseries -> TimeseriesCollecting? in
             let effectiveCollectTypes = timeseries.effectiveCollectTypes
             // An empty effective selection (explicit `[]`, or emptied by platform availability, e.g.
@@ -227,6 +242,7 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
                 )
             },
             sessionType: configuration.sessionTypeOverride.flatMap { RUMSessionType(rawValue: $0) },
+            initialSessionUUID: initialSessionUUID,
             timeseriesCollector: timeseriesCollector
         )
 

--- a/DatadogRUM/Sources/Feature/RUMFeature.swift
+++ b/DatadogRUM/Sources/Feature/RUMFeature.swift
@@ -149,6 +149,10 @@ internal final class RUMFeature: DatadogRemoteFeature, RUMSessionSamplerProvider
         // Trace, Profiling and the URLSession handlers do NOT read this. They still resolve their RUM context
         // through the message bus and keep their existing behaviour until the centralized sampling service
         // lands. See RUM-17921.
+        //
+        // Note this derives the sampler in a second place: `RUMSessionScope` still derives its own for every
+        // other session, from the same UUID and sampling rate, so the two always agree. The centralized
+        // service removes the duplication by becoming the only owner of the session identity.
         let initialSessionUUID = configuration.uuidGenerator.generateUnique()
         _rumSessionSampler.mutate {
             $0 = DeterministicSampler(uuid: initialSessionUUID.rawValue, samplingRate: sessionSampleRate)

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -217,6 +217,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         if didCreateInitialSessionCount > 0 { // Sanity check
             dependencies.telemetry.error("Creating initial session \(didCreateInitialSessionCount) extra time(s) due to \(type(of: command)) (previous end reason: \(lastSessionEndReason?.rawValue ?? "unknown"))")
         }
+        let isFirstInitialSession = didCreateInitialSessionCount == 0
         didCreateInitialSessionCount += 1
 
         var startPrecondition: RUMSessionPrecondition? = nil
@@ -241,7 +242,11 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             startPrecondition: startPrecondition,
             context: context,
             dependencies: dependencies,
-            applicationState: applicationState
+            applicationState: applicationState,
+            // Adopt the ID created in `RUM.enable()` rather than generating a new one. Only the very first
+            // initial session may adopt it; the sanity path above can run again, and reusing the same ID
+            // would produce two sessions sharing an identity.
+            presetSessionUUID: isFirstInitialSession ? dependencies.initialSessionUUID : nil
         )
 
         lastSessionEndReason = nil

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -38,6 +38,11 @@ internal struct RUMScopeDependencies {
     let distributedTracingSampleRate: SampleRate?
     let eventBuilder: RUMEventBuilder
     let rumUUIDGenerator: RUMUUIDGenerator
+    /// The session ID created synchronously in `RUM.enable()`, adopted by the initial session instead of
+    /// generating a new one. This makes the session's deterministic sampler available through
+    /// `RUMSessionSamplerProvider` before `RUM.enable()` returns. `nil` restores the previous behaviour of
+    /// generating it lazily.
+    let initialSessionUUID: RUMUUID?
     let backtraceReporter: BacktraceReporting?
     /// Integration with CIApp tests. It contains the CIApp test context when active.
     let ciTest: RUMCITest?
@@ -102,6 +107,7 @@ internal struct RUMScopeDependencies {
         networkSettledMetricFactory: @escaping (Date, String) -> TNSMetricTracking,
         interactionToNextViewMetricFactory: @escaping () -> INVMetricTracking?,
         sessionType: RUMSessionType?,
+        initialSessionUUID: RUMUUID? = nil,
         timeseriesCollector: TimeseriesCollecting? = nil
     ) {
         self.featureScope = featureScope
@@ -114,6 +120,7 @@ internal struct RUMScopeDependencies {
         self.distributedTracingSampleRate = distributedTracingSampleRate
         self.eventBuilder = eventBuilder
         self.rumUUIDGenerator = rumUUIDGenerator
+        self.initialSessionUUID = initialSessionUUID
         self.backtraceReporter = backtraceReporter
         self.ciTest = ciTest
         self.syntheticsTest = syntheticsTest

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -128,9 +128,13 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         context: DatadogContext,
         dependencies: RUMScopeDependencies,
         applicationState: RUMApplicationState,
-        resumingViewScope: RUMViewScope? = nil
+        resumingViewScope: RUMViewScope? = nil,
+        presetSessionUUID: RUMUUID? = nil
     ) {
-        let sessionUUID = dependencies.rumUUIDGenerator.generateUnique()
+        // `presetSessionUUID` is created synchronously in `RUM.enable()` for the initial session, so the
+        // sampler derived from it is exposed through `RUMSessionSamplerProvider` before `RUM.enable()` returns.
+        // Every other session generates its ID here, as before.
+        let sessionUUID = presetSessionUUID ?? dependencies.rumUUIDGenerator.generateUnique()
 
         self.parent = parent
         self.dependencies = dependencies

--- a/DatadogRUM/Tests/RUMTests.swift
+++ b/DatadogRUM/Tests/RUMTests.swift
@@ -77,6 +77,45 @@ class RUMTests: XCTestCase {
 
     // MARK: - Configuration Tests
 
+    func testWhenEnabled_thenSessionSamplerIsAvailableBeforeEnableReturns() throws {
+        // Given
+        // This session ID is not sampled at 50%, but it is sampled at 60%:
+        let sessionUUID = UUID(uuidString: "c5b3c4ab-fa4a-4de9-8199-a522131ec48a")!
+        config.sessionSampleRate = 60
+        config.uuidGenerator = RUMUUIDGeneratorMock(uuid: RUMUUID(rawValue: sessionUUID))
+
+        // When
+        RUM.enable(with: config, in: core)
+
+        // Then - deliberately no `flush()` and no waiting: the sampling decision must already be resolved
+        // by the time `RUM.enable()` returns, otherwise Features instrumenting a request right here (e.g.
+        // WebViewTracking) get no decision at all. See RUM-17921.
+        let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
+        let sampler = try XCTUnwrap(
+            rum.rumSessionSampler,
+            "The session sampler must be available synchronously, without waiting for the initial session"
+        )
+        XCTAssertEqual(sampler, DeterministicSampler(uuid: sessionUUID, samplingRate: 60))
+        XCTAssertTrue(sampler.isSampled)
+    }
+
+    func testWhenEnabledWithDebugSDK_thenSessionSamplerUsesTheOverriddenRate() throws {
+        // Given
+        let sessionUUID = UUID(uuidString: "c5b3c4ab-fa4a-4de9-8199-a522131ec48a")!
+        config.sessionSampleRate = 0
+        config.debugSDK = true
+        config.uuidGenerator = RUMUUIDGeneratorMock(uuid: RUMUUID(rawValue: sessionUUID))
+
+        // When
+        RUM.enable(with: config, in: core)
+
+        // Then - `debugSDK` forces 100%, and the synchronous sampler must honour it like the session does
+        let rum = try XCTUnwrap(core.get(feature: RUMFeature.self))
+        let sampler = try XCTUnwrap(rum.rumSessionSampler)
+        XCTAssertEqual(sampler, DeterministicSampler(uuid: sessionUUID, samplingRate: 100))
+        XCTAssertTrue(sampler.isSampled)
+    }
+
     func testWhenEnabledWithDefaultConfiguration() throws {
         // Given
         let applicationID: String = .mockRandom()

--- a/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
+++ b/DatadogWebViewTracking/Tests/WebViewTrackingTests.swift
@@ -331,6 +331,41 @@ class WebViewTrackingTests: XCTestCase {
         }
     }
 
+    func testItInjectsATracingDecisionBeforeTheInitialSessionExists() throws {
+        // Given
+        // This session ID is not sampled at 50%, but it is sampled at 60%:
+        let sessionUUID = RUMUUID(rawValue: UUID(uuidString: "c5b3c4ab-fa4a-4de9-8199-a522131ec48a")!)
+
+        // `FeatureRegistrationCoreMock` returns a NOP feature scope, so the asynchronous flow that creates
+        // the initial RUM session never runs. Any decision available here can only have been resolved
+        // synchronously inside `RUM.enable()`.
+        //
+        // A real core cannot express this deterministically: whether the session lands before the WebView is
+        // instrumented depends on machine load, which is precisely the race reported in RUMS-6198.
+        let core = FeatureRegistrationCoreMock()
+
+        // When
+        RUM.enable(
+            with: .mockWith(applicationID: "test-app-id") {
+                $0.sessionSampleRate = 100
+                $0.uuidGenerator = RUMUUIDGeneratorMock(uuid: sessionUUID)
+                $0.urlSessionTracking = .init(
+                    firstPartyHostsTracing: .trace(hosts: ["localhost"], sampleRate: 60)
+                )
+            },
+            in: core
+        )
+
+        // Then - the value injected into the JS bridge must be a real decision. `null` hands sampling back to
+        // the Browser SDK, which then decides independently of the native session. See RUM-17921.
+        let decision = WebViewTracking.isTraceSampledStringValue(for: core)
+        XCTAssertEqual(
+            decision,
+            "true",
+            "Session sampled at 100% composed with a 60% first party host rate must resolve to `true`, not `\(decision)`"
+        )
+    }
+
     func testItChangesBridgeDecisionOnSessionRollover() throws {
         // Given
         // This session ID is not sampled at 50%, but it is sampled at 60%:


### PR DESCRIPTION
### What and why?

This PR makes the RUM session identity, and therefore its sampling decision, available synchronously when `RUM.enable()` returns.

The session ID and its deterministic sampler were created inside the asynchronous session-creation flow, so `RUMSessionSamplerProvider` resolved to `nil` for a window after enable. A WebView instrumented in that window gets a `null` tracing decision injected into its JS bridge, and the Browser SDK then samples independently of the native session.

Scope is limited to that path. Trace, Profiling and the URLSession handlers still read their RUM context from the message bus and are unaffected. They move to a centralised synchronous sampling service in a follow-up, which is what fixes early native requests.

### How?

* Create the initial session UUID and derive its deterministic sampler in `RUMFeature.init`, on the main thread inside `RUM.enable()`.
* Publish the sampler to `rumSessionSampler` immediately, so `RUMSessionSamplerProvider` resolves before `RUM.enable()` returns.
* Carry the UUID through `RUMScopeDependencies.initialSessionUUID` and adopt it in `RUMSessionScope` via `presetSessionUUID` instead of generating a new one. Other sessions are unchanged.
* Gate adoption on the first initial session, so the sanity path cannot produce two sessions sharing an ID.
* Add tests for the WebView decision at instrumentation time, the sampler at enable time, and adoption of the preset ID.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes
- [x] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [x] Run `make api-surface` when adding new APIs
