### PR TITLE
RUM-18464: Migrate `DatadogProfiling` to Swift 6

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -11464,6 +11464,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach/include";
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Debug;
@@ -11499,6 +11500,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach/include";
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Release;
@@ -11534,6 +11536,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach/include";
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 			};
 			name = Integration;
@@ -12062,6 +12065,7 @@
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach/include";
 				SWIFT_OBJC_INTEROP_MODE = objcxx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 				TVOS_DEPLOYMENT_TARGET = 16.6;
 			};
@@ -12087,6 +12091,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach/include";
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 				TVOS_DEPLOYMENT_TARGET = 16.6;
 			};
@@ -12112,6 +12117,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../DatadogProfiling/Mach/include";
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,7";
 				TVOS_DEPLOYMENT_TARGET = 16.6;
 			};

--- a/DatadogProfiling.podspec
+++ b/DatadogProfiling.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = "Datadog, Inc."
 
-  s.swift_version = '5.9'
+  s.swift_version = '6.0'
   s.ios.deployment_target = '15.0'
   s.tvos.deployment_target = '15.0'
   s.visionos.deployment_target = '1.0'

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -9,13 +9,9 @@ import Foundation
 
 #if !os(watchOS)
 
-// swiftlint:disable duplicate_imports
-#if swift(>=6.0)
-internal import DatadogMachProfiler
-#else
+// Keep this implementation-only. Otherwise, Swift 6 records DatadogMachProfiler as a
+// transitive module dependency, but it is not distributed as an XCFramework.
 @_implementationOnly import DatadogMachProfiler
-#endif
-// swiftlint:enable duplicate_imports
 
 internal final class DatadogProfiler: ProfilingHandler, @unchecked Sendable {
     enum Constants {

--- a/DatadogProfiling/Sources/DatadogProfiler.swift
+++ b/DatadogProfiling/Sources/DatadogProfiler.swift
@@ -5,7 +5,7 @@
  */
 
 import Foundation
-import DatadogInternal
+@preconcurrency import DatadogInternal
 
 #if !os(watchOS)
 
@@ -17,7 +17,7 @@ internal import DatadogMachProfiler
 #endif
 // swiftlint:enable duplicate_imports
 
-internal final class DatadogProfiler: ProfilingHandler {
+internal final class DatadogProfiler: ProfilingHandler, @unchecked Sendable {
     enum Constants {
         /// Default profile duration during continuous profiling.
         static let maxProfileDuration: TimeInterval = 60 // 1 minute profiles

--- a/DatadogProfiling/Sources/ProfilerFeature.swift
+++ b/DatadogProfiling/Sources/ProfilerFeature.swift
@@ -9,13 +9,9 @@ import DatadogInternal
 
 #if !os(watchOS)
 
-// swiftlint:disable duplicate_imports
-#if swift(>=6.0)
-internal import DatadogMachProfiler
-#else
+// Keep this implementation-only. Otherwise, Swift 6 records DatadogMachProfiler as a
+// transitive module dependency, but it is not distributed as an XCFramework.
 @_implementationOnly import DatadogMachProfiler
-#endif
-// swiftlint:enable duplicate_imports
 
 internal final class ProfilerFeature: DatadogRemoteFeature {
     enum Constants {

--- a/DatadogProfiling/Sources/Profiling.swift
+++ b/DatadogProfiling/Sources/Profiling.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 @_spi(Internal)
-import DatadogInternal
+@preconcurrency import DatadogInternal
 
 #if !os(watchOS)
 

--- a/DatadogProfiling/Sources/Profiling.swift
+++ b/DatadogProfiling/Sources/Profiling.swift
@@ -10,13 +10,9 @@ import Foundation
 
 #if !os(watchOS)
 
-// swiftlint:disable duplicate_imports
-#if swift(>=6.0)
-internal import DatadogMachProfiler
-#else
+// Keep this implementation-only. Otherwise, Swift 6 records DatadogMachProfiler as a
+// transitive module dependency, but it is not distributed as an XCFramework.
 @_implementationOnly import DatadogMachProfiler
-#endif
-// swiftlint:enable duplicate_imports
 
 /// Main entry point for Datadog profiling functionality.
 ///

--- a/DatadogProfiling/Sources/ProfilingConfiguration.swift
+++ b/DatadogProfiling/Sources/ProfilingConfiguration.swift
@@ -11,7 +11,7 @@ import DatadogInternal
 
 extension Profiling {
     /// Configuration options for the profiling feature.
-    public struct Configuration {
+    public struct Configuration: Sendable {
         /// Overrides the custom server endpoint where Profiles are sent.
         /// If `nil`, the default Datadog endpoint will be used.
         public var customEndpoint: URL?
@@ -81,7 +81,7 @@ extension Profiling.Configuration {
     public typealias FeatureFlags = [FeatureFlag: Bool]
 
     /// Feature flags available in Profiling.
-    public enum FeatureFlag: String {
+    public enum FeatureFlag: String, Sendable {
         /// Adds CPU-time sample values alongside wall-time sample values.
         case cpuTimeSamples
     }

--- a/DatadogProfiling/Sources/ProfilingHandler.swift
+++ b/DatadogProfiling/Sources/ProfilingHandler.swift
@@ -9,13 +9,9 @@ import DatadogInternal
 
 #if !os(watchOS)
 
-// swiftlint:disable duplicate_imports
-#if swift(>=6.0)
-internal import DatadogMachProfiler
-#else
+// Keep this implementation-only. Otherwise, Swift 6 records DatadogMachProfiler as a
+// transitive module dependency, but it is not distributed as an XCFramework.
 @_implementationOnly import DatadogMachProfiler
-#endif
-// swiftlint:enable duplicate_imports
 
 internal protocol ProfilingHandler {
     var attributes: [AttributeKey: AttributeValue] { get }

--- a/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
+++ b/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
@@ -259,6 +259,8 @@ private extension QuotaResponse.Attributes {
             decision = .quotaOK
         case .quotaOk, .quotaExceeded, .orgDisabled, .undefined:
             decision = admitted ? .quotaOK : .quotaKO
+        @unknown default:
+            decision = admitted ? .quotaOK : .quotaKO
         }
 
         return .init(decision: decision, reason: reason)

--- a/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
+++ b/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
@@ -9,14 +9,23 @@ import DatadogInternal
 
 #if !os(watchOS)
 
-internal struct ProfilingQuotaResult: Equatable {
-    internal enum Decision: Equatable {
+internal struct ProfilingQuotaResult: Equatable, Sendable {
+    internal enum Decision: Equatable, Sendable {
         case quotaOK
         case quotaKO
     }
 
     let decision: Decision
-    let reason: DDProfiling.QuotaReason
+    private let reasonRawValue: String
+
+    var reason: DDProfiling.QuotaReason {
+        DDProfiling.QuotaReason(rawValue: reasonRawValue) ?? .undefined
+    }
+
+    init(decision: Decision, reason: DDProfiling.QuotaReason) {
+        self.decision = decision
+        self.reasonRawValue = reason.rawValue
+    }
 }
 
 internal protocol ProfilingQuotaChecking: AnyObject, FeatureMessageReceiver {
@@ -26,7 +35,7 @@ internal protocol ProfilingQuotaChecking: AnyObject, FeatureMessageReceiver {
     ///
     /// The callback emits `nil` when a new session starts and the previous result is cleared,
     /// then emits the resolved result once the quota request completes.
-    var onQuotaResultUpdate: ((ProfilingQuotaResult?) -> Void)? { get set }
+    var onQuotaResultUpdate: (@Sendable (ProfilingQuotaResult?) -> Void)? { get set }
 }
 
 extension ProfilingQuotaChecking {
@@ -42,7 +51,7 @@ extension ProfilingQuotaChecking {
 /// It starts a quota request when a sampled-in RUM session id is observed with granted
 /// tracking consent, ignores stale responses for previous sessions and fails open
 /// on request or decoding errors.
-internal final class ProfilingQuotaChecker: ProfilingQuotaChecking {
+internal final class ProfilingQuotaChecker: ProfilingQuotaChecking, Sendable {
     private enum Constants {
         static let quotaPath = "/api/v2/profiling/quota"
         static let sessionIDQueryItem = "session_id"
@@ -58,12 +67,15 @@ internal final class ProfilingQuotaChecker: ProfilingQuotaChecking {
     }
 
     private let urlSession: URLSession
+    private let state = ReadWriteLock(wrappedValue: State.idle)
+    private let quotaResultUpdate = ReadWriteLock<(@Sendable (ProfilingQuotaResult?) -> Void)?>(wrappedValue: nil)
 
-    @ReadWriteLock
-    private var state: State = .idle
-    var quotaResult: ProfilingQuotaResult? { state.quotaResult }
+    var quotaResult: ProfilingQuotaResult? { state.wrappedValue.quotaResult }
 
-    var onQuotaResultUpdate: ((ProfilingQuotaResult?) -> Void)?
+    var onQuotaResultUpdate: (@Sendable (ProfilingQuotaResult?) -> Void)? {
+        get { quotaResultUpdate.wrappedValue }
+        set { quotaResultUpdate.wrappedValue = newValue }
+    }
 
     init(urlSession: URLSession = ProfilingQuotaChecker.urlSession) {
         self.urlSession = urlSession
@@ -87,7 +99,7 @@ extension ProfilingQuotaChecker: FeatureMessageReceiver {
     private func checkIfNeeded(sessionID: String, context: DatadogContext) {
         var shouldStartRequest = false
 
-        _state.mutate {
+        state.mutate {
             switch $0 {
             case .idle:
                 $0 = .pending(sessionID: sessionID)
@@ -147,7 +159,7 @@ extension ProfilingQuotaChecker: FeatureMessageReceiver {
     private func storeIfCurrentSession(result: ProfilingQuotaResult, sessionID: String) -> Bool {
         var didStore = false
 
-        _state.mutate {
+        state.mutate {
             switch $0 {
             case .pending(let currentSessionID) where currentSessionID == sessionID,
                     .resolved(let currentSessionID, _) where currentSessionID == sessionID:

--- a/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
+++ b/DatadogProfiling/Sources/ProfilingQuotaChecker.swift
@@ -28,6 +28,8 @@ internal struct ProfilingQuotaResult: Equatable, Sendable {
     }
 }
 
+internal typealias ProfilingQuotaResultListener = @Sendable (ProfilingQuotaResult?) -> Void
+
 internal protocol ProfilingQuotaChecking: AnyObject, FeatureMessageReceiver {
     var quotaResult: ProfilingQuotaResult? { get }
 
@@ -35,7 +37,7 @@ internal protocol ProfilingQuotaChecking: AnyObject, FeatureMessageReceiver {
     ///
     /// The callback emits `nil` when a new session starts and the previous result is cleared,
     /// then emits the resolved result once the quota request completes.
-    var onQuotaResultUpdate: (@Sendable (ProfilingQuotaResult?) -> Void)? { get set }
+    var onQuotaResultUpdate: ProfilingQuotaResultListener? { get set }
 }
 
 extension ProfilingQuotaChecking {
@@ -68,11 +70,11 @@ internal final class ProfilingQuotaChecker: ProfilingQuotaChecking, Sendable {
 
     private let urlSession: URLSession
     private let state = ReadWriteLock(wrappedValue: State.idle)
-    private let quotaResultUpdate = ReadWriteLock<(@Sendable (ProfilingQuotaResult?) -> Void)?>(wrappedValue: nil)
+    private let quotaResultUpdate = ReadWriteLock<ProfilingQuotaResultListener?>(wrappedValue: nil)
 
     var quotaResult: ProfilingQuotaResult? { state.wrappedValue.quotaResult }
 
-    var onQuotaResultUpdate: (@Sendable (ProfilingQuotaResult?) -> Void)? {
+    var onQuotaResultUpdate: ProfilingQuotaResultListener? {
         get { quotaResultUpdate.wrappedValue }
         set { quotaResultUpdate.wrappedValue = newValue }
     }

--- a/DatadogProfiling/Sources/SDKMetrics/AggregationDiagnosticsMetric.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/AggregationDiagnosticsMetric.swift
@@ -8,13 +8,9 @@ import Foundation
 
 #if !os(watchOS)
 
-// swiftlint:disable duplicate_imports
-#if swift(>=6.0)
-internal import DatadogMachProfiler
-#else
+// Keep this implementation-only. Otherwise, Swift 6 records DatadogMachProfiler as a
+// transitive module dependency, but it is not distributed as an XCFramework.
 @_implementationOnly import DatadogMachProfiler
-#endif
-// swiftlint:enable duplicate_imports
 
 /// Tracks profiling aggregation diagnostics to be added to telemetry metrics.
 internal final class AggregationDiagnosticsMetric {

--- a/DatadogProfiling/Sources/SDKMetrics/ConfigurationMetric.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ConfigurationMetric.swift
@@ -8,13 +8,9 @@ import Foundation
 
 #if !os(watchOS)
 
-// swiftlint:disable duplicate_imports
-#if swift(>=6.0)
-internal import DatadogMachProfiler
-#else
+// Keep this implementation-only. Otherwise, Swift 6 records DatadogMachProfiler as a
+// transitive module dependency, but it is not distributed as an XCFramework.
 @_implementationOnly import DatadogMachProfiler
-#endif
-// swiftlint:enable duplicate_imports
 
 /// Tracks the profiling configuration to be added to telemetry metrics.
 internal final class ConfigurationMetric {

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingSessionMetric.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingSessionMetric.swift
@@ -52,6 +52,8 @@ internal final class ProfilingSessionMetric {
                 self = .executionFailed
             case .unknown:
                 self = .unknown
+            @unknown default:
+                self = .unknown
             }
         }
     }

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingSessionMetric.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingSessionMetric.swift
@@ -128,6 +128,8 @@ internal final class ProfilingSessionMetric {
             errorMessage = errorMessage ?? reason.rawValue
         case .unknown:
             errorMessage = errorMessage ?? "Unknown profiling status."
+        @unknown default:
+            errorMessage = errorMessage ?? "Unknown profiling status."
         }
 
         return [

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
@@ -154,6 +154,8 @@ private extension LaunchInfo {
             "prewarming"
         case .uncertain:
             "uncertain"
+        @unknown default:
+            "uncertain"
         }
     }
 }

--- a/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
+++ b/DatadogProfiling/Sources/SDKMetrics/ProfilingTelemetryController.swift
@@ -9,6 +9,10 @@ import DatadogInternal
 
 #if !os(watchOS)
 
+// Keep this implementation-only. Otherwise, Swift 6 records DatadogMachProfiler as a
+// transitive module dependency, but it is not distributed as an XCFramework.
+@_implementationOnly import DatadogMachProfiler
+
 internal final class ProfilingTelemetryController {
     /// The default sample rate for "Profiling Session" metric (20%),
     /// applied in addition to the Profiling continuous sample rate (5% by default).

--- a/DatadogProfiling/Tests/DatadogProfilerTests.swift
+++ b/DatadogProfiling/Tests/DatadogProfilerTests.swift
@@ -1083,7 +1083,7 @@ extension DatadogProfilerTests {
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
             samplingExpectation.fulfill()
         }
-        waitForExpectations(timeout: 1.0)
+        wait(for: [samplingExpectation], timeout: 1.0)
 
         let timedOutProfile = dd_profiler_flush_and_get_profile()
         dd_pprof_destroy(timedOutProfile)
@@ -2779,7 +2779,7 @@ private extension DatadogProfilerTests {
 
         action()
 
-        waitForExpectations(timeout: timeout)
+        wait(for: [expectation], timeout: timeout)
     }
 
     func flushQueue() {

--- a/DatadogProfiling/Tests/ProfilingQuotaCheckerTests.swift
+++ b/DatadogProfiling/Tests/ProfilingQuotaCheckerTests.swift
@@ -327,7 +327,7 @@ private extension ProfilingQuotaCheckerTests {
 final class ProfilingQuotaCheckerMock: ProfilingQuotaChecking {
     private(set) var receivedContexts: [DatadogContext] = []
     var quotaResult: ProfilingQuotaResult?
-    var onQuotaResultUpdate: (@Sendable (ProfilingQuotaResult?) -> Void)?
+    var onQuotaResultUpdate: ProfilingQuotaResultListener?
     var receiveHandler: ((DatadogContext) -> ProfilingQuotaResult?)?
     private var currentSessionID: String?
 

--- a/DatadogProfiling/Tests/ProfilingQuotaCheckerTests.swift
+++ b/DatadogProfiling/Tests/ProfilingQuotaCheckerTests.swift
@@ -306,7 +306,7 @@ final class ProfilingQuotaCheckerTests: XCTestCase {
         _ = server.waitAndReturnRequests(count: 1)
 
         // Then
-        waitForExpectations(timeout: 1.0)
+        wait(for: [expectation], timeout: 1.0)
     }
 }
 
@@ -327,7 +327,7 @@ private extension ProfilingQuotaCheckerTests {
 final class ProfilingQuotaCheckerMock: ProfilingQuotaChecking {
     private(set) var receivedContexts: [DatadogContext] = []
     var quotaResult: ProfilingQuotaResult?
-    var onQuotaResultUpdate: ((ProfilingQuotaResult?) -> Void)?
+    var onQuotaResultUpdate: (@Sendable (ProfilingQuotaResult?) -> Void)?
     var receiveHandler: ((DatadogContext) -> ProfilingQuotaResult?)?
     private var currentSessionID: String?
 

--- a/DatadogProfiling/Tests/SafeReadTests.swift
+++ b/DatadogProfiling/Tests/SafeReadTests.swift
@@ -404,8 +404,8 @@ final class SafeReadTests: XCTestCase {
         // Listener thread waits up to 500ms for an exception message.
         // Timeout = no exception was raised; receive = safe-read regressed.
         let listenerDone = DispatchSemaphore(value: 0)
-        let receivedLock = NSLock()
-        var didReceiveMessage = false
+        let messageReceived = DispatchSemaphore(value: 0)
+        let listenerExceptionPort = exceptionPort
 
         DispatchQueue.global().async {
             let bufferSize: mach_msg_size_t = 1_024
@@ -417,14 +417,14 @@ final class SafeReadTests: XCTestCase {
                     MACH_RCV_MSG | MACH_RCV_TIMEOUT,
                     0,
                     bufferSize,
-                    exceptionPort,
+                    listenerExceptionPort,
                     500,
                     0
                 )
             }
-            receivedLock.lock()
-            didReceiveMessage = (result == MACH_MSG_SUCCESS)
-            receivedLock.unlock()
+            if result == MACH_MSG_SUCCESS {
+                messageReceived.signal()
+            }
             listenerDone.signal()
         }
 
@@ -440,9 +440,7 @@ final class SafeReadTests: XCTestCase {
         let waitResult = listenerDone.wait(timeout: .now() + 1.5)
         XCTAssertEqual(waitResult, .success, "Listener should complete (timed out, as expected)")
 
-        receivedLock.lock()
-        let gotMessage = didReceiveMessage
-        receivedLock.unlock()
+        let gotMessage = messageReceived.wait(timeout: .now()) == .success
 
         let regressionMessage = "Mach exception handler must NOT receive a message - this is the Crashlytics fix"
         XCTAssertFalse(gotMessage, regressionMessage)

--- a/Package.swift
+++ b/Package.swift
@@ -221,7 +221,7 @@ let package = Package(
             resources: [
                 .copy("Resources/PrivacyInfo.xcprivacy")
             ],
-            swiftSettings: internalSwiftSettings
+            swiftSettings: [.swiftLanguageMode(.v6)] + internalSwiftSettings
         ),
         .target(
             name: "DatadogMachProfiler",
@@ -235,7 +235,7 @@ let package = Package(
                 .target(name: "TestUtilities"),
             ],
             path: "DatadogProfiling/Tests",
-            swiftSettings: [.interoperabilityMode(.Cxx)] + internalSwiftSettings
+            swiftSettings: [.interoperabilityMode(.Cxx), .swiftLanguageMode(.v6)] + internalSwiftSettings
         ),
 
         .target(

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1703,7 +1703,7 @@ public struct FlagsEvaluationContext: Equatable, Codable
 public enum Profiling
     public static func enable(with configuration: Configuration = .init(), in core: DatadogCoreProtocol = CoreRegistry.default)
 [?] extension Profiling
-    public struct Configuration
+    public struct Configuration: Sendable
         public var customEndpoint: URL?
         public var applicationLaunchSampleRate: SampleRate
         public var continuousSampleRate: SampleRate
@@ -1711,7 +1711,7 @@ public enum Profiling
         public init(customEndpoint: URL? = nil,applicationLaunchSampleRate: SampleRate = 5,continuousSampleRate: SampleRate = 5,featureFlags: FeatureFlags = .defaults)
 [?] extension Profiling.Configuration
     public typealias FeatureFlags = [FeatureFlag: Bool]
-    public enum FeatureFlag: String
+    public enum FeatureFlag: String, Sendable
         case cpuTimeSamples
 [?] extension Profiling.Configuration.FeatureFlags
     public static var defaults: Self


### PR DESCRIPTION
### What and why?

This PR migrates the `DatadogProfiling` module and its tests to Swift 6. 
This resolves strict-concurrency diagnostics while preserving existing profiling behavior and API compatibility.

### How?

- Enables Swift 6 language mode for the Profiling targets in SwiftPM and Xcode.
- Makes `Profiling.Configuration` and `ProfilingQuotaChecker` types `Sendable`.
- Marks `DatadogProfiler` as `@unchecked Sendable`, relying on its existing serial-queue and locking guarantees.
- Updates the generated API surface to include the new public `Sendable` conformances.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs - see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) 
- [ ] Run `make api-surface` when adding new APIs