### PR TITLE
[PANA-8974] Key heatmap identifiers by layer

### DIFF
--- a/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIEventCommandFactory.swift
+++ b/DatadogRUM/Sources/Instrumentation/Actions/UIKit/UIEventCommandFactory.swift
@@ -87,8 +87,8 @@ internal final class UITouchCommandFactory: UIEventCommandFactory {
 
         var heatmapAttributes: HeatmapAttributes?
 
-        // Heatmap identifiers are looked up by `tap.view`, not the action target
-        if let heatmapIdentifier = heatmapIdentifierRegistry.heatmapIdentifier(for: ObjectIdentifier(view)) {
+        // Heatmap identifiers are looked up by `tap.view.layer`, not the action target
+        if let heatmapIdentifier = heatmapIdentifierRegistry.heatmapIdentifier(for: ObjectIdentifier(view.layer)) {
             heatmapAttributes = HeatmapAttributes(
                 identifier: heatmapIdentifier,
                 size: view.bounds.size,

--- a/DatadogRUM/Tests/Heatmaps/HeatmapIdentifierStoreTests.swift
+++ b/DatadogRUM/Tests/Heatmaps/HeatmapIdentifierStoreTests.swift
@@ -19,18 +19,18 @@ struct HeatmapIdentifierStoreTests {
     func setHeatmapIdentifiersReplacesCurrentSnapshot() {
         // given
         let store = HeatmapIdentifierStore()
-        let view1 = UIView()
-        let view2 = UIView()
+        let layer1 = CALayer()
+        let layer2 = CALayer()
         let id1 = HeatmapIdentifier(rawValue: "aaa")
         let id2 = HeatmapIdentifier(rawValue: "bbb")
 
         // when
-        store.setHeatmapIdentifiers([ObjectIdentifier(view1): id1])
-        store.setHeatmapIdentifiers([ObjectIdentifier(view2): id2])
+        store.setHeatmapIdentifiers([ObjectIdentifier(layer1): id1])
+        store.setHeatmapIdentifiers([ObjectIdentifier(layer2): id2])
 
         // then
-        #expect(store.heatmapIdentifier(for: ObjectIdentifier(view1)) == nil)
-        #expect(store.heatmapIdentifier(for: ObjectIdentifier(view2)) == id2)
+        #expect(store.heatmapIdentifier(for: ObjectIdentifier(layer1)) == nil)
+        #expect(store.heatmapIdentifier(for: ObjectIdentifier(layer2)) == id2)
     }
 }
 #endif

--- a/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
+++ b/DatadogRUM/Tests/Instrumentation/Actions/RUMActionsHandlerTests.swift
@@ -147,7 +147,7 @@ class RUMActionsHandlerTests: XCTestCase {
 
     // MARK: - Heatmap attributes
 
-    func testWhenTapViewIsInRegistry_itLooksUpHeatmapByTapView() {
+    func testWhenTapViewLayerIsInRegistry_itLooksUpHeatmapByTapViewLayer() {
         // Given
         let cell = UITableViewCell(frame: .init(x: 0, y: 0, width: 320, height: 88))
         mockAppWindow.addSubview(cell)
@@ -156,8 +156,8 @@ class RUMActionsHandlerTests: XCTestCase {
         cell.contentView.addSubview(leaf)
 
         let registry = HeatmapIdentifierRegistryMock(identifiers: [
-            ObjectIdentifier(cell): HeatmapIdentifier(rawValue: "cell-id"),
-            ObjectIdentifier(leaf): HeatmapIdentifier(rawValue: "leaf-id"),
+            ObjectIdentifier(cell.layer): HeatmapIdentifier(rawValue: "cell-id"),
+            ObjectIdentifier(leaf.layer): HeatmapIdentifier(rawValue: "leaf-id"),
         ])
         let handler = touchHandler(heatmapRegistry: registry)
 
@@ -174,7 +174,7 @@ class RUMActionsHandlerTests: XCTestCase {
         XCTAssertEqual(command?.heatmapAttributes?.targetHeight, 30)
     }
 
-    func testWhenTapViewIsNotInRegistry_itDoesNotAttachHeatmapAttributes() {
+    func testWhenTapViewLayerIsNotInRegistry_itDoesNotAttachHeatmapAttributes() {
         // Given
         let cell = UITableViewCell()
         mockAppWindow.addSubview(cell)
@@ -183,7 +183,7 @@ class RUMActionsHandlerTests: XCTestCase {
         cell.contentView.addSubview(leaf)
 
         let registry = HeatmapIdentifierRegistryMock(identifiers: [
-            ObjectIdentifier(cell): HeatmapIdentifier(rawValue: "cell-id"),
+            ObjectIdentifier(cell.layer): HeatmapIdentifier(rawValue: "cell-id"),
         ])
         let handler = touchHandler(heatmapRegistry: registry)
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -82,7 +82,7 @@ internal struct ViewTreeRecorder {
                     screenName: viewPath,
                     bundleIdentifier: bundleIdentifier() ?? "unknown"
                 )
-                heatmapCache.identifiers[ObjectIdentifier(view)] = identifier
+                heatmapCache.identifiers[ObjectIdentifier(view.layer)] = identifier
                 heatmapIdentifier = identifier
             }
             nodes.append(

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/HeatmapIdentifierComputationTests.swift
@@ -148,9 +148,12 @@ struct HeatmapIdentifierComputationTests {
         _ = recorder.record(parent, in: context)
 
         // Then
-        #expect(heatmapCache.identifiers[ObjectIdentifier(parent)] != nil)
-        #expect(heatmapCache.identifiers[ObjectIdentifier(child)] != nil)
-        #expect(heatmapCache.identifiers[ObjectIdentifier(parent)] != heatmapCache.identifiers[ObjectIdentifier(child)])
+        #expect(heatmapCache.identifiers[ObjectIdentifier(parent.layer)] != nil)
+        #expect(heatmapCache.identifiers[ObjectIdentifier(child.layer)] != nil)
+        #expect(
+            heatmapCache.identifiers[ObjectIdentifier(parent.layer)]
+                != heatmapCache.identifiers[ObjectIdentifier(child.layer)]
+        )
     }
 
     @Test("Skips heatmap cache write for views that produce no rendered nodes")
@@ -176,8 +179,8 @@ struct HeatmapIdentifierComputationTests {
         _ = recorder.record(parent, in: context)
 
         // Then
-        #expect(heatmapCache.identifiers[ObjectIdentifier(parent)] == nil)
-        #expect(heatmapCache.identifiers[ObjectIdentifier(child)] != nil)
+        #expect(heatmapCache.identifiers[ObjectIdentifier(parent.layer)] == nil)
+        #expect(heatmapCache.identifiers[ObjectIdentifier(child.layer)] != nil)
     }
 
     @Test("Skips heatmap computation when viewPath is nil")

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -95,7 +95,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         XCTAssertEqual(queryContext.recorder.date, randomRecorderContext.date)
     }
 
-    func testWhenCreatingSnapshot_itWritesHeatmapIdentifiersToRegistry() throws {
+    func testWhenCreatingSnapshot_itWritesHeatmapIdentifiersToRegistryByLayer() throws {
         // Given
         let view = UIView.mock(withFixture: .visible(.someAppearance))
         let core = FeatureRegistrationCoreMock()
@@ -114,7 +114,8 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         _ = builder.createSnapshot(of: view, with: context)
 
         // Then
-        XCTAssertFalse(registry.identifiers.isEmpty)
+        XCTAssertNotNil(registry.identifiers[ObjectIdentifier(view.layer)])
+        XCTAssertNil(registry.identifiers[ObjectIdentifier(view)])
     }
 
     func testWhenCreatingSnapshot_withNoViewPath_itDoesNotWriteToRegistry() throws {


### PR DESCRIPTION
### What and why?

Heatmap correlation currently uses `UIView` identity, while the composition-tree pipeline records `CALayer` nodes.

This PR switches the existing view-tree and RUM integration to layer identity, establishing a shared key without changing the registry API or current heatmap behavior.

### How?

- Store view-tree heatmap identifiers using `ObjectIdentifier(view.layer)`.
- Look up heatmap identifiers using the tapped view’s layer.
- Update tests to verify that identifiers are keyed by layers rather than views.

Follow-up PRs will:

- Resolve SwiftUI tap targets to the appropriate recorded layer.
- Compute permanent IDs and publish layer mappings from the composition-tree pipeline.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs
