### PR TITLE
[CHORE] Stress-test dominant flaky tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ variables:
   DEFAULT_TVOS_OS: "26.0"
   DEFAULT_WATCHOS_OS: "26.0"
   DEFAULT_VISIONOS_OS: "26.0"
+  FLAKY_TEST_STRESS_BRANCH: "cgcote/flaky-test-stress"
   # Prefilled variables for running a pipeline manually:
   # Ref.: https://docs.gitlab.com/ee/ci/pipelines/index.html#prefill-variables-in-manual-pipelines
   RELEASE_GIT_TAG:
@@ -39,6 +40,11 @@ default:
 # the previous pipeline when a new commit is pushed to that branch.
 workflow:
   rules:
+    - if: '$CI_COMMIT_BRANCH == $FLAKY_TEST_STRESS_BRANCH'
+      variables:
+        FLAKY_TEST_STRESS: "1"
+      auto_cancel:
+        on_new_commit: interruptible
     - if: '$CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH !~ /^(develop|master|dogfooding|release\/.*|hotfix\/.*)$/'
       auto_cancel:
         on_new_commit: interruptible
@@ -58,6 +64,8 @@ workflow:
 
 .test-pipeline-job:
   rules:
+    - if: '$FLAKY_TEST_STRESS == "1"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == $DEVELOP_BRANCH || $CI_COMMIT_BRANCH == $MAIN_BRANCH' # always on main branches
     - if: '$CI_COMMIT_BRANCH' # when on other branch with following changes compared to develop
       changes:
@@ -186,6 +194,31 @@ Unit Tests (iOS):
     - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
     - make clean repo-setup ENV=ci
     - make test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE" USE_TEST_VISIBILITY=1
+  artifacts:
+    paths:
+      - "ResultBundles/*.xcresult"
+      - "ResultBundles/*.log"
+    when: always
+
+Flaky Test Stress (iOS):
+  stage: test
+  rules:
+    - if: '$FLAKY_TEST_STRESS == "1"'
+  timeout: 55m
+  variables:
+    PLATFORM: "iOS Simulator"
+    DEVICE: "iPhone 17 Pro"
+    TEST_ITERATIONS: "100"
+    RUNNER_SCRIPT_TIMEOUT: "50m"
+  parallel:
+    matrix:
+      - TEST_IDENTIFIER:
+          - "DatadogCoreTests/DataUploadWorkerTests/testWhenCancelled_itPerformsNoMoreUploads"
+          - "DatadogCoreTests/CrashReportReceiverTests/testReceiveCrashAndViewEvent"
+  script:
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE"
+    - make clean repo-setup ENV=ci
+    - USE_TEST_VISIBILITY=1 ./tools/test.sh --scheme "DatadogCore" --os "$DEFAULT_IOS_OS" --platform "$PLATFORM" --device "$DEVICE" --only-testing "$TEST_IDENTIFIER" --test-iterations "$TEST_ITERATIONS" --run-tests-until-failure
   artifacts:
     paths:
       - "ResultBundles/*.xcresult"
@@ -353,6 +386,8 @@ SR Layer Snapshot Tests:
 Tools Tests:
   stage: test
   rules:
+    - if: '$FLAKY_TEST_STRESS == "1"'
+      when: never
     - if: '$CI_COMMIT_BRANCH' # when on branch with following changes compared to develop
       changes:
         paths:
@@ -620,5 +655,9 @@ Publish CP podspec (Profiling):
 # It syncs the GitLab pipeline status with GitHub status checks.
 Sync GH Checks:
   stage: post
+  rules:
+    - if: '$FLAKY_TEST_STRESS == "1"'
+      when: never
+    - when: always
   script:
     - echo "All good"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,6 +122,7 @@ ENV check:
 Build Dependencies:
   stage: pre
   rules:
+    - if: '$FLAKY_TEST_STRESS == "1"'
     - !reference [.test-pipeline-job, rules]
     - !reference [.release-pipeline-job, rules]
   artifacts:
@@ -204,6 +205,8 @@ Flaky Test Stress (iOS):
   stage: test
   rules:
     - if: '$FLAKY_TEST_STRESS == "1"'
+  dependencies:
+    - "Build Dependencies"
   timeout: 55m
   variables:
     PLATFORM: "iOS Simulator"

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -34,7 +34,7 @@ class CrashReportReceiverTests: XCTestCase {
     func testReceiveCrashAndViewEvent() throws {
         // Given
         let receiver: CrashReportReceiver = .mockWith(featureScope: featureScope)
-        let lastRUMViewEvent: RUMViewEvent = .mockRandom()
+        let lastRUMViewEvent: RUMViewEvent = .mockRandomWith(crashCount: 0)
 
         // When
         let message: FeatureMessage = .payload(

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -9,6 +9,9 @@
 #   --scheme: Identifies the test scheme to execute
 #   --platform: Defines the type of simulator platform for the tests, e.g. 'iOS Simulator'
 #   --os: Sets the operating system version for the tests, e.g. '17.5'
+#   --only-testing: Constrains execution to one test identifier.
+#   --test-iterations: Sets the maximum number of test iterations.
+#   --run-tests-until-failure: Repeats tests until the first failure.
 
 set -eo pipefail
 source ./tools/utils/argparse.sh
@@ -21,6 +24,9 @@ define_arg "scheme" "" "Identifies the test scheme to execute" "string" "true"
 define_arg "os" "" "Sets the operating system version for the tests, e.g. '17.5'" "string" "true"
 define_arg "platform" "" "Defines the type of simulator platform for the tests, e.g. 'iOS Simulator'" "string" "true"
 define_arg "device" "" "Specifies the simulator device for running tests, e.g. 'iPhone 15 Pro'" "string" "true"
+define_arg "only-testing" "" "Constrains execution to one test identifier" "string" "false"
+define_arg "test-iterations" "" "Sets the maximum number of test iterations" "string" "false"
+define_arg "run-tests-until-failure" "false" "Repeats tests until the first failure" "store_true" "false"
 
 check_for_help "$@"
 parse_args "$@"
@@ -28,6 +34,17 @@ parse_args "$@"
 WORKSPACE="Datadog.xcworkspace"
 DESTINATION="platform=$platform,name=$device,OS=$os"
 SCHEME=$scheme
+
+TEST_ARGUMENTS=()
+if [[ -n "$only_testing" ]]; then
+    TEST_ARGUMENTS+=("-only-testing:$only_testing")
+fi
+if [[ -n "$test_iterations" ]]; then
+    TEST_ARGUMENTS+=("-test-iterations" "$test_iterations")
+fi
+if [[ "$run_tests_until_failure" == "true" ]]; then
+    TEST_ARGUMENTS+=("-run-tests-until-failure" "-test-repetition-relaunch-enabled" "YES")
+fi
 
 # Enables Datadog Test Visibility to trace tests execution
 # Ref.: https://docs.datadoghq.com/tests/setup/swift/
@@ -109,7 +126,7 @@ if [ "$CI" = "true" ]; then
     # process gets killed mid-run, e.g. by RUNNER_SCRIPT_TIMEOUT on a hung test. The raw
     # .xcresult bundle and this log are uploaded as-is (no need to zip): GitLab's artifact
     # uploader already archives whatever paths match, zip or not.
-    xcodebuild -workspace "$WORKSPACE" -destination "$DESTINATION" -scheme "$SCHEME" -resultBundlePath "$RESULT_BUNDLE_PATH" test 2>&1 | tee "ResultBundles/${SCHEME}.log" | xcbeautify
+    xcodebuild -workspace "$WORKSPACE" -destination "$DESTINATION" -scheme "$SCHEME" -resultBundlePath "$RESULT_BUNDLE_PATH" "${TEST_ARGUMENTS[@]}" test 2>&1 | tee "ResultBundles/${SCHEME}.log" | xcbeautify
 else
-    xcodebuild -workspace "$WORKSPACE" -destination "$DESTINATION" -scheme "$SCHEME" test 2>&1 | xcbeautify
+    xcodebuild -workspace "$WORKSPACE" -destination "$DESTINATION" -scheme "$SCHEME" "${TEST_ARGUMENTS[@]}" test 2>&1 | xcbeautify
 fi


### PR DESCRIPTION
### What and why?

This diagnostic PR isolates the two tests responsible for the largest share of known flaky-test failures. It is intended to collect reproducibility data and is not intended for merging as-is.

### How?

- Suppress the normal branch pipeline only for `cgcote/flaky-test-stress`.
- Run one focused CI job per flaky test in parallel.
- Run each test until its first failure, with a maximum of 100 isolated test-process iterations.
- Keep Test Visibility enabled and upload raw logs and xcresult bundles for investigation.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (this PR runs the two target tests directly)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference (diagnostic chore; no reference supplied)
- [x] Add CHANGELOG entry for user facing changes (not applicable)
- [x] Add Objective-C interface for public APIs (not applicable)
- [x] Run `make api-surface` when adding new APIs (not applicable)