### PR TITLE
Report smoke tests to Test Visibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -383,9 +383,17 @@ Smoke Tests (iOS):
     PLATFORM: "iOS Simulator"
     DEVICE: "iPhone 17 Pro"
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh --datadog-ci
     - make clean repo-setup ENV=ci
     - make smoke-test-ios-all OS="$DEFAULT_IOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
+  after_script:
+    - ./tools/upload-smoke-test-reports.sh
+  artifacts:
+    paths:
+      - "artifacts/smoke-test-reports/**/*.xml"
+    reports:
+      junit: "artifacts/smoke-test-reports/**/*.xml"
+    when: always
 
 Smoke Tests (tvOS):
   stage: smoke-test
@@ -398,9 +406,17 @@ Smoke Tests (tvOS):
     PLATFORM: "tvOS Simulator"
     DEVICE: "Apple TV"
   script:
-    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh
+    - ./tools/runner-setup.sh --xcode "$DEFAULT_XCODE" --ssh --datadog-ci
     - make clean repo-setup ENV=ci
     - make smoke-test-tvos-all OS="$DEFAULT_TVOS_OS" PLATFORM="$PLATFORM" DEVICE="$DEVICE"
+  after_script:
+    - ./tools/upload-smoke-test-reports.sh
+  artifacts:
+    paths:
+      - "artifacts/smoke-test-reports/**/*.xml"
+    reports:
+      junit: "artifacts/smoke-test-reports/**/*.xml"
+    when: always
 
 SPM Build (Swift 6.2):
   stage: smoke-test

--- a/SmokeTests/carthage/Makefile
+++ b/SmokeTests/carthage/Makefile
@@ -70,4 +70,4 @@ endif
 		fi;)
 	set -eo pipefail; \
 	xcodebuild -version; \
-	xcodebuild -project "CTProject.xcodeproj" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME)" test | xcbeautify
+	xcodebuild -project "CTProject.xcodeproj" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME)" test | $(call XCBEAUTIFY)

--- a/SmokeTests/cocoapods/Makefile
+++ b/SmokeTests/cocoapods/Makefile
@@ -52,9 +52,9 @@ endif
 	@$(ECHO_SUBTITLE2) "➔ Testing SCHEME='$(SCHEME1)'"
 	set -eo pipefail; \
 	xcodebuild -version; \
-	xcodebuild -workspace "CPProject.xcworkspace" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME1)" test | xcbeautify
+	xcodebuild -workspace "CPProject.xcworkspace" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME1)" test | $(call XCBEAUTIFY,dynamic)
 
 	@$(ECHO_SUBTITLE2) "➔ Testing SCHEME='$(SCHEME2)'"
 	set -eo pipefail; \
 	xcodebuild -version; \
-	xcodebuild -workspace "CPProject.xcworkspace" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME2)" test | xcbeautify
+	xcodebuild -workspace "CPProject.xcworkspace" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME2)" test | $(call XCBEAUTIFY,static)

--- a/SmokeTests/spm-6/Makefile
+++ b/SmokeTests/spm-6/Makefile
@@ -38,5 +38,4 @@ endif
 	@$(ECHO_INFO) "Using SCHEME='$(SCHEME)'"
 	set -eo pipefail; \
 	xcodebuild -version; \
-	xcodebuild -project "SPMProject.xcodeproj" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME)" test | xcbeautify
-
+	xcodebuild -project "SPMProject.xcodeproj" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME)" test | $(call XCBEAUTIFY)

--- a/SmokeTests/spm/Makefile
+++ b/SmokeTests/spm/Makefile
@@ -32,7 +32,7 @@ endif
 	@$(ECHO_INFO) "Using SCHEME='$(SCHEME)'"
 	set -eo pipefail; \
 	xcodebuild -version; \
-	xcodebuild -project "SPMProject.xcodeproj" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME)" test | xcbeautify
+	xcodebuild -project "SPMProject.xcodeproj" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME)" test | $(call XCBEAUTIFY)
 
 # Helper to apply any changes made to 'SPMProject.xcodeproj' back to 'SPMProject.xcodeproj.src'
 create-src-from-xcodeproj:

--- a/SmokeTests/xcframeworks/Makefile
+++ b/SmokeTests/xcframeworks/Makefile
@@ -71,4 +71,4 @@ endif
 		fi;)
 	set -eo pipefail; \
 	xcodebuild -version; \
-	xcodebuild -project "XCProject.xcodeproj" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME)" test | xcbeautify
+	xcodebuild -project "XCProject.xcodeproj" -destination "platform=$(PLATFORM),name=$(DEVICE),OS=$(OS)" -scheme "$(SCHEME)" test | $(call XCBEAUTIFY)

--- a/tools/smoke-test.sh
+++ b/tools/smoke-test.sh
@@ -28,7 +28,13 @@ parse_args "$@"
 # already covers SmokeTests sources.
 export SKIP_LINT=1
 
+reports_path=""
+if [ "$CI" = "true" ]; then
+    reports_path="$(pwd)/artifacts/smoke-test-reports/${test_directory:t}"
+    mkdir -p "$reports_path"
+fi
+
 echo_subtitle "Run 'make clean install test OS=\"$os\" PLATFORM=\"$platform\" DEVICE=\"$device\"' in '$test_directory'"
 echo_succ "Smoke testing for git ref: '$(current_git_ref)'"
-cd "$test_directory" && make clean install test OS="$os" PLATFORM="$platform" DEVICE="$device"
+cd "$test_directory" && make clean install test OS="$os" PLATFORM="$platform" DEVICE="$device" JUNIT_REPORTS_PATH="$reports_path"
 cd -

--- a/tools/upload-smoke-test-reports.sh
+++ b/tools/upload-smoke-test-reports.sh
@@ -1,0 +1,23 @@
+#!/bin/zsh
+
+# Uploads smoke-test JUnit reports to Datadog Test Visibility.
+
+set -eo pipefail
+source ./tools/utils/echo-color.sh
+source ./tools/secrets/get-secret.sh
+
+reports_path="artifacts/smoke-test-reports"
+report_files=("$reports_path"/**/*.xml(N))
+
+if (( ${#report_files} == 0 )); then
+    echo_warn "No smoke-test JUnit reports found. Skipping Test Visibility upload."
+    exit 0
+fi
+
+export DATADOG_API_KEY="$(get_secret "$DD_IOS_SECRET__TEST_VISIBILITY_API_KEY")"
+export DD_ENV="ci"
+
+datadog-ci junit upload \
+    --service "dd-sdk-ios" \
+    --git-repository-url "git@github.com:DataDog/dd-sdk-ios.git" \
+    "$reports_path"

--- a/tools/upload-smoke-test-reports.sh
+++ b/tools/upload-smoke-test-reports.sh
@@ -20,4 +20,4 @@ export DD_ENV="ci"
 datadog-ci junit upload \
     --service "dd-sdk-ios" \
     --git-repository-url "git@github.com:DataDog/dd-sdk-ios.git" \
-    "$reports_path"
+    "${report_files[@]}"

--- a/tools/utils/common.mk
+++ b/tools/utils/common.mk
@@ -18,6 +18,12 @@ ECHO_ERROR=$(REPO_ROOT)/tools/utils/echo-color.sh --err
 ECHO_WARNING=$(REPO_ROOT)/tools/utils/echo-color.sh --warn
 ECHO_SUCCESS=$(REPO_ROOT)/tools/utils/echo-color.sh --succ
 
+# Formats xcodebuild output and optionally produces a JUnit report. Callers can
+# enable the report by supplying JUNIT_REPORTS_PATH and an optional subdirectory.
+define XCBEAUTIFY
+xcbeautify $(if $(JUNIT_REPORTS_PATH),--report junit --report-path "$(JUNIT_REPORTS_PATH)$(if $(1),/$(1))")
+endef
+
 define require_param
     if [ -z "$${$(1)}" ]; then \
         $(ECHO_ERROR) "Error:" "$(1) parameter is required but not provided."; \


### PR DESCRIPTION
### What and why?

Report smoke-test executions to Datadog Test Visibility. Currently the smoke-test CI jobs are visible as pipeline spans, but show zero test runs because their XCTest results are not reported.

### How?

- Generate JUnit XML reports from each smoke-test xcodebuild invocation using xcbeautify.
- Keep separate reports for the CocoaPods dynamic and static schemes.
- Upload reports to Datadog with datadog-ci junit upload from after_script, ensuring completed tests are reported when a later test fails.
- Publish the same reports as GitLab JUnit artifacts.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (validated JUnit generation and datadog-ci ingestion locally)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] CHANGELOG entry is not required because this is an internal CI change
- [x] Objective-C interface is not applicable
- [x] API surface verification is not applicable